### PR TITLE
Improve error checking on connections in bled112 and adapterstream

### DIFF
--- a/iotilecore/RELEASE.md
+++ b/iotilecore/RELEASE.md
@@ -2,6 +2,11 @@
 
 All major changes in each released version of IOTileCore are listed here.
 
+## 3.1.1
+
+- Add support for error checking in AdapterStream to catch errors connecting to a device
+  or opening interfaces and convert them into HardwareErrors
+
 ## 3.1.0
 
 - Add support for report streaming from IOTile devices through iotile-core and associated

--- a/iotilecore/iotile/core/hw/transport/adapterstream.py
+++ b/iotilecore/iotile/core/hw/transport/adapterstream.py
@@ -82,7 +82,7 @@ class AdapterCMDStream(CMDStream):
         if not res['success']:
             self.adapter.disconnect_sync(0)
             raise HardwareError("Could not open RPC interface on device", reason=res['failure_reason'], connection_string=connection_string)
-    
+
     def _disconnect(self):
         self.adapter.disconnect_sync(0)
         self.adapter.periodic_callback()
@@ -107,7 +107,9 @@ class AdapterCMDStream(CMDStream):
 
     def _enable_streaming(self):
         self._reports = Queue.Queue()
-        self.adapter.open_interface_sync(0, 'streaming')
+        res = self.adapter.open_interface_sync(0, 'streaming')
+        if not res['success']:
+            raise HardwareError("Could not open streaming interface to device", reason=res['failure_reason'])
 
         return self._reports
 

--- a/iotilecore/iotile/core/hw/transport/cmdstream.py
+++ b/iotilecore/iotile/core/hw/transport/cmdstream.py
@@ -52,7 +52,11 @@ class CMDStream(object):
             self._recording = {}
 
         if self.connection_string != None:
-            self.connect_direct(self.connection_string)
+            try:
+                self.connect_direct(self.connection_string)
+            except:
+                self.close()
+                raise
 
     def scan(self):
         """Scan for available IOTile devices

--- a/iotilecore/version.py
+++ b/iotilecore/version.py
@@ -1,1 +1,1 @@
-version = "3.1.0"
+version = "3.1.1"

--- a/transport_plugins/bled112/RELEASE.md
+++ b/transport_plugins/bled112/RELEASE.md
@@ -2,6 +2,10 @@
 
 All major changes in each released version of the bled112 transport plugin are listed here.
 
+## 1.1.1
+
+- Add more robust error checking with a nice message if the connection disconnects unexpectedly
+
 ## 1.1.0
 
 - Support report streaming from IOTile devices

--- a/transport_plugins/bled112/iotile_transport_bled112/bled112.py
+++ b/transport_plugins/bled112/iotile_transport_bled112/bled112.py
@@ -298,8 +298,12 @@ class BLED112Adapter(DeviceAdapter):
                 callback(conn_id, adapter_id, success, failure_reason)
         """
 
-        handle = self._find_handle(conn_id)
-        services = self._connections[handle]['services']
+        try:
+            handle = self._find_handle(conn_id)
+            services = self._connections[handle]['services']
+        except (ValueError, KeyError):
+            callback(conn_id, self.id, False, 'Connection closed unexpectedly before we could open the rpc interface')
+            return
 
         self._command_task.async_command(['_enable_rpcs', handle, services], self._on_interface_finished, {'connection_id': conn_id, 'callback': callback})
 
@@ -312,8 +316,12 @@ class BLED112Adapter(DeviceAdapter):
                 callback(conn_id, adapter_id, success, failure_reason)
         """
 
-        handle = self._find_handle(conn_id)
-        services = self._connections[handle]['services']
+        try:
+            handle = self._find_handle(conn_id)
+            services = self._connections[handle]['services']
+        except (ValueError, KeyError):
+            callback(conn_id, self.id, False, 'Connection closed unexpectedly before we could open the script interface')
+            return
 
         success = TileBusHighSpeedCharacteristic in services[TileBusService]['characteristics']
         reason = None
@@ -331,8 +339,12 @@ class BLED112Adapter(DeviceAdapter):
                 callback(conn_id, adapter_id, success, failure_reason)
         """
 
-        handle = self._find_handle(conn_id)
-        services = self._connections[handle]['services']
+        try:
+            handle = self._find_handle(conn_id)
+            services = self._connections[handle]['services']
+        except (ValueError, KeyError):
+            callback(conn_id, self.id, False, 'Connection closed unexpectedly before we could open the streaming interface')
+            return
 
         self._command_task.async_command(['_enable_streaming', handle, services], self._on_interface_finished, {'connection_id': conn_id, 'callback': callback})
 
@@ -345,8 +357,12 @@ class BLED112Adapter(DeviceAdapter):
                 callback(conn_id, adapter_id, success, failure_reason)
         """
 
-        handle = self._find_handle(conn_id)
-        services = self._connections[handle]['services']
+        try:
+            handle = self._find_handle(conn_id)
+            services = self._connections[handle]['services']
+        except (ValueError, KeyError):
+            callback(conn_id, self.id, False, 'Connection closed unexpectedly before we could close the rpc interface')
+            return
 
         self._command_task.async_command(['_disable_rpcs', handle, services], self._on_interface_finished, {'connection_id': conn_id, 'callback': callback})
 

--- a/transport_plugins/bled112/iotile_transport_bled112/bled112_cmd.py
+++ b/transport_plugins/bled112/iotile_transport_bled112/bled112_cmd.py
@@ -532,10 +532,13 @@ class BLED112CommandProcessor(threading.Thread):
         conn_interval_max = 100
         timeout = 1.0
 
-        #Allow passing either a binary address or a hex string
-        if isinstance(address, basestring) and len(address) > 6:
-            address = address.replace(':', '')
-            address = str(bytearray.fromhex(address)[::-1])
+        try:
+            #Allow passing either a binary address or a hex string
+            if isinstance(address, basestring) and len(address) > 6:
+                address = address.replace(':', '')
+                address = str(bytearray.fromhex(address)[::-1])
+        except ValueError:
+            return False, None
 
         #Allow simple determination of whether a device has a public or private address
         #This is not foolproof

--- a/transport_plugins/bled112/test/test_bled112_adapterstream.py
+++ b/transport_plugins/bled112/test/test_bled112_adapterstream.py
@@ -10,6 +10,7 @@ from iotile_transport_bled112.bled112 import BLED112Adapter
 from iotile.core.hw.reports.individual_format import IndividualReadingReport
 from iotile.core.hw.reports.report import IOTileReading
 from iotile.core.hw.hwmanager import HardwareManager
+from iotile.core.exceptions import ArgumentError, HardwareError
 import time
 import logging
 import sys
@@ -44,6 +45,14 @@ class TestBLED112AdapterStream(unittest.TestCase):
 
     def test_connect_direct(self):
         self.hw.connect_direct("00:11:22:33:44:55")
+
+    def test_connect_nonexistent(self):
+        with pytest.raises(HardwareError):
+            self.hw.connect_direct("00:11:22:33:44:56")
+
+    def test_connect_badconnstring(self):
+        with pytest.raises(HardwareError):
+            self.hw.connect_direct("00:11:22:33:44:5L")
 
     def test_report_streaming(self):
         self.hw.connect_direct("00:11:22:33:44:55")

--- a/transport_plugins/bled112/test/util/dummy_serial.py
+++ b/transport_plugins/bled112/test/util/dummy_serial.py
@@ -127,6 +127,16 @@ class Serial():
         self._isOpen = False
         self.port = None
 
+    def inject(self, data):
+        """Inject data asynchronously into the serial port to simulate an event
+
+        Args:
+            data (string): the data to be injected into the serial port read buffer
+        """
+
+        with self._data_lock:
+            self._waiting_data += data
+
     def write(self, inputdata):
         """Write to a port on dummy_serial.
 

--- a/transport_plugins/bled112/version.py
+++ b/transport_plugins/bled112/version.py
@@ -1,1 +1,1 @@
-version = "1.1.0"
+version = "1.1.1"


### PR DESCRIPTION
Errors on connections we not properly checked leading to hangs with exceptions being thrown in background threads.

Now:
- bled112 should be robust against malformed connection strings, just failing but not hanging
- connections opened use HardwareManager(port='bled112:<auto>,STRING') that fail should not longer hang
- adapterstream now checks the return status of calls and converts failures to exceptions