### PR TITLE
Add support for iotile release command

### DIFF
--- a/iotilebuild/RELEASE.md
+++ b/iotilebuild/RELEASE.md
@@ -2,6 +2,13 @@
 
 All major changes in each released version of IOTileBuild are listed here.
 
+## 2.2.0
+
+- Add entry point for inserting release providers that allow releasing IOTile components.
+- Add iotile release command for releasing an IOTile using a sequence of release providers
+- Update minimum required iotile-core version to 3.3.0 based on the need for release_steps
+  parsing in the IOTile object.
+
 ## 2.1.0
 
 - Add entry point for inserting DependencyResolvers into the lookup chain

--- a/iotilebuild/iotile/build/plugin.py
+++ b/iotilebuild/iotile/build/plugin.py
@@ -5,4 +5,7 @@ def setup_plugin():
 	d = unicode('depends')
 	dv = unicode('iotile.build.dev,DependencyManager')
 
-	return [(u,v), (d,dv)]
+	b = unicode('release')
+	bv = unicode('iotile.build.release.release,release')
+
+	return [(u,v), (d,dv), (b, bv)]

--- a/iotilebuild/iotile/build/release/null_provider.py
+++ b/iotilebuild/iotile/build/release/null_provider.py
@@ -1,0 +1,34 @@
+import provider
+from iotile.core.exceptions import BuildError
+
+class NullReleaseProvider(provider.ReleaseProvider):
+    """A Noop release provider for testing purposes
+    """
+
+    def stage(self):
+        """Stage this component for release
+        """
+
+        if self.args.get('stage_error', False):
+            raise BuildError("Staging error triggered in NullReleaseProvider")
+
+    def unstage(self):
+        """Unstage this component assuming that stage succeeded
+        """
+
+        if self.args.get('unstage_error', False):
+            raise BuildError("Unstaging error triggered in NullReleaseProvider")
+
+    def release(self):
+        """Release this component assuming that stage succeeded
+        """
+
+        if self.args.get('release_error', False):
+            raise BuildError("Release error triggered in NullReleaseProvider")
+
+    def unrelease(self):
+        """Unrelease this component assuming that release succeeded
+        """
+
+        if self.args.get('unrelease_error', False):
+            raise BuildError("Staging error triggered in NullReleaseProvider")

--- a/iotilebuild/iotile/build/release/provider.py
+++ b/iotilebuild/iotile/build/release/provider.py
@@ -1,0 +1,59 @@
+"""Superclass for ReleaseProvider objects that allow releasing IOTile components
+"""
+
+class ReleaseProvider(object):
+    """Base class for release providers that allow releasing IOTile components
+
+    ReleaseProviders has just two methods: stage, unstage, release and unrelease (if supported)
+
+    All methods take in a release mode IOTile object.
+
+    - stage should attempt to release the IOTile as much as possible without making it
+      externally visible.  The purpose of stage is to allow a sequence of ReleaseProviders
+      to be executed sequentially and then rolled back if one of them fails.  If staging
+      does not make sense for a given provider, it can be implemented as a noop.
+
+    - release should make the IOTile object externally visible and completely released.
+      release can assume that stage has returned successfully before it has been run.
+
+    - unstage should undo whatever is done in stage.  unstage will only be run if stage
+      has completed successfully.  If an exception is raised during stage, it must clean
+      up after itself before passing the exception back up the stack.
+
+    - unrelease should undo whatever is done in release.  If release builds on something
+      that is done in stage, then unrelease should also call unstage or implement the
+      same functionality.
+
+    Args:
+        args (dict): Whatever arguments were specified for this release provider in module_settings.json
+        component (IOTile): The IOTile object that should be released.  It must be a release mode IOTile
+            object.
+    """
+
+    def __init__(self, component, args):
+        self.component = component
+        self.args = args
+
+    def stage(self):
+        """Stage this component for release
+        """
+
+        raise NotImplementedError("ReleaseProvider subclasses must override the stage method")
+
+    def unstage(self):
+        """Unstage this component assuming that stage succeeded
+        """
+
+        raise NotImplementedError("ReleaseProvider subclasses must override the unstage method")
+
+    def release(self):
+        """Release this component assuming that stage succeeded
+        """
+
+        raise NotImplementedError("ReleaseProvider subclasses must override the release method")
+
+    def unrelease(self):
+        """Unrelease this component assuming that release succeeded
+        """
+
+        raise NotImplementedError("ReleaseProvider subclasses must override the unrelease method")

--- a/iotilebuild/iotile/build/release/release.py
+++ b/iotilebuild/iotile/build/release/release.py
@@ -1,0 +1,105 @@
+"""Tools for automatically releasing built IOTile components
+"""
+
+import pkg_resources
+from iotile.core.dev.iotileobj import IOTile
+from iotile.core.utilities.typedargs import param
+from iotile.core.exceptions import ArgumentError, DataError, BuildError, IOTileException
+
+class ReleaseFailureError(BuildError):
+    pass
+
+
+class CleanReleaseFailureError(ReleaseFailureError):
+    """The release process failed but it was rolled back successfully
+
+    No intermediate release products should be left.
+    """
+    pass
+
+
+class DirtyReleaseFailureError(ReleaseFailureError):
+    """The release process failed and additionally there was an error rolling back
+
+    There may be intermediate release products that need to be cleaned up.
+    """
+    pass
+
+
+@param("component", "path", desc="Path to the iotile object that we should release")
+def release(component):
+    """Release an IOTile component using release providers
+
+    Releasing an IOTile component means packaging up the products of its build process and storing 
+    them somewhere.  The module_settings.json file of the IOTile component should have a 
+    "release_steps" key that lists the release providers that will be used to release the various
+    build products.  There are usually multiple release providers to, for example, send firmware
+    images somewhere for future download, post the documentation and upload python support wheels
+    to a PyPI index.
+    """
+
+    comp = IOTile(component)
+    providers = _find_release_providers()
+
+    #If we were given a dev mode component that has been built, get its release mode version
+    if not comp.release and comp.release_date is not None:
+        comp = IOTile(comp.output_folder)
+
+    if not comp.release:
+        raise ArgumentError("Attempting to release a dev mode IOTile component that has not been built.", suggestion='Use iotile build to build the component before releasing', component=comp)
+
+    if not comp.can_release:
+        raise ArgumentError("Attemping to release an IOTile component that does not specify release_steps and hence is not releasable", suggestion="Update module_settings.json to include release_steps")
+
+    configured_provs = []
+
+    for step in comp.release_steps:
+        if step.provider not in providers:
+            raise DataError("Release step for component required unknown ReleaseProvider", provider=step.provider, known_providers=providers.keys())
+
+        prov = providers[step.provider](comp, step.args)
+        configured_provs.append(prov)
+
+    #Attempt to stage releases for each provider and then release them all, rolling back if there is an error
+    for i, prov in enumerate(configured_provs):
+        try:
+            prov.stage()
+        except IOTileException, exc:
+            try:
+                #There was an error, roll back
+                for j in xrange(0, i):
+                    configured_provs[j].unstage()
+            except Exception, unstage_exc:
+                raise DirtyReleaseFailureError("Error staging release (COULD NOT ROLL BACK)", failed_step=i, original_exception=exc, operation='staging', failed_unstage=j, unstage_exception=unstage_exc)
+            
+            raise CleanReleaseFailureError("Error staging release (cleanly rolled back)", failed_step=i, original_exception=exc, operation='staging')
+        except Exception, exc:
+            raise DirtyReleaseFailureError("Error staging release due to unknown exception type (DID NOT ATTEMPT ROLL BACK)", failed_step=i, original_exception=exc, operation='staging')
+
+    #Stage was sucessful, attempt to release
+    for i, prov in enumerate(configured_provs):
+        try:
+            prov.release()
+        except IOTileException, exc:
+            try:
+                #There was an error, roll back
+                for j in xrange(0, i):
+                    configured_provs[j].unrelease()
+            except Exception, unstage_exc:
+                raise DirtyReleaseFailureError("Error performing release (COULD NOT ROLL BACK)", failed_step=i, original_exception=exc, operation='release', failed_unrelease=j, unrelease_exception=unstage_exc)
+            
+            raise CleanReleaseFailureError("Error performing release (cleanly rolled back)", failed_step=i, original_exception=exc, operation='release')
+        except Exception, exc:
+            raise DirtyReleaseFailureError("Error performing release due to unknown exception type (DID NOT ATTEMPT ROLL BACK)", failed_step=i, original_exception=exc, operation='release')
+
+
+def _find_release_providers():
+    provs = {}
+
+    for entry in pkg_resources.iter_entry_points('iotile.build.release_provider'):
+        name = entry.name
+        prov = entry.load()
+
+        provs[name] = prov
+
+    return provs

--- a/iotilebuild/iotile/build/release/release.py
+++ b/iotilebuild/iotile/build/release/release.py
@@ -49,7 +49,7 @@ def release(component):
         raise ArgumentError("Attempting to release a dev mode IOTile component that has not been built.", suggestion='Use iotile build to build the component before releasing', component=comp)
 
     if not comp.can_release:
-        raise ArgumentError("Attemping to release an IOTile component that does not specify release_steps and hence is not releasable", suggestion="Update module_settings.json to include release_steps")
+        raise ArgumentError("Attemping to release an IOTile component that does not specify release_steps and hence is not releasable", suggestion="Update module_settings.json to include release_steps", component=comp)
 
     configured_provs = []
 

--- a/iotilebuild/setup.py
+++ b/iotilebuild/setup.py
@@ -29,7 +29,7 @@ setup(
     version=version.version,
     license="LGPLv3",
     install_requires=[
-        "iotile-core>=3.0.0",
+        "iotile-core>=3.3.0",
         "sphinx>=1.3.1",
         "Cheetah>=2.4.4",
         "breathe>=4.2.0",
@@ -39,7 +39,8 @@ setup(
     include_package_data=True,
     entry_points={'iotile.plugin': ['.build = iotile.build.plugin:setup_plugin'],
                   'iotile.build.default_depresolver': ['registry_resolver = iotile.build.dev.resolvers:DEFAULT_REGISTRY_RESOLVER'],
-                  'iotile.build.depresolver': ['registry_resolver = iotile.build.dev.resolvers.registry_resolver:ComponentRegistryResolver']},
+                  'iotile.build.depresolver': ['registry_resolver = iotile.build.dev.resolvers.registry_resolver:ComponentRegistryResolver'],
+                  'iotile.build.release_provider': ['null = iotile.build.release.null_provider:NullReleaseProvider']},
     description="IOTile Build Support",
     author="Arch",
     author_email="info@arch-iot.com",

--- a/iotilebuild/test/test_release/dev_mode_comp/build/output/module_settings.json
+++ b/iotilebuild/test/test_release/dev_mode_comp/build/output/module_settings.json
@@ -1,0 +1,27 @@
+{
+	"module_name": "tile_gpio",
+	"release": true,
+	"release_date": "2016-10-11 02:37:21",
+	
+	"module_targets": 
+	{
+		"tile_gpio": ["lpc824"]
+	},
+
+	"modules":
+	{
+		"tile_gpio":
+		{
+			"release_steps":
+			[
+				{
+					"provider": "null"
+				},
+
+				{
+					"provider": "null"
+				}
+			]
+		}
+	}
+}

--- a/iotilebuild/test/test_release/dev_mode_comp/module_settings.json
+++ b/iotilebuild/test/test_release/dev_mode_comp/module_settings.json
@@ -1,0 +1,26 @@
+{
+	"module_name": "tile_gpio",
+	"release_date": "2016-10-11 02:37:21",
+	
+	"module_targets": 
+	{
+		"tile_gpio": ["lpc824"]
+	},
+
+	"modules":
+	{
+		"tile_gpio":
+		{
+			"release_steps":
+			[
+				{
+					"provider": "null"
+				},
+
+				{
+					"provider": "null"
+				}
+			]
+		}
+	}
+}

--- a/iotilebuild/test/test_release/fail_first_release_comp/module_settings.json
+++ b/iotilebuild/test/test_release/fail_first_release_comp/module_settings.json
@@ -1,0 +1,35 @@
+{
+	"module_name": "tile_gpio",
+	"release": true,
+	"release_date": "2016-10-11 02:37:21",
+	
+	"module_targets": 
+	{
+		"tile_gpio": ["lpc824"]
+	},
+
+	"modules":
+	{
+		"tile_gpio":
+		{
+			"release_steps":
+			[
+				{
+					"provider": "null",
+					"args":
+					{
+						"release_error": true
+					}
+				},
+
+				{
+					"provider": "null",
+					"args":
+					{
+						"unrelease_error": true
+					}
+				}
+			]
+		}
+	}
+}

--- a/iotilebuild/test/test_release/fail_first_stage_comp/module_settings.json
+++ b/iotilebuild/test/test_release/fail_first_stage_comp/module_settings.json
@@ -1,0 +1,35 @@
+{
+	"module_name": "tile_gpio",
+	"release": true,
+	"release_date": "2016-10-11 02:37:21",
+	
+	"module_targets": 
+	{
+		"tile_gpio": ["lpc824"]
+	},
+
+	"modules":
+	{
+		"tile_gpio":
+		{
+			"release_steps":
+			[
+				{
+					"provider": "null",
+					"args":
+					{
+						"stage_error": true
+					}
+				},
+
+				{
+					"provider": "null",
+					"args":
+					{
+						"unstage_error": true
+					}
+				}
+			]
+		}
+	}
+}

--- a/iotilebuild/test/test_release/fail_second_release_comp/module_settings.json
+++ b/iotilebuild/test/test_release/fail_second_release_comp/module_settings.json
@@ -1,0 +1,35 @@
+{
+	"module_name": "tile_gpio",
+	"release": true,
+	"release_date": "2016-10-11 02:37:21",
+	
+	"module_targets": 
+	{
+		"tile_gpio": ["lpc824"]
+	},
+
+	"modules":
+	{
+		"tile_gpio":
+		{
+			"release_steps":
+			[
+				{
+					"provider": "null",
+					"args":
+					{
+						"unrelease_error": true
+					}
+				},
+
+				{
+					"provider": "null",
+					"args":
+					{
+						"release_error": true
+					}
+				}
+			]
+		}
+	}
+}

--- a/iotilebuild/test/test_release/fail_second_stage_comp/module_settings.json
+++ b/iotilebuild/test/test_release/fail_second_stage_comp/module_settings.json
@@ -1,0 +1,35 @@
+{
+	"module_name": "tile_gpio",
+	"release": true,
+	"release_date": "2016-10-11 02:37:21",
+	
+	"module_targets": 
+	{
+		"tile_gpio": ["lpc824"]
+	},
+
+	"modules":
+	{
+		"tile_gpio":
+		{
+			"release_steps":
+			[
+				{
+					"provider": "null",
+					"args":
+					{
+						"unstage_error": true
+					}
+				},
+
+				{
+					"provider": "null",
+					"args":
+					{
+						"stage_error": true
+					}
+				}
+			]
+		}
+	}
+}

--- a/iotilebuild/test/test_release/nosteps_comp/module_settings.json
+++ b/iotilebuild/test/test_release/nosteps_comp/module_settings.json
@@ -1,0 +1,18 @@
+{
+	"module_name": "tile_gpio",
+	"release": true,
+	"release_date": "2016-10-11 02:37:21",
+	
+	"module_targets": 
+	{
+		"tile_gpio": ["lpc824"]
+	},
+
+	"modules":
+	{
+		"tile_gpio":
+		{
+
+		}
+	}
+}

--- a/iotilebuild/test/test_release/successful_release_comp/module_settings.json
+++ b/iotilebuild/test/test_release/successful_release_comp/module_settings.json
@@ -1,0 +1,27 @@
+{
+	"module_name": "tile_gpio",
+	"release": true,
+	"release_date": "2016-10-11 02:37:21",
+	
+	"module_targets": 
+	{
+		"tile_gpio": ["lpc824"]
+	},
+
+	"modules":
+	{
+		"tile_gpio":
+		{
+			"release_steps":
+			[
+				{
+					"provider": "null"
+				},
+
+				{
+					"provider": "null"
+				}
+			]
+		}
+	}
+}

--- a/iotilebuild/test/test_release/test_release.py
+++ b/iotilebuild/test/test_release/test_release.py
@@ -1,7 +1,13 @@
 import pytest
 import os
+import subprocess
+
+def test_iotiletool():
+    err = subprocess.check_call(["iotile" , "quit"])
+    assert err == 0
+
 from iotile.build.release.release import release, DirtyReleaseFailureError, CleanReleaseFailureError
-from iotile.core.exceptions import DataError
+from iotile.core.exceptions import DataError, ArgumentError
 
 def build_path(name):
     parent = os.path.dirname(__file__)
@@ -78,11 +84,44 @@ def test_failed_release2():
 
             raise
 
+def test_built_devmode_comp():
+    """Make sure that if a devmode comp has been built we release the build/output folder
+    """
+
+    comp = build_path('dev_mode_comp')
+    release(comp)
+
+def test_unbuilt_devmode_comp():
+    """Make sure that we throw an error if we try to release an unbuilt dev mode component
+    """
+
+    comp = build_path('unbuilt_dev_mode_comp')
+    
+    with pytest.raises(ArgumentError):
+        release(comp)
+
+def test_nosteps_comp():
+    """Make sure that if there are no release steps we throw an error
+    """
+
+    comp = build_path('nosteps_comp')
+    
+    with pytest.raises(ArgumentError):
+        release(comp)
+
+
 def test_unknown_provider():
     """Make sure that we get the appropriate error if a ReleaseProvider cannot be found
     """
-    
+
     comp = build_path('unknown_provider_comp')
 
     with pytest.raises(DataError):
         release(comp)
+
+def test_release_plugin():
+    """Makes sure the release plugin works correctly in the iotile tool
+    """
+
+    err = subprocess.check_call(["iotile" , "release", build_path('successful_release_comp')])
+    assert err == 0

--- a/iotilebuild/test/test_release/test_release.py
+++ b/iotilebuild/test/test_release/test_release.py
@@ -1,0 +1,88 @@
+import pytest
+import os
+from iotile.build.release.release import release, DirtyReleaseFailureError, CleanReleaseFailureError
+from iotile.core.exceptions import DataError
+
+def build_path(name):
+    parent = os.path.dirname(__file__)
+    path = os.path.join(parent, name)
+
+    return path
+
+def test_successful_release():
+    comp = build_path('successful_release_comp')
+
+    release(comp)
+
+def test_failed_stage1():
+    """Make sure appropriate error is thrown when staging fails
+
+    Also test to make sure unstage happens correctly
+    """
+
+    comp = build_path('fail_first_stage_comp')
+
+    with pytest.raises(CleanReleaseFailureError):
+        try:
+            release(comp)
+        except CleanReleaseFailureError, exc:
+            assert exc.params['failed_step'] == 0
+            assert exc.params['operation'] == 'staging'
+            raise
+
+def test_failed_stage2():
+    """Make sure appropriate dirty error is thrown if staging fails and cannot roll back
+    """
+
+    comp = build_path('fail_second_stage_comp')
+
+    with pytest.raises(DirtyReleaseFailureError):
+        try:
+            release(comp)
+        except DirtyReleaseFailureError, exc:
+            assert exc.params['failed_step'] == 1
+            assert exc.params['failed_unstage'] == 0
+            assert exc.params['operation'] == 'staging'
+
+            raise
+
+def test_failed_release1():
+    """Make sure appropriate error is thrown when release fails
+
+    Also test to make sure unrelease happens correctly
+    """
+
+    comp = build_path('fail_first_release_comp')
+
+    with pytest.raises(CleanReleaseFailureError):
+        try:
+            release(comp)
+        except CleanReleaseFailureError, exc:
+            assert exc.params['failed_step'] == 0
+            assert exc.params['operation'] == 'release'
+            raise
+
+def test_failed_release2():
+    """Make sure appropriate dirty error is thrown if releasing fails and cannot roll back
+    """
+
+    comp = build_path('fail_second_release_comp')
+
+    with pytest.raises(DirtyReleaseFailureError):
+        try:
+            release(comp)
+        except DirtyReleaseFailureError, exc:
+            assert exc.params['failed_step'] == 1
+            assert exc.params['failed_unrelease'] == 0
+            assert exc.params['operation'] == 'release'
+
+            raise
+
+def test_unknown_provider():
+    """Make sure that we get the appropriate error if a ReleaseProvider cannot be found
+    """
+    
+    comp = build_path('unknown_provider_comp')
+
+    with pytest.raises(DataError):
+        release(comp)

--- a/iotilebuild/test/test_release/unbuilt_dev_mode_comp/module_settings.json
+++ b/iotilebuild/test/test_release/unbuilt_dev_mode_comp/module_settings.json
@@ -1,0 +1,25 @@
+{
+	"module_name": "tile_gpio",
+	
+	"module_targets": 
+	{
+		"tile_gpio": ["lpc824"]
+	},
+
+	"modules":
+	{
+		"tile_gpio":
+		{
+			"release_steps":
+			[
+				{
+					"provider": "null"
+				},
+
+				{
+					"provider": "null"
+				}
+			]
+		}
+	}
+}

--- a/iotilebuild/test/test_release/unknown_provider_comp/module_settings.json
+++ b/iotilebuild/test/test_release/unknown_provider_comp/module_settings.json
@@ -1,0 +1,27 @@
+{
+	"module_name": "tile_gpio",
+	"release": true,
+	"release_date": "2016-10-11 02:37:21",
+	
+	"module_targets": 
+	{
+		"tile_gpio": ["lpc824"]
+	},
+
+	"modules":
+	{
+		"tile_gpio":
+		{
+			"release_steps":
+			[
+				{
+					"provider": "null"
+				},
+
+				{
+					"provider": "unknown_provider"
+				}
+			]
+		}
+	}
+}

--- a/iotilebuild/version.py
+++ b/iotilebuild/version.py
@@ -1,1 +1,1 @@
-version = "2.1.0"
+version = "2.2.0"

--- a/iotilecore/RELEASE.md
+++ b/iotilecore/RELEASE.md
@@ -2,6 +2,12 @@
 
 All major changes in each released version of IOTileCore are listed here.
 
+## 3.3.0
+
+- Add support for storing release steps in module_settings.json and parsing release steps
+  in IOTile objects.  This will allow iotile-build and others to provide the ability to 
+  release built IOTileComponents for public or private distribution automatically.
+
 ## 3.2.0
 
 - Add support for storing config settings in per virtualenv registry

--- a/iotilecore/test/test_dev/releasesteps_good_component/module_settings.json
+++ b/iotilecore/test/test_dev/releasesteps_good_component/module_settings.json
@@ -1,0 +1,55 @@
+{
+	"module_name": "tile_gpio",
+	
+	"module_targets": 
+	{
+		"tile_gpio": ["lpc824"]
+	},
+
+	"modules":
+	{
+		"tile_gpio":
+		{
+			"depends":
+			{
+				"iotile_standard_library/common": ["include_directories"],
+				"iotile_standard_library/liblpc824": ["include_directories", "liblpc824_lpc824.a"],
+				"iotile_standard_library/libcortexm0p_runtime": ["include_directories", "cortex_m0p_cdb_application.ld", "libcortexm0p_runtime_lpc824.a"]
+			},
+
+			"domain": "iotile_standard_library",
+
+			"release_steps":
+			[
+				{
+					"provider": "github",
+					"args":
+					{
+						"owner": "iotile",
+						"repo": "tile_gpio"
+					}
+				},
+
+				{
+					"provider": "gemfury"
+				}
+			],
+
+			"defines":
+			{
+				"kVoltageControlPin": 9,
+				"kVoltageSourcePin1": 8,
+				"kVoltageSourcePin2": 23,
+				"kVoltageSensePin2": 14,
+				"kVoltageSenseChannel2": 2, 
+				"kSensePin": 6,
+				"kSenseChannel": 1
+			},
+
+			"products":
+			{
+				"python/gpio1_proxy.py": "proxy_module"
+			}
+		}
+	}
+}

--- a/iotilecore/test/test_dev/releasesteps_invalid_component/module_settings.json
+++ b/iotilecore/test/test_dev/releasesteps_invalid_component/module_settings.json
@@ -1,0 +1,55 @@
+{
+	"module_name": "tile_gpio",
+	
+	"module_targets": 
+	{
+		"tile_gpio": ["lpc824"]
+	},
+
+	"modules":
+	{
+		"tile_gpio":
+		{
+			"depends":
+			{
+				"iotile_standard_library/common": ["include_directories"],
+				"iotile_standard_library/liblpc824": ["include_directories", "liblpc824_lpc824.a"],
+				"iotile_standard_library/libcortexm0p_runtime": ["include_directories", "cortex_m0p_cdb_application.ld", "libcortexm0p_runtime_lpc824.a"]
+			},
+
+			"domain": "iotile_standard_library",
+
+			"release_steps":
+			[
+				{
+					"provider": "github",
+					"args":
+					{
+						"owner": "iotile",
+						"repo": "tile_gpio"
+					}
+				},
+
+				{
+					"no_provider_given": "gemfury"
+				}
+			],
+
+			"defines":
+			{
+				"kVoltageControlPin": 9,
+				"kVoltageSourcePin1": 8,
+				"kVoltageSourcePin2": 23,
+				"kVoltageSensePin2": 14,
+				"kVoltageSenseChannel2": 2, 
+				"kSensePin": 6,
+				"kSenseChannel": 1
+			},
+
+			"products":
+			{
+				"python/gpio1_proxy.py": "proxy_module"
+			}
+		}
+	}
+}

--- a/iotilecore/test/test_dev/test_iotile.py
+++ b/iotilecore/test/test_dev/test_iotile.py
@@ -1,29 +1,53 @@
-from  iotile.core.dev.iotileobj import IOTile
+from iotile.core.dev.iotileobj import IOTile
+from iotile.core.exceptions import DataError
+import pytest
 import os
 
 def load_tile(name):
-	parent = os.path.dirname(__file__)
-	path = os.path.join(parent, name)
+    parent = os.path.dirname(__file__)
+    path = os.path.join(parent, name)
 
-	return IOTile(path)
+    return IOTile(path)
 
 def test_load_releasemode():
-	tile = load_tile('releasemode_component')
+    tile = load_tile('releasemode_component')
 
-	assert tile.release == True
-	assert tile.short_name == 'tile_gpio'
-	assert tile.output_folder == tile.folder
+    assert tile.release == True
+    assert tile.short_name == 'tile_gpio'
+    assert tile.output_folder == tile.folder
 
 def test_load_devmode():
-	tile = load_tile('devmode_component')
+    tile = load_tile('devmode_component')
 
-	assert tile.release == False
-	assert tile.short_name == 'tile_gpio'
-	assert tile.output_folder != tile.folder
+    assert tile.release == False
+    assert tile.short_name == 'tile_gpio'
+    assert tile.output_folder != tile.folder
+    assert tile.can_release is False
 
 def test_load_oldstyle():
-	tile = load_tile('oldstyle_component')
+    tile = load_tile('oldstyle_component')
 
-	assert tile.release == False
-	assert tile.short_name == 'tile_gpio'
-	assert tile.output_folder != tile.folder
+    assert tile.release == False
+    assert tile.short_name == 'tile_gpio'
+    assert tile.output_folder != tile.folder
+
+def test_load_releasesteps():
+    tile = load_tile('releasesteps_good_component')
+
+    assert tile.release is False
+    assert tile.can_release is True
+    assert len(tile.release_steps) == 2
+
+    step1 = tile.release_steps[0]
+    step2 = tile.release_steps[1]
+
+    assert step1.provider == 'github'
+    assert step1.args['repo'] == 'tile_gpio'
+    assert step1.args['owner'] == 'iotile'
+
+    assert step2.provider == 'gemfury'
+    assert len(step2.args) == 0
+
+def  test_load_invalidsteps():
+    with pytest.raises(DataError):
+        tile = load_tile('releasesteps_invalid_component')

--- a/iotilecore/version.py
+++ b/iotilecore/version.py
@@ -1,1 +1,1 @@
-version = "3.2.0"
+version = "3.3.0"


### PR DESCRIPTION
Added the concept of ReleaseProviders to iotile-build and a new plugin ```iotile release```.

```iotile release``` will look at a list of release steps stored in module_settings.json, match them to ReleaseProvider subclasses and then execute them one by one.  This provides the infrastructure needed to allow releasing iotile components like firmware images.

Closes #68.