### PR TITLE
Add signed lists of readings as a new supported report type

### DIFF
--- a/iotilebuild/RELEASE.md
+++ b/iotilebuild/RELEASE.md
@@ -2,6 +2,11 @@
 
 All major changes in each released version of IOTileBuild are listed here.
 
+## 2.2.8
+
+- Add explicit dependency on setuptools and wheel to make sure we have the bdist_wheel
+  commmand.
+
 ## 2.2.7
 
 - Update build system to allow modules to specify architecture overlays, not just other

--- a/iotilebuild/setup.py
+++ b/iotilebuild/setup.py
@@ -34,7 +34,9 @@ setup(
         "Cheetah>=2.4.4",
         "breathe>=4.2.0",
         "pygtrie>=2.0.0",
-        "toposort>=1.5.0"
+        "toposort>=1.5.0",
+        "wheel>=0.29",
+        "setuptools>=32"
     ],
     include_package_data=True,
     entry_points={'iotile.plugin': ['.build = iotile.build.plugin:setup_plugin'],

--- a/iotilebuild/version.py
+++ b/iotilebuild/version.py
@@ -1,1 +1,1 @@
-version = "2.2.7"
+version = "2.2.8"

--- a/iotilecore/RELEASE.md
+++ b/iotilecore/RELEASE.md
@@ -2,6 +2,11 @@
 
 All major changes in each released version of IOTileCore are listed here.
 
+## 3.7.0
+
+- Add SignedList report format for streaming signed lists of multiple readings in
+  a single report
+
 ## 3.6.2
 
 - Add audit message for error streaming report

--- a/iotilecore/iotile/core/hw/reports/__init__.py
+++ b/iotilecore/iotile/core/hw/reports/__init__.py
@@ -1,0 +1,6 @@
+from individual_format import IndividualReadingReport
+from report import IOTileReading, IOTileReport
+from signed_list_format import SignedListReport
+from parser import IOTileReportParser
+
+__all__ = ['IndividualReadingReport', 'IOTileReport', 'IOTileReading', 'SignedListReport', 'IOTileReportParser']

--- a/iotilecore/iotile/core/hw/reports/parser.py
+++ b/iotilecore/iotile/core/hw/reports/parser.py
@@ -23,7 +23,7 @@ class IOTileReportParser (object):
 
     #States for parser state machine
     WaitingForReportType = 1
-    WaitingForReportHeader = 2 
+    WaitingForReportHeader = 2
     WaitingForCompleteReport = 3
     ErrorState = 4
 

--- a/iotilecore/iotile/core/hw/reports/parser.py
+++ b/iotilecore/iotile/core/hw/reports/parser.py
@@ -88,7 +88,7 @@ class IOTileReportParser (object):
                     self.error_callback(self.ErrorFindingReportType, str(exc), self.context)
                 else:
                     raise
-        
+
         if self.state == self.WaitingForReportHeader and len(self.raw_data) >= self.current_header_size:
             try:
                 self.current_report_size = self.calculate_report_size(self.current_type, self.raw_data[:self.current_header_size])

--- a/iotilecore/iotile/core/hw/reports/report.py
+++ b/iotilecore/iotile/core/hw/reports/report.py
@@ -13,14 +13,19 @@ class IOTileReading(object):
         time_base (datetime): An optional estimate of when the device was
             last turned on so that we can calulate the actual time of the
             reading
+        reading_id (int): An optional unique identifier for this reading that allows
+            deduplication.
         stream (int): The stream that this reading is part of
         value (bytearray): the raw reading value
     """
 
-    def __init__(self, raw_time, stream, value, time_base=None):
+    InvalidReadingID = 0xFFFFFFFF
+
+    def __init__(self, raw_time, stream, value, time_base=None, reading_id=0xFFFFFFFF):
         self.raw_time = raw_time
         self.stream = stream
         self.value = value
+        self.reading_id = reading_id
 
         self.reading_time = None
         if time_base is not None:

--- a/iotilecore/iotile/core/hw/reports/report.py
+++ b/iotilecore/iotile/core/hw/reports/report.py
@@ -31,6 +31,9 @@ class IOTileReading(object):
         if time_base is not None:
             self.reading_time = time_base + datetime.timedelta(seconds=raw_time)
 
+    def __eq__(self, other):
+        return self.raw_time == other.raw_time and self.stream == other.stream and self.value == other.value and self.reading_id == other.reading_id
+
     def __str__(self):
         if self.reading_time is not None:
             return "Stream {}: {} at {}".format(self.stream, self.value, self.reading_time)
@@ -120,6 +123,18 @@ class IOTileReport(object):
         """
 
         return self.raw_report
+
+    def save(self, path):
+        """Save a binary copy of this report
+
+        Args:
+            path (string): The path where we should save the binary copy of the report
+        """
+
+        data = self.encode()
+
+        with open(path, "wb") as out:
+            out.write(data)
 
     def serialize(self):
         """Turn this report into a dictionary that encodes all information including received timestamp

--- a/iotilecore/iotile/core/hw/reports/signed_list_format.py
+++ b/iotilecore/iotile/core/hw/reports/signed_list_format.py
@@ -1,0 +1,114 @@
+"""IOTileReport subclass for readings packaged as individual readings
+"""
+
+import datetime
+import struct
+from report import IOTileReport, IOTileReading
+from iotile.core.utilities.packed import unpack
+from iotile.core.exceptions import ArgumentError
+
+
+class SignedListReport(IOTileReport):
+    """A report that consists of a signed list of readings.
+
+    Args:
+        rawreport (bytearray): The raw data of this report
+    """
+
+    ReportType = 1
+
+    def __init__(self, rawreport, **kwargs):
+        super(SignedListReport, self).__init__(rawreport, signed=True, encrypted=False, **kwargs)
+
+    @classmethod
+    def HeaderLength(cls):
+        """Return the length of a header needed to calculate this report's length
+
+        Returns:
+            int: the length of the needed report header
+        """
+
+        return 20
+
+    @classmethod
+    def ReportLength(cls, header):
+        """Given a header of HeaderLength bytes, calculate the size of this report
+        """
+
+        first_word, = unpack("<L", header[:4])
+
+        length = (first_word >> 8)
+        return length
+
+    @classmethod
+    def FromReadings(cls, uuid, readings):
+        """Generate an instance of the report format from a list of readings and a uuid
+        """
+
+        if len(readings) != 1:
+            raise ArgumentError("IndividualReading reports must be created with exactly one reading", num_readings=len(readings))
+
+        reading = readings[0]
+        data = struct.pack("<BBHLLLL", 0, 0, reading.stream, uuid, 0, reading.raw_time, reading.value)
+        return SignedListReport(data)
+
+    def decode(self):
+        """Decode this report into a list of readings
+        """
+
+        fmt, len_low, len_high, device_id, report_id, sent_timestamp, signature_flags, origin_streamer, streamer_selector = unpack("<BBHLLLBBH", self.raw_report)
+
+        assert fmt == 1
+        length = (len_high << 8) | len_low
+
+        self.origin = device_id
+        self.report_id = report_id
+        self.sent_timestamp = sent_timestamp
+        self.origin_streamer = origin_streamer
+        self.streamer_selector = streamer_selector
+        self.signature_flags = signature_flags
+
+        remaining = self.raw_report[20:]
+        assert len(remaining) >= 24
+        readings = remaining[:-24]
+        footer = remaining[-24:]
+
+        lowest_id, highest_id, signature = unpack("<LL16s", footer)
+        signature = bytearray(signature)
+
+        self.signature = signature
+        self.lowest_id = lowest_id
+        self.highest_id = highest_id
+
+        #Make sure this report has an integer number of readings
+        assert (len(readings) % 16) == 0
+
+        time_base = self.received_time - datetime.timedelta(seconds=sent_timestamp)
+        parsed_readings = []
+
+        for i in xrange(0, len(readings), 16):
+            reading = readings[i:i+16]
+            stream, _, reading_id, timestamp, value = unpack("<HHLLL", reading)
+
+            parsed = IOTileReading(timestamp, stream, value, time_base=time_base, reading_id=reading_id)
+            parsed_readings.append(parsed)
+
+        #FIXME: attempt to validate the signature
+        return parsed_readings
+
+    def encode(self):
+        """Turn this report into a serialized bytearray that could be decoded with a call to decode
+
+        If we were generated from a binary report, just return that so that the signature remains intact,
+        otherwise generate one and attempt to sign it 
+        """
+
+        if hasattr(self, 'raw_report'):
+            return self.raw_report
+
+        #
+
+        reading = self.visible_readings[0]
+        data = struct.pack("<BBHLLLL", 0, 0, reading.stream, self.origin, self.sent_timestamp, reading.raw_time, reading.value)
+
+        return bytearray(data)

--- a/iotilecore/setup.py
+++ b/iotilecore/setup.py
@@ -44,7 +44,8 @@ setup(
             'recorded = iotile.core.hw.transport.recordedstream:RecordedStream'
         ],
         'iotile.report_format': [
-            'individual = iotile.core.hw.reports.individual_format:IndividualReadingReport'
+            'individual = iotile.core.hw.reports.individual_format:IndividualReadingReport',
+            'signed_list = iotile.core.hw.reports.signed_list_format:SignedListReport'
             ]
     },
     description="IOTile Core Tools",

--- a/iotilecore/test/test_reports/test_individual_report.py
+++ b/iotilecore/test/test_reports/test_individual_report.py
@@ -101,3 +101,21 @@ def test_serialization():
     assert ser['received_time'] == received_time
     assert ser['origin'] == 10
     assert ser['report_format'] == IndividualReadingReport.ReportType
+
+def test_save(tmpdir):
+    """Make sure we can save and load this report from a file
+    """
+    p = tmpdir.join('out.bin')
+
+    report_data = make_report(10, 1, 2, 3, 4)
+    received_time = datetime.datetime.utcnow()
+
+    report = IndividualReadingReport(report_data, received_time=received_time)
+    report.save(str(p))
+
+    data = p.read()
+
+    report2 = IndividualReadingReport(data, received_time=received_time)
+
+    assert report2.origin == report.origin
+    assert report2.sent_timestamp == report.sent_timestamp

--- a/iotilecore/test/test_reports/test_signed_list_report.py
+++ b/iotilecore/test/test_reports/test_signed_list_report.py
@@ -1,0 +1,37 @@
+import unittest
+import os
+import pytest
+from iotile.core.exceptions import *
+from iotile.core.hw.reports.signed_list_format import SignedListReport
+from iotile.core.hw.reports.report import IOTileReading
+import struct
+import datetime
+
+def make_sequential(iotile_id, stream, num_readings, give_ids=False):
+    readings = []
+
+    for i in xrange(0, num_readings):
+        if give_ids:
+            reading = IOTileReading(i, stream, i, reading_id=i)
+        else:
+            reading = IOTileReading(i, stream, i)
+
+        readings.append(reading)
+        
+    report = SignedListReport.FromReadings(iotile_id, readings)
+    return report
+
+def test_basic_parsing():
+    """Make sure we can decode a signed report
+    """
+
+    report = make_sequential(1, 0x1000, 10)
+    encoded = report.encode()
+
+    report2 = SignedListReport(encoded)
+
+    assert len(report.visible_readings) == 10
+    assert len(report2.visible_readings) == 10
+
+    for i, reading in enumerate(report.visible_readings):
+        assert reading == report2.visible_readings[i]

--- a/iotilecore/version.py
+++ b/iotilecore/version.py
@@ -1,1 +1,1 @@
-version = "3.6.2"
+version = "3.7.0"

--- a/iotiletest/RELEASE.md
+++ b/iotiletest/RELEASE.md
@@ -2,6 +2,11 @@
 
 All major changes in each released version of IOTileTest are listed here.
 
+## 0.5.0
+
+- Update invidual_reports device to report_test device and add support for SignedList
+  report type.
+
 ## 0.4.2
 
 - Allow iotile ids to be specified as hex strings or integers

--- a/iotiletest/setup.py
+++ b/iotiletest/setup.py
@@ -27,7 +27,7 @@ setup(
     ],
     description="IOTile Core Tools",
     entry_points={'iotile.virtual_device': ['simple = iotile.mock.devices.simple_virtual_device:SimpleVirtualDevice',
-                                            'individual_reports = iotile.mock.devices.individual_report_test_device:IndividualReportTestDevice'],
+                                            'report_test = iotile.mock.devices.report_test_device:ReportTestDevice'],
                   'iotile.proxy': ['simple = iotile.mock.devices.simple_virtual_proxy']},
     author="Arch",
     author_email="info@arch-iot.com",

--- a/iotiletest/version.py
+++ b/iotiletest/version.py
@@ -1,1 +1,1 @@
-version = "0.4.2"
+version = "0.5.0"


### PR DESCRIPTION
This just includes basic support.  Hooks for actually verifying signatures and generating them for internally generated reports are still forthcoming.