### PR TITLE
Remove improperly named exceptions

### DIFF
--- a/iotile_ext_cloud/iotile/cloud/cloud.py
+++ b/iotile_ext_cloud/iotile/cloud/cloud.py
@@ -6,7 +6,7 @@ import requests
 from iotile_cloud.api.connection import Api
 from iotile_cloud.api.exceptions import RestHttpBaseException, HttpNotFoundError
 from iotile.core.dev.registry import ComponentRegistry
-from iotile.core.exceptions import ArgumentError, EnvironmentError
+from iotile.core.exceptions import ArgumentError, ExternalError
 from iotile.core.utilities.typedargs import context, param, return_type, annotated
 
 
@@ -21,7 +21,7 @@ class IOTileCloud(object):
         try:
             token = reg.get_config('arch:cloud_token')
         except ArgumentError:
-            raise EnvironmentError("No stored iotile cloud authentication information", suggestion='Call iotile config link_cloud with your iotile cloud username and password')
+            raise ExternalError("No stored iotile cloud authentication information", suggestion='Call iotile config link_cloud with your iotile cloud username and password')
 
         self.api = Api()
         self.api.set_token(token)
@@ -69,7 +69,7 @@ class IOTileCloud(object):
             if exc.response.status_code == 400:
                 raise ArgumentError("Error setting sensor graph, invalid value", value=new_sg, error_code=exc.response.status_code)
             else:
-                raise EnvironmentError("Error calling method on iotile.cloud", exception=exc, response=exc.response.status_code)
+                raise ExternalError("Error calling method on iotile.cloud", exception=exc, response=exc.response.status_code)
 
     @param("project_id", "string", desc="ID of the project to download a list of devices from")
     @return_type("list(integer)")
@@ -94,7 +94,7 @@ class IOTileCloud(object):
         try:
             self.api.device(slug).unclaim.post(payload)
         except RestHttpBaseException, exc:
-            raise EnvironmentError("Error calling method on iotile.cloud", exception=exc, response=exc.response.status_code)
+            raise ExternalError("Error calling method on iotile.cloud", exception=exc, response=exc.response.status_code)
 
     def upload_report(self, report):
         """Upload an IOTile report to the cloud.
@@ -141,7 +141,7 @@ class IOTileCloud(object):
             raise ArgumentError("Could not get information for streamer", device_id=device_id, streamer_id=streamer, slug=slug, err=str(exc))
 
         if 'last_id' not in data:
-            raise EnvironmentError("Response fom the cloud did not have last_id set", response=data)
+            raise ExternalError("Response fom the cloud did not have last_id set", response=data)
 
         return data['last_id']
 
@@ -153,7 +153,7 @@ class IOTileCloud(object):
         url = 'https://iotile.cloud/api/v1/auth/api-jwt-refresh/'
         resp = requests.post(url, json={'token': self.token})
         if resp.status_code != 200:
-            raise EnvironmentError("Could not refresh token", error_code=resp.status_code)
+            raise ExternalError("Could not refresh token", error_code=resp.status_code)
 
         data = resp.json()
 

--- a/iotilebuild/iotile/build/dev/resolverchain.py
+++ b/iotilebuild/iotile/build/dev/resolverchain.py
@@ -46,8 +46,8 @@ class DependencyResolverChain(object):
             name = factory.__name__
 
             if name in self._known_resolvers:
-                raise EnvironmentError("The same dependency resolver class name is provided by more than one entry point", name=name)
-            
+                raise ExternalError("The same dependency resolver class name is provided by more than one entry point", name=name)
+
             self._known_resolvers[name] = factory
 
     def instantiate_resolver(self, name, args):
@@ -80,7 +80,7 @@ class DependencyResolverChain(object):
                 be fetched.
 
         Raises:
-            EnvironmentError: If the destination folder exists and force is not specified
+            ExternalError: If the destination folder exists and force is not specified
             ArgumentError: If the specified component could not be found with the required version
         """
 
@@ -96,7 +96,7 @@ class DependencyResolverChain(object):
         destdir = os.path.join(destfolder, unique_id)
         if os.path.exists(destdir):
             if not force:
-                raise EnvironmentError("Output directory exists and force was not specified, aborting", output_directory=destdir)
+                raise ExternalError("Output directory exists and force was not specified, aborting", output_directory=destdir)
 
             shutil.rmtree(destdir)
 
@@ -122,7 +122,7 @@ class DependencyResolverChain(object):
 
         if destdir is None:
             destdir = os.path.join(tile.folder, 'build', 'deps', depinfo['unique_id'])
-        
+
         has_version = False
         had_version = False
         if os.path.exists(destdir):
@@ -201,7 +201,7 @@ class DependencyResolverChain(object):
         except IOError as e:
             return False
 
-        #If this dependency was initially resolved with a different resolver, then 
+        #If this dependency was initially resolved with a different resolver, then
         #we cannot check if it is up to date
         if settings['resolver'] != resolver.__class__.__name__:
             return None
@@ -211,7 +211,7 @@ class DependencyResolverChain(object):
             resolver_settings = settings['settings']
 
         return resolver.check(depinfo, deptile, resolver_settings)
-    
+
     def _find_resolver(self, rule):
         regex,factory,args = rule
         return factory(args)

--- a/iotilebuild/iotile/build/dev/resolvers/registry_resolver.py
+++ b/iotilebuild/iotile/build/dev/resolvers/registry_resolver.py
@@ -1,6 +1,6 @@
 import os
 from depresolver import DependencyResolver
-from iotile.core.exceptions import ArgumentError, EnvironmentError, IOTileException
+from iotile.core.exceptions import ArgumentError, ExternalError, IOTileException
 from iotile.core.utilities.typedargs import iprint
 from iotile.core.dev.iotileobj import IOTile
 
@@ -29,12 +29,12 @@ class ComponentRegistryResolver (DependencyResolver):
         # raise an error.
 
         if not os.path.exists(comp.output_folder):
-            raise EnvironmentError("Component found in registry but has not been built", path=comp.folder, name=comp.name, suggestion="Run iotile build on this component first")
+            raise ExternalError("Component found in registry but has not been built", path=comp.folder, name=comp.name, suggestion="Run iotile build on this component first")
 
         try:
             IOTile(comp.output_folder)
         except IOTileException:
-            raise EnvironmentError("Component found in registry but its build/output folder is not valid", path=comp.folder, name=comp.name, suggestion="Cleanly rebuild the component")
+            raise ExternalError("Component found in registry but its build/output folder is not valid", path=comp.folder, name=comp.name, suggestion="Cleanly rebuild the component")
 
         self._copy_folder_contents(comp.output_folder, destdir)
         return {'found': True}

--- a/iotilebuild/test/test_depresolvers/test_resolverchain.py
+++ b/iotilebuild/test/test_depresolvers/test_resolverchain.py
@@ -1,7 +1,7 @@
 import pytest
 import os
 import shutil
-from iotile.core.exceptions import EnvironmentError
+from iotile.core.exceptions import ExternalError
 from iotile.build.dev.resolverchain import DependencyResolverChain
 from iotile.mock.mock_resolver import MockDependencyResolver
 from iotile.core.dev.iotileobj import IOTile
@@ -125,7 +125,7 @@ def test_registry_resolver_unbuilt(tmpdir):
 
     try:
         reg.add_component(comp_path('comp1_v1.1_unbuilt'))
-        with pytest.raises(EnvironmentError) as excinfo:
+        with pytest.raises(ExternalError) as excinfo:
             for dep in tile.dependencies:
                 result = chain.update_dependency(tile, dep)
 
@@ -144,7 +144,7 @@ def test_registry_resolver_built_invalid(tmpdir):
 
     try:
         reg.add_component(comp_path('comp1_v1.1_built_empty'))
-        with pytest.raises(EnvironmentError) as excinfo:
+        with pytest.raises(ExternalError) as excinfo:
             for dep in tile.dependencies:
                 result = chain.update_dependency(tile, dep)
 

--- a/iotilebuild/test/test_iotilebuild/component_nodependskey/build/output/module_settings.json
+++ b/iotilebuild/test/test_iotilebuild/component_nodependskey/build/output/module_settings.json
@@ -1,19 +1,13 @@
 {
-    "dependency_versions": {}, 
-    "modules": {
-        "tile_gpio": {
-            "defines": {
-                "kVoltageSenseChannel2": 2, 
-                "kVoltageControlPin": 9, 
-                "kSensePin": 6, 
-                "kVoltageSourcePin2": 23, 
-                "kVoltageSourcePin1": 8, 
-                "kVoltageSensePin2": 14, 
-                "kSenseChannel": 1
-            }, 
-            "domain": "iotile_standard_library"
-        }
+    "module_name": "tile_gpio", 
+    "release_date": "2017-05-04T01:49:12.619000", 
+    "module_targets": {
+        "tile_gpio": [
+            "lpc824"
+        ]
     }, 
+    "dependency_versions": {}, 
+    "release": true, 
     "architectures": {
         "lpc824": {
             "defines": {
@@ -21,12 +15,18 @@
             }
         }
     }, 
-    "module_targets": {
-        "tile_gpio": [
-            "lpc824"
-        ]
-    }, 
-    "release_date": "2017-04-20T01:12:10.050000", 
-    "module_name": "tile_gpio", 
-    "release": true
+    "modules": {
+        "tile_gpio": {
+            "domain": "iotile_standard_library", 
+            "defines": {
+                "kVoltageSourcePin1": 8, 
+                "kVoltageSourcePin2": 23, 
+                "kVoltageSenseChannel2": 2, 
+                "kSenseChannel": 1, 
+                "kSensePin": 6, 
+                "kVoltageSensePin2": 14, 
+                "kVoltageControlPin": 9
+            }
+        }
+    }
 }

--- a/iotilecore/iotile/core/dev/config.py
+++ b/iotilecore/iotile/core/dev/config.py
@@ -20,7 +20,7 @@ import pkg_resources
 import fnmatch
 from collections import namedtuple
 from iotile.core.dev.registry import ComponentRegistry
-from iotile.core.exceptions import ArgumentError, EnvironmentError
+from iotile.core.exceptions import ArgumentError, ExternalError
 from iotile.core.utilities.typedargs import context, param, return_type, stringable, type_system
 
 MISSING = object()
@@ -49,11 +49,11 @@ class ConfigManager(object):
                 provider = entry.load()
                 prefix, conf_vars = provider()
             except (ValueError, TypeError) as exc:
-                raise EnvironmentError("Error loading config variables", package=entry.name, error=str(exc))
+                raise ExternalError("Error loading config variables", package=entry.name, error=str(exc))
 
             for var in conf_vars:
                 if len(var) != 3 and len(var) != 4:
-                    raise EnvironmentError("Error loading config variable, invalid length", data=var, package=entry.name)
+                    raise ExternalError("Error loading config variable, invalid length", data=var, package=entry.name)
 
                 name = prefix + ':' + var[0]
                 if len(var) == 3:
@@ -62,7 +62,7 @@ class ConfigManager(object):
                     var_obj = ConfigVariable(name, var[1], var[2], var[3])
 
                 if name in self._known_variables:
-                    raise EnvironmentError("The same config variable was defined twice", name=name)
+                    raise ExternalError("The same config variable was defined twice", name=name)
 
                 self._known_variables[name] = var_obj
 
@@ -81,7 +81,7 @@ class ConfigManager(object):
 
                 self.add_function(name, conf_func)
             except (ValueError, TypeError) as exc:
-                raise EnvironmentError("Error loading config function", name=name, error=str(exc))
+                raise ExternalError("Error loading config function", name=name, error=str(exc))
 
     def _format_variable(self, name, var):
         """Format a helpful string describing a config variable

--- a/iotilecore/iotile/core/dev/iotileobj.py
+++ b/iotilecore/iotile/core/dev/iotileobj.py
@@ -32,7 +32,7 @@ class IOTile(object):
             with open(modfile, "r") as f:
                 settings = json.load(f)
         except IOError:
-            raise EnvironmentError("Could not load module_settings.json file, make sure this directory is an IOTile component", path=self.folder)
+            raise ExternalError("Could not load module_settings.json file, make sure this directory is an IOTile component", path=self.folder)
 
         if 'module_name' in settings:
             modname = settings['module_name']

--- a/iotilecore/iotile/core/exceptions.py
+++ b/iotilecore/iotile/core/exceptions.py
@@ -149,7 +149,7 @@ class BuildError(IOTileException):
 
 class TypeSystemError(IOTileException):
     """
-    There was an error with the MoMo type system.  This can be due to improperly
+    There was an error with the IOTile type system.  This can be due to improperly
     specifying an unknown type or because the required type was not properly loaded
     from an external module before a function that used that type was needed.
     """
@@ -158,7 +158,7 @@ class TypeSystemError(IOTileException):
 
 class ExternalError(IOTileException):
     """
-    The external environment is not properly configured for the MoMo API command that was called.
+    The external environment is not properly configured for the IOTile API command that was called.
     This can be because a required program was not installed or accessible or because
     a required environment variable was not defined.
     """
@@ -167,7 +167,7 @@ class ExternalError(IOTileException):
 
 class HardwareError(IOTileException):
     """
-    There was an issue communicating with or controlling a MoMo hardware module.  This
+    There was an issue communicating with or controlling an IOTile hardware module.  This
     exception anchors a range of exceptions that refer to specific kinds of hardware issues.
 
     By catching this exception, you will catch any sort of hardware failure.  If you are

--- a/iotilecore/iotile/core/exceptions.py
+++ b/iotilecore/iotile/core/exceptions.py
@@ -156,9 +156,9 @@ class TypeSystemError(IOTileException):
 
     pass
 
-class EnvironmentError(IOTileException):
+class ExternalError(IOTileException):
     """
-    The environment is not properly configured for the MoMo API command that was called.
+    The external environment is not properly configured for the MoMo API command that was called.
     This can be because a required program was not installed or accessible or because
     a required environment variable was not defined.
     """

--- a/iotilecore/iotile/core/exceptions.py
+++ b/iotilecore/iotile/core/exceptions.py
@@ -10,7 +10,7 @@
 
 class IOTileException(Exception):
     """
-    All MoMo API routines, upon encountering unrecoverable errors,
+    All IOTile API routines, upon encountering unrecoverable errors,
     will throw an exception that is a subclass of this exception.
     All other exceptions are caught and rethrown as an APIError
     for consistency.  Calling methods can assume that all annotated
@@ -83,7 +83,7 @@ class NotFoundError(IOTileException):
 
     pass
 
-class TimeoutError(IOTileException):
+class TimeoutExpiredError(IOTileException):
     """
     The method timed out, usually indicating that a communication failure
     occurred, either with another process or with a hardware module.

--- a/iotilecore/iotile/core/hw/auth/auth_chain.py
+++ b/iotilecore/iotile/core/hw/auth/auth_chain.py
@@ -3,7 +3,7 @@
 
 import pkg_resources
 from auth_provider import AuthProvider, KnownSignatureMethods
-from iotile.core.exceptions import NotFoundError, EnvironmentError
+from iotile.core.exceptions import NotFoundError, ExternalError
 
 class ChainedAuthProvider(AuthProvider):
     """An AuthProvider that delegates operations to a list of subproviders
@@ -28,7 +28,7 @@ class ChainedAuthProvider(AuthProvider):
             priority, provider, args = entry.load()
 
             if provider not in self._auth_factories:
-                raise EnvironmentError("Default authentication provider list references unknown auth provider", provider_name=provider, known_providers=self._auth_factories.keys())
+                raise ExternalError("Default authentication provider list references unknown auth provider", provider_name=provider, known_providers=self._auth_factories.keys())
             configured = self._auth_factories[provider](args)
             sub_providers.append((priority, configured))
 

--- a/iotilecore/iotile/core/hw/hwmanager.py
+++ b/iotilecore/iotile/core/hw/hwmanager.py
@@ -236,7 +236,7 @@ class HardwareManager:
         """
 
         if self._stream_queue is None:
-            raise EnvironmentError("You have to enable streaming before you can wait for reports")
+            raise ExternalError("You have to enable streaming before you can wait for reports")
 
         reports = []
 

--- a/iotilecore/iotile/core/hw/hwmanager.py
+++ b/iotilecore/iotile/core/hw/hwmanager.py
@@ -245,7 +245,7 @@ class HardwareManager:
                 report = self._stream_queue.get(timeout=timeout)
                 reports.append(report)
             except Empty:
-                raise TimeoutError("Timeout waiting for a report", expected_number=num_reports, received_number=i, received_reports=reports)
+                raise TimeoutExpiredError("Timeout waiting for a report", expected_number=num_reports, received_number=i, received_reports=reports)
 
         return reports
 

--- a/iotilecore/iotile/core/hw/reports/signed_list_format.py
+++ b/iotilecore/iotile/core/hw/reports/signed_list_format.py
@@ -5,7 +5,7 @@ import datetime
 import struct
 from report import IOTileReport, IOTileReading
 from iotile.core.utilities.packed import unpack
-from iotile.core.exceptions import ArgumentError, NotFoundError, EnvironmentError
+from iotile.core.exceptions import ArgumentError, NotFoundError, ExternalError
 import iotile.core.hw.auth.auth_provider as auth_provider
 from iotile.core.hw.auth.auth_chain import ChainedAuthProvider
 
@@ -84,7 +84,7 @@ class SignedListReport(IOTileReport):
         try:
             signature = signer.sign(uuid, signature_method, signed_data)
         except NotFoundError:
-            raise EnvironmentError("Could not sign report because no AuthProvider supported the requested signature method for the requested device", device_id=uuid, signature_method=signature_method)
+            raise ExternalError("Could not sign report because no AuthProvider supported the requested signature method for the requested device", device_id=uuid, signature_method=signature_method)
         
         footer = struct.pack("16s", str(signature['signature'][:16]))
         footer = bytearray(footer)

--- a/iotilecore/iotile/core/hw/transport/websocketstream.py
+++ b/iotilecore/iotile/core/hw/transport/websocketstream.py
@@ -162,7 +162,7 @@ class WebSocketStream(CMDStream):
             try:
                 result = self.client.messages.get(timeout=10.0)
             except Empty:
-                raise TimeoutError('Timeout waiting for response to %s command from websocket server' % command)
+                raise TimeoutExpiredError('Timeout waiting for response to %s command from websocket server' % command)
 
             if 'type' in result and result['type'] == 'progress':
                 total = result['total']

--- a/iotilecore/iotile/core/utilities/stoppable_thread.py
+++ b/iotilecore/iotile/core/utilities/stoppable_thread.py
@@ -5,7 +5,7 @@ import threading
 import inspect
 import traceback
 import time
-from iotile.core.exceptions import TimeoutError
+from iotile.core.exceptions import TimeoutExpiredError
 
 
 class StoppableWorkerThread(threading.Thread):
@@ -123,14 +123,14 @@ class StoppableWorkerThread(threading.Thread):
         flag = self._running.wait(timeout)
 
         if flag is False:
-            raise TimeoutError("Timeout waiting for thread to start running")
+            raise TimeoutExpiredError("Timeout waiting for thread to start running")
 
     def stop(self, timeout=None, force=False):
         """Stop the worker thread and synchronously wait for it to finish.
 
         Args:
             timeout (float): The maximum time to wait for the thread to stop
-                before raising a TimeoutError.  If force is True, TimeoutError
+                before raising a TimeoutExpiredError.  If force is True, TimeoutExpiredError
                 is not raised and the thread is just marked as a daemon thread
                 so that it does not block cleanly exiting the process.
             force (bool): If true and the thread does not exit in timeout seconds
@@ -142,4 +142,4 @@ class StoppableWorkerThread(threading.Thread):
         self.join(timeout)
 
         if self.is_alive() and force is False:
-            raise TimeoutError("Error waiting for background thread to exit", timeout=timeout)
+            raise TimeoutExpiredError("Error waiting for background thread to exit", timeout=timeout)

--- a/iotilecore/iotile/core/utilities/validating_wsclient.py
+++ b/iotilecore/iotile/core/utilities/validating_wsclient.py
@@ -5,7 +5,7 @@ import threading
 import msgpack
 import datetime
 import logging
-from iotile.core.exceptions import IOTileException, InternalError, ValidationError, TimeoutError
+from iotile.core.exceptions import IOTileException, InternalError, ValidationError, TimeoutExpiredError
 from iotile.core.utilities.schema_verify import Verifier, DictionaryVerifier, StringVerifier, LiteralVerifier, OptionsVerifier
 
 # The prescribed schema of command response messages
@@ -90,7 +90,7 @@ class ValidatingWSClient(WebSocketClient):
 
         flag = self._connected.wait(timeout=timeout)
         if not flag:
-            raise TimeoutError("Conection attempt to host timed out")
+            raise TimeoutExpiredError("Conection attempt to host timed out")
 
     def stop(self, timeout=5.0):
         """Synchronously disconnect from websocket server.
@@ -110,7 +110,7 @@ class ValidatingWSClient(WebSocketClient):
 
         flag = self._disconnection_finished.wait(timeout=timeout)
         if not flag:
-            raise TimeoutError("Disconnection attempt from host timed out")
+            raise TimeoutExpiredError("Disconnection attempt from host timed out")
 
     def send_message(self, obj):
         """Send a packed message.
@@ -142,7 +142,7 @@ class ValidatingWSClient(WebSocketClient):
 
             flag = self._response_received.wait(timeout=timeout)
             if not flag:
-                raise TimeoutError("Timeout waiting for response")
+                raise TimeoutExpiredError("Timeout waiting for response")
 
             self._response_received.clear()
             return self._last_response

--- a/iotilecore/test/test_reports/test_signed_list_report.py
+++ b/iotilecore/test/test_reports/test_signed_list_report.py
@@ -1,7 +1,7 @@
 import unittest
 import os
 import pytest
-from iotile.core.exceptions import *
+from iotile.core.exceptions import ExternalError
 from iotile.core.hw.reports.signed_list_format import SignedListReport
 from iotile.core.hw.reports.report import IOTileReading
 import struct
@@ -18,7 +18,7 @@ def make_sequential(iotile_id, stream, num_readings, give_ids=False, signature_m
             reading = IOTileReading(i, stream, i)
 
         readings.append(reading)
-        
+
     report = SignedListReport.FromReadings(iotile_id, readings, signature_method=signature_method)
     return report
 
@@ -58,7 +58,7 @@ def test_userkey_signing(monkeypatch):
     print(os.environ.keys())
     monkeypatch.setenv('USER_KEY_00000002', '0000000000000000000000000000000000000000000000000000000000000000')
 
-    with pytest.raises(EnvironmentError):
+    with pytest.raises(ExternalError):
         report1 = make_sequential(1, 0x1000, 10, give_ids=True, signature_method=1)
 
     report1 = make_sequential(2, 0x1000, 10, give_ids=True, signature_method=1)

--- a/iotilecore/test/test_utilities/test_stoppable_thread.py
+++ b/iotilecore/test/test_utilities/test_stoppable_thread.py
@@ -8,7 +8,7 @@ else:
     import queue as queue
 
 from iotile.core.utilities.stoppable_thread import StoppableWorkerThread
-from iotile.core.exceptions import TimeoutError
+from iotile.core.exceptions import TimeoutExpiredError
 
 def test_running_function():
     """Make sure we can run a function in the thread
@@ -88,7 +88,7 @@ def test_failed_stop():
     thread.start()
     thread.wait_running(timeout=1.0)
 
-    with pytest.raises(TimeoutError):
+    with pytest.raises(TimeoutExpiredError):
         thread.stop(timeout=0.01)
 
 def test_failed_stop_force():

--- a/iotiletest/iotile/mock/mock_resolver.py
+++ b/iotiletest/iotile/mock/mock_resolver.py
@@ -49,12 +49,12 @@ class MockDependencyResolver(object):
             bool: True meaning the dependency is up-to-date or False if it is not.
 
         Raises:
-            EnvironmentError: if the checking process was not able to assess whether the dependency was 
+            ExternalError: if the checking process was not able to assess whether the dependency was 
                 up to date or not.
         """
 
         if depinfo['unique_id'] not in self.known_deps:
-            raise EnvironmentError("Could not check dependency's status", unique_id=depinfo['unique_id'])
+            raise ExternalError("Could not check dependency's status", unique_id=depinfo['unique_id'])
 
         dep = self.known_deps[depinfo['unique_id']]
         if not depinfo['required_version'].check(dep.parsed_version):

--- a/transport_plugins/awsiot/iotile_transport_awsiot/gateway_agent.py
+++ b/transport_plugins/awsiot/iotile_transport_awsiot/gateway_agent.py
@@ -6,7 +6,7 @@ import messages
 from monotonic import monotonic
 from mqtt_client import OrderedAWSIOTClient
 from topic_validator import MQTTTopicValidator
-from iotile.core.exceptions import EnvironmentError, ArgumentError, ValidationError
+from iotile.core.exceptions import ExternalError, ArgumentError, ValidationError
 
 
 class AWSIOTGatewayAgent(object):
@@ -105,7 +105,7 @@ class AWSIOTGatewayAgent(object):
         try:
             self.client.connect(self.slug)
         except Exception, exc:
-            raise EnvironmentError("Could not connect to AWS IOT", error=str(exc))
+            raise ExternalError("Could not connect to AWS IOT", error=str(exc))
 
         self.topics = MQTTTopicValidator(self.prefix + 'devices/{}'.format(self.slug))
         self._bind_topics()

--- a/transport_plugins/awsiot/iotile_transport_awsiot/mqtt_client.py
+++ b/transport_plugins/awsiot/iotile_transport_awsiot/mqtt_client.py
@@ -3,7 +3,7 @@ import logging
 import AWSIoTPythonSDK.MQTTLib
 import re
 from AWSIoTPythonSDK.exception import operationError
-from iotile.core.exceptions import ArgumentError, EnvironmentError, InternalError
+from iotile.core.exceptions import ArgumentError, ExternalError, InternalError
 from iotile.core.dev.registry import ComponentRegistry
 from packet_queue import PacketQueue
 from topic_sequencer import TopicSequencer
@@ -30,13 +30,13 @@ class OrderedAWSIOTClient(object):
         try:
             if not use_websockets:
                 if cert is None:
-                    raise EnvironmentError("Certificate for AWS IOT not passed in certificate key")
+                    raise ExternalError("Certificate for AWS IOT not passed in certificate key")
                 elif key is None:
-                    raise EnvironmentError("Private key for certificate not passed in private_key key")
+                    raise ExternalError("Private key for certificate not passed in private_key key")
             else:
                 if iamkey is None or iamsecret is None:
-                    raise EnvironmentError("IAM Credentials need to be provided for websockets auth")
-        except EnvironmentError:
+                    raise ExternalError("IAM Credentials need to be provided for websockets auth")
+        except ExternalError:
             # If the correct information is not passed in, try and see if we get it from our environment
             # try to pull in root certs, endpoint name and iam or cognito session information
             reg = ComponentRegistry()
@@ -57,9 +57,9 @@ class OrderedAWSIOTClient(object):
             use_websockets = True
 
         if root is None:
-            raise EnvironmentError("Root of certificate chain not passed in root_certificate key (and not in registry)")
+            raise ExternalError("Root of certificate chain not passed in root_certificate key (and not in registry)")
         elif endpoint is None:
-            raise EnvironmentError("AWS IOT endpoint not passed in endpoint key (and not in registry)")
+            raise ExternalError("AWS IOT endpoint not passed in endpoint key (and not in registry)")
 
         self.websockets = use_websockets
         self.iam_key = iamkey

--- a/transport_plugins/bled112/iotile_transport_bled112/async_packet.py
+++ b/transport_plugins/bled112/iotile_transport_bled112/async_packet.py
@@ -1,7 +1,7 @@
 from threading import Thread, Event
 from Queue import Queue, Empty
 
-class TimeoutError(Exception):
+class InternalTimeoutError(Exception):
     pass
 
 class AsyncPacketBuffer:
@@ -41,7 +41,7 @@ class AsyncPacketBuffer:
         try:
             return self.queue.get(timeout=timeout)
         except Empty:
-            raise TimeoutError("Timeout waiting for packet in AsyncPacketBuffer")
+            raise InternalTimeoutError("Timeout waiting for packet in AsyncPacketBuffer")
 
 
 def ReaderThread(filelike, read_queue, header_length, length_function, stop):

--- a/transport_plugins/bled112/iotile_transport_bled112/virtual_bled112.py
+++ b/transport_plugins/bled112/iotile_transport_bled112/virtual_bled112.py
@@ -16,7 +16,7 @@ import time
 import binascii
 import serial
 import serial.tools.list_ports
-from iotile.core.exceptions import EnvironmentError, HardwareError
+from iotile.core.exceptions import ExternalError, HardwareError
 from async_packet import AsyncPacketBuffer
 from iotile.core.hw.virtual.virtualinterface import VirtualIOTileInterface
 from iotile.core.hw.virtual.virtualdevice import RPCInvalidIDError, RPCNotFoundError, TileNotFoundError
@@ -64,7 +64,7 @@ class BLED112VirtualInterface(VirtualIOTileInterface):
             if len(devices) > 0:
                 port = devices[0]
             else:
-                raise EnvironmentError("Could not find any BLED112 adapters connected to this computer")
+                raise ExternalError("Could not find any BLED112 adapters connected to this computer")
 
         self._serial_port = serial.Serial(port, 256000, timeout=0.01, rtscts=True)
         self._stream = AsyncPacketBuffer(self._serial_port, header_length=4, length_function=packet_length)


### PR DESCRIPTION
Legacy cleanup

There were internal exceptions named EnvironmentError and TimeoutError that shadow builtin exceptions.  This replaces them with ExternalError and TimeoutExpiredError.

Closes #188 