### PR TITLE
prevent key error on failed gateway connection

### DIFF
--- a/transport_plugins/awsiot/iotile_transport_awsiot/gateway_agent.py
+++ b/transport_plugins/awsiot/iotile_transport_awsiot/gateway_agent.py
@@ -570,9 +570,11 @@ class AWSIOTGatewayAgent(object):
                                        'last_progress': None}
         else:
             message['failure_reason'] = resp['reason']
+            self._connections[uuid] = {}
 
-        self._connections[uuid]['report_monitor'] = self._manager.register_monitor(uuid, ['report'], self._notify_report)
-        self._connections[uuid]['trace_monitor'] = self._manager.register_monitor(uuid, ['trace'], self._notify_trace)
+        connection = self._connections[uuid]
+        connection['report_monitor'] = self._manager.register_monitor(uuid, ['report'], self._notify_report)
+        connection['trace_monitor'] = self._manager.register_monitor(uuid, ['trace'], self._notify_trace)
 
         self._publish_status(slug, message)
 


### PR DESCRIPTION
At the point when a conditional check is done to see whether the connection succeeded, `uuid` is guaranteed to not be inside of `self._connections` (this method would have already returned before this code is reached if otherwise), and `self._connections[uuid]` does not get initialized. This dict entry for `uuid` is now initialized with an empty dict to avoid a key error in the subsequent code.