### PR TITLE
Change settings_directory directory for Mac

### DIFF
--- a/iotilecore/iotile/core/utilities/paths.py
+++ b/iotilecore/iotile/core/utilities/paths.py
@@ -24,9 +24,9 @@ def settings_directory():
         if 'APPDATA' in os.environ:
             basedir = os.environ['APPDATA']
 
-    #If we're not on Windows or Mac OS X, assume we're on some
-    #kind of posix system where the appropriate place would be
-    #~/.config
+    # If we're not on Windows assume we're on some
+    # kind of posix system or Mac, where the appropriate place would be
+    # ~/.config
     if basedir is None:
         basedir = os.path.expanduser('~')
         basedir = os.path.join(basedir, '.config')

--- a/iotilecore/iotile/core/utilities/paths.py
+++ b/iotilecore/iotile/core/utilities/paths.py
@@ -23,8 +23,6 @@ def settings_directory():
     if system == 'Windows':
         if 'APPDATA' in os.environ:
             basedir = os.environ['APPDATA']
-    elif system == 'Darwin':
-        basedir = os.path.expanduser('~/Library/Preferences')
 
     #If we're not on Windows or Mac OS X, assume we're on some
     #kind of posix system where the appropriate place would be

--- a/iotilecore/test/test_utilities/test_settings_dir.py
+++ b/iotilecore/test/test_utilities/test_settings_dir.py
@@ -18,7 +18,7 @@ class TestSettingsDirectory(unittest.TestCase):
         self.settings_dir = settings_directory()
         self.confdir = os.path.join(os.path.expanduser('~'), '.config')
 
-    @unittest.skipIf(platform.system() != 'Linux', 'Linux specific test')
+    @unittest.skipIf(platform.system() == 'Windows', 'Linux/Mac specific test')
     def test_settings_linix(self):
         settings_dir = os.path.abspath(os.path.join(self.confdir, 'IOTile-Core'))
 

--- a/iotilecore/test/test_utilities/test_settings_dir.py
+++ b/iotilecore/test/test_utilities/test_settings_dir.py
@@ -3,7 +3,7 @@
 # info@welldone.org
 # http://welldone.org
 #
-# Modifications to this file from the original created at WellDone International 
+# Modifications to this file from the original created at WellDone International
 # are copyright Arch Systems Inc.
 
 import unittest
@@ -32,12 +32,4 @@ class TestSettingsDirectory(unittest.TestCase):
             base = self.confdir
 
         settings_dir = os.path.abspath(os.path.join(base, 'IOTile-Core'))
-        assert settings_dir == self.settings_dir
-
-    @unittest.skipIf(platform.system() != 'Darwin', 'Mac OS X specific test')
-    def test_settings_darwin(self):
-
-        settings_dir = os.path.abspath(os.path.join(os.path.expanduser('~'), 'Library', 'Preferences',
-                                                            'IOTile-Core'))
-
         assert settings_dir == self.settings_dir


### PR DESCRIPTION
Mac now uses the same path as Linux: `~/.config/`