### PR TITLE
Bugfix bled112 initialization error

### DIFF
--- a/transport_plugins/bled112/RELEASE.md
+++ b/transport_plugins/bled112/RELEASE.md
@@ -2,6 +2,11 @@
 
 All major changes in each released version of the bled112 transport plugin are listed here.
 
+## 1.4.6
+
+- Fix initialization that can hang if a previous process exited uncleanly without
+  stopping scanning.  Now we gratuitously stop scanning on dongle initialization. (#231)
+
 ## 1.4.5
 
 - Added helper method to BLED112Adapter for safely removing connections

--- a/transport_plugins/bled112/iotile_transport_bled112/bled112.py
+++ b/transport_plugins/bled112/iotile_transport_bled112/bled112.py
@@ -621,7 +621,10 @@ class BLED112Adapter(DeviceAdapter):
         try:
             self.stop_scan()
         except HardwareError:
-            pass
+            # If we errored our it is because we were not currently scanning, so make sure
+            # we update our self.scanning flag (which would not be updated by stop_scan since
+            # it raised an exception.)
+            self.scanning = False
 
         self._command_task.sync_command(['_set_mode', 0, 0]) #Disable advertising
 

--- a/transport_plugins/bled112/version.py
+++ b/transport_plugins/bled112/version.py
@@ -1,1 +1,1 @@
-version = "1.4.5"
+version = "1.4.6"


### PR DESCRIPTION
Closes #231

If a previous process died in a specifically dirty fashion, the dongle
could not allow future processes to initialize it because the start
scan command would fail since scanning was already in progress.