### PR TITLE
Fix sphinx-build colorization issue on powershell

### DIFF
--- a/iotilebuild/iotile/build/config/site_scons/autobuild.py
+++ b/iotilebuild/iotile/build/config/site_scons/autobuild.py
@@ -200,9 +200,11 @@ def autobuild_documentation(tile):
         autobuild_doxygen(tile)
         env.Depends(outfile, 'doxygen')
 
-    #There is no /dev/null on Windows
+    # There is no /dev/null on Windows
+    # Also disable color output on Windows since it seems to leave powershell
+    # in a weird state.
     if platform.system() == 'Windows':
-        action = 'sphinx-build -b html %s %s > NUL' % (docdir[1:], outdir)
+        action = 'sphinx-build --no-color -b html %s %s > NUL' % (docdir[1:], outdir)
     else:
         action = 'sphinx-build -b html %s %s > /dev/null' % (docdir[1:], outdir)
 


### PR DESCRIPTION
The windows powershell issue is being caused by misinterpreted ascii color codes being emitted by `sphinx-build` as it builds our firmware documentation.  Until `sphinx` is fixed, the workaround is to just disable color output on windows.  

I verified that this fixes the issue on my windows builds.

Closes #239