### PR TITLE
Feat utils

### DIFF
--- a/iotile_ext_cloud/iotile/__init__.py
+++ b/iotile_ext_cloud/iotile/__init__.py
@@ -1,6 +1,3 @@
 from pkgutil import extend_path
-from cloud.utilities import device_slug_to_id, device_id_to_slug
-from cloud.cloud import IOTileCloud
 
 __path__ = extend_path(__path__, __name__)
-__all__ = ['device_slug_to_id', 'device_id_to_slug', 'IOTileCloud']

--- a/iotile_ext_cloud/iotile/__init__.py
+++ b/iotile_ext_cloud/iotile/__init__.py
@@ -1,2 +1,6 @@
 from pkgutil import extend_path
+from cloud.utilities import device_slug_to_id, device_id_to_slug
+from cloud.cloud import IOTileCloud
+
 __path__ = extend_path(__path__, __name__)
+__all__ = ['device_slug_to_id', 'device_id_to_slug', 'IOTileCloud']

--- a/iotile_ext_cloud/iotile/cloud/__init__.py
+++ b/iotile_ext_cloud/iotile/cloud/__init__.py
@@ -1,0 +1,4 @@
+from .utilities import device_slug_to_id, device_id_to_slug
+from .cloud import IOTileCloud
+
+__all__ = ['device_slug_to_id', 'device_id_to_slug', 'IOTileCloud']

--- a/iotile_ext_cloud/iotile/cloud/utilities.py
+++ b/iotile_ext_cloud/iotile/cloud/utilities.py
@@ -41,7 +41,7 @@ def device_id_to_slug(id):
     """
     if isinstance(id,int):
         id = long(id)
-    elif isinstance(id,long):
+    elif not isinstance(id,long):
         raise ArgumentError("Id is not a number")
     if (id <= 0 or id > pow(16,16)):
         raise ArgumentError("Id not in the correct range")

--- a/iotile_ext_cloud/iotile/cloud/utilities.py
+++ b/iotile_ext_cloud/iotile/cloud/utilities.py
@@ -31,7 +31,7 @@ def device_slug_to_id(slug):
     except ValueError as exc:
         raise ArgumentError("Invalid device slug with non-numeric components", error_mesage=str(exc), slug=slug)
 
-def device_slug_from_id(id):
+def device_id_to_slug(id):
     """ Converts a device id into a correct device slug.
 
     Args:
@@ -44,6 +44,9 @@ def device_slug_from_id(id):
     Raises:
         ArgumentError: if the ID is more than 16 chars or if it contains characters outside 0123456789ABCDEF
     """
+
+    if not isinstance(id, (str, unicode)):
+        raise ArgumentError("Invalid device id that is not a string", id=id)
 
     id = id.replace(' ','') # get rid of the spaces
 

--- a/iotile_ext_cloud/iotile/cloud/utilities.py
+++ b/iotile_ext_cloud/iotile/cloud/utilities.py
@@ -35,29 +35,22 @@ def device_id_to_slug(id):
     """ Converts a device id into a correct device slug.
 
     Args:
-        id (str) : A device id in either of the following formats :
-            XXXX XXXX XXXX XXXX
-            XXXXXXXXXXXXXXXX
-            0xXXXXXXXXXXXXXXXX
+        id (long) : A device id
     Returns:
         str: The device slug in the d--XXXX-XXXX-XXXX-XXXX format
     Raises:
-        ArgumentError: if the ID is more than 16 chars or if it contains characters outside 0123456789ABCDEF
+        ArgumentError: if the ID is not in the [1, 16**16] range, or if it is not an int
     """
+    if (type(id) == int):
+        id = long(id)
+    elif (type(id) != long):
+        raise ArgumentError("Id is not a number")
+    if (id <= 0 or id > pow(16,16)):
+        raise ArgumentError("Id not in the correct range")
 
-    if not isinstance(id, (str, unicode)):
-        raise ArgumentError("Invalid device id that is not a string", id=id)
+    id = hex(id)[2:-1] # get rid of the 0x and the trailing L
 
-    id = id.replace(' ','') # get rid of the spaces
-
-    if (id.startswith('0x')):
-        id = id[2:] # remove 0x identifier
-
-    id = id.zfill(16).lower()   # pad to 16 chars and convert to uppercase
-    if (not set(id) <= set(hexdigits)):
-        raise ArgumentError("ID cannot contain non hexadecimal characters !")
-    if (len(id) > 16):
-        raise ArgumentError("ID cannot be more than 16 chars !")
+    id = id.zfill(16).lower()   # pad to 16 chars and convert to lowercase
 
     chunks = [id[i:i+4] for i in range(0, len(id), 4)] # get 4 strings of 4 chars
 

--- a/iotile_ext_cloud/iotile/cloud/utilities.py
+++ b/iotile_ext_cloud/iotile/cloud/utilities.py
@@ -50,7 +50,7 @@ def device_slug_from_id(id):
     if (id.startswith('0x')):
         id = id[2:] # remove 0x identifier
 
-    id = id.zfill(16).upper()   # pad to 16 chars and convert to uppercase
+    id = id.zfill(16).lower()   # pad to 16 chars and convert to uppercase
     if (not set(id) <= set(hexdigits)):
         raise ArgumentError("ID cannot contain non hexadecimal characters !")
     if (len(id) > 16):

--- a/iotile_ext_cloud/iotile/cloud/utilities.py
+++ b/iotile_ext_cloud/iotile/cloud/utilities.py
@@ -35,7 +35,7 @@ def device_slug_from_id(id):
     """ Converts a device id into a correct device slug.
 
     Args:
-        id (str or int) : A device id in either of the following formats :
+        id (str) : A device id in either of the following formats :
             XXXX XXXX XXXX XXXX
             XXXXXXXXXXXXXXXX
             0xXXXXXXXXXXXXXXXX
@@ -45,7 +45,7 @@ def device_slug_from_id(id):
         ArgumentError: if the ID is more than 16 chars or if it contains characters outside 0123456789ABCDEF
     """
 
-    id = str(id).replace(' ','') # get rid of the spaces
+    id = id.replace(' ','') # get rid of the spaces
 
     if (id.startswith('0x')):
         id = id[2:] # remove 0x identifier

--- a/iotile_ext_cloud/iotile/cloud/utilities.py
+++ b/iotile_ext_cloud/iotile/cloud/utilities.py
@@ -2,6 +2,8 @@
 
 from iotile.core.exceptions import ArgumentError
 
+from string import hexdigits
+
 def device_slug_to_id(slug):
     """Convert a d-- device slug to an integer.
 
@@ -28,3 +30,32 @@ def device_slug_to_id(slug):
         return int(short, 16)
     except ValueError as exc:
         raise ArgumentError("Invalid device slug with non-numeric components", error_mesage=str(exc), slug=slug)
+
+def device_slug_from_id(id):
+    """ Converts a device id into a correct device slug.
+
+    Args:
+        id (str or int) : A device id in either of the following formats :
+            XXXX XXXX XXXX XXXX
+            XXXXXXXXXXXXXXXX
+            0xXXXXXXXXXXXXXXXX
+    Returns:
+        str: The device slug in the d--XXXX-XXXX-XXXX-XXXX format
+    Raises:
+        ArgumentError: if the ID is more than 16 chars or if it contains characters outside 0123456789ABCDEF
+    """
+
+    id = str(id).replace(' ','') # get rid of the spaces
+
+    if (id.startswith('0x')):
+        id = id[2:] # remove 0x identifier
+
+    id = id.zfill(16).upper()   # pad to 16 chars and convert to uppercase
+    if (not set(id) <= set(hexdigits)):
+        raise ArgumentError("ID cannot contain non hexadecimal characters !")
+    if (len(id) > 16):
+        raise ArgumentError("ID cannot be more than 16 chars !")
+
+    chunks = [id[i:i+4] for i in range(0, len(id), 4)] # get 4 strings of 4 chars
+
+    return 'd--' + '-'.join(chunks)

--- a/iotile_ext_cloud/iotile/cloud/utilities.py
+++ b/iotile_ext_cloud/iotile/cloud/utilities.py
@@ -2,8 +2,6 @@
 
 from iotile.core.exceptions import ArgumentError
 
-from string import hexdigits
-
 def device_slug_to_id(slug):
     """Convert a d-- device slug to an integer.
 
@@ -41,9 +39,9 @@ def device_id_to_slug(id):
     Raises:
         ArgumentError: if the ID is not in the [1, 16**16] range, or if it is not an int
     """
-    if (type(id) == int):
+    if isinstance(id,int):
         id = long(id)
-    elif (type(id) != long):
+    elif isinstance(id,long):
         raise ArgumentError("Id is not a number")
     if (id <= 0 or id > pow(16,16)):
         raise ArgumentError("Id not in the correct range")

--- a/iotile_ext_cloud/test/test_utils.py
+++ b/iotile_ext_cloud/test/test_utils.py
@@ -1,6 +1,6 @@
 import pytest
 from iotile.core.exceptions import ArgumentError
-from iotile.cloud.utilities import device_slug_to_id
+from iotile.cloud.utilities import device_slug_to_id, device_id_to_slug
 
 
 def test_device_slug_to_id():
@@ -20,3 +20,16 @@ def test_device_slug_to_id():
 
     with pytest.raises(ArgumentError):
         device_slug_to_id(0x100)
+
+def test_device_id_to_slug():
+    assert device_id_to_slug('0x10') == 'd--0000-0000-0000-0010'
+    assert device_id_to_slug('1234 aBcD 5678 Ef90') == 'd--1234-abcd-5678-ef90'
+
+    with pytest.raises(ArgumentError):
+        device_id_to_slug('12345678901234567')
+
+    with pytest.raises(ArgumentError):
+        device_id_to_slug('non hexa chars')
+
+    with pytest.raises(ArgumentError):
+        device_slug_to_id(1234)

--- a/iotile_ext_cloud/test/test_utils.py
+++ b/iotile_ext_cloud/test/test_utils.py
@@ -24,7 +24,8 @@ def test_device_slug_to_id():
 def test_device_id_to_slug():
     assert device_id_to_slug(0x10) == 'd--0000-0000-0000-0010'
     assert device_id_to_slug(0x1234abcd5678ef90) == 'd--1234-abcd-5678-ef90'
-
+    assert device_id_to_slug(0x1234L) == 'd--0000-0000-0000-1234'
+    
     with pytest.raises(ArgumentError):
         device_id_to_slug('string')
 

--- a/iotile_ext_cloud/test/test_utils.py
+++ b/iotile_ext_cloud/test/test_utils.py
@@ -22,14 +22,14 @@ def test_device_slug_to_id():
         device_slug_to_id(0x100)
 
 def test_device_id_to_slug():
-    assert device_id_to_slug('0x10') == 'd--0000-0000-0000-0010'
-    assert device_id_to_slug('1234 aBcD 5678 Ef90') == 'd--1234-abcd-5678-ef90'
+    assert device_id_to_slug(0x10) == 'd--0000-0000-0000-0010'
+    assert device_id_to_slug(0x1234abcd5678ef90) == 'd--1234-abcd-5678-ef90'
 
     with pytest.raises(ArgumentError):
-        device_id_to_slug('12345678901234567')
+        device_id_to_slug('string')
 
     with pytest.raises(ArgumentError):
-        device_id_to_slug('non hexa chars')
+        device_id_to_slug(pow(16,16) + 1)
 
     with pytest.raises(ArgumentError):
-        device_slug_to_id(1234)
+        device_slug_to_id(-5)


### PR DESCRIPTION
Adds a device_id_to_slug function that should work for the entire lifespan of the slug format as currently defined ( `d--xxxx-xxxx-xxxx-xxxx` ). Unit tested.
Also adds imports exports in `__init__`