### PR TITLE
Feat fleets bugfix

### DIFF
--- a/iotile_ext_cloud/iotile/cloud/cloud.py
+++ b/iotile_ext_cloud/iotile/cloud/cloud.py
@@ -129,11 +129,12 @@ class IOTileCloud(object):
         for network in networks_to_manage :
             out.update(network)
 
-        if not out:
-            raise ExternalError("No device to manage in these fleets !")
         # Remove ourselves from the whitelist that we are supposed to manage
         if slug in out:
            del out[slug]
+
+        if not out:
+            raise ExternalError("No device to manage in these fleets !")
 
         return out
 

--- a/iotile_ext_cloud/test/large_mock_answer.json
+++ b/iotile_ext_cloud/test/large_mock_answer.json
@@ -91,6 +91,19 @@
         }
     ]
   },
+  "whitelist_g4":
+  {
+    "count": 1,
+    "next": null,
+    "previous": null,
+    "results": [
+        {
+            "device": "d--0000-0000-0000-01bd",
+            "always_on": true,
+            "is_access_point": true
+        }
+    ]
+  },
   "expected":{
         "d--0000-0000-0000-00f7": {
             "always_on": true,
@@ -99,5 +112,23 @@
         "d--0000-0000-0000-00f8": {
             "always_on": true,
             "is_access_point": false}
+    },
+    "empty_whitelist_test":
+    {
+        "count": 1,
+        "next": null,
+        "previous": null,
+        "results": [
+            {
+                "id": 4,
+                "name": "Emptytest",
+                "slug": "g--0000-0000-0004",
+                "org": "arch-internal",
+                "description": "TEDLT",
+                "created_on": "2017-09-11T22:55:02.517052Z",
+                "created_by": "david",
+                "is_network": true
+            }
+        ]
     }
 }

--- a/iotile_ext_cloud/test/test_login.py
+++ b/iotile_ext_cloud/test/test_login.py
@@ -150,6 +150,8 @@ def test_get_whitelist():
         p2 = j['whitelist_g2']
         p3 = j['whitelist_g3']
         expected = j['expected']
+        empty_whitelist_test = j['empty_whitelist_test']
+        p4 = j['whitelist_g4']
     payload = {
         'jwt': 'big-token',
         'username': 'user1'
@@ -172,3 +174,8 @@ def test_get_whitelist():
         mocker.get('https://iotile.cloud/api/v1/fleet/g--0000-0000-0002/devices/', json=p2)
         mocker.get('https://iotile.cloud/api/v1/fleet/g--0000-0000-0003/devices/', json=p3)
         assert cloud.get_whitelist(0x1bd) == expected
+        mocker.get('https://iotile.cloud/api/v1/fleet/?device=d--0000-0000-0000-01bd', json=empty_whitelist_test)
+        mocker.get('https://iotile.cloud/api/v1/fleet/g--0000-0000-0004/devices/', json=p4)
+        with pytest.raises(ExternalError):
+            cloud.get_whitelist(0x1bd)
+        


### PR DESCRIPTION
`get_whitelist` should raise an ExternalError when the whitelist is empty, but it does not as the gateway itself is removed after this trial.
This commit fixes that, and adds a new test to make sure this does not happen again