### PR TITLE
Feat trusted certs

### DIFF
--- a/iotile_ext_cloud/iotile/cloud/cloud.py
+++ b/iotile_ext_cloud/iotile/cloud/cloud.py
@@ -46,9 +46,9 @@ class IOTileCloud(object):
         if domain is None:
             domain = conf.get('cloud:server')
 
-        trusted = conf.get('cloud:trusted')
+        verify = conf.get('cloud:verify')
 
-        self.api = Api(domain=domain, trusted=trusted)
+        self.api = Api(domain=domain, verify=verify)
 
         try:
             token = reg.get_config('arch:cloud_token')

--- a/iotile_ext_cloud/iotile/cloud/cloud.py
+++ b/iotile_ext_cloud/iotile/cloud/cloud.py
@@ -46,7 +46,9 @@ class IOTileCloud(object):
         if domain is None:
             domain = conf.get('cloud:server')
 
-        self.api = Api(domain=domain)
+        trusted = conf.get('cloud:trusted')
+
+        self.api = Api(domain=domain, trusted=trusted)
 
         try:
             token = reg.get_config('arch:cloud_token')

--- a/iotile_ext_cloud/iotile/cloud/config.py
+++ b/iotile_ext_cloud/iotile/cloud/config.py
@@ -68,5 +68,6 @@ def get_variables():
 
     conf_vars = []
     conf_vars.append(["server", "string", "The domain name to talk to for iotile.cloud operations (including https:// prefix)", 'https://iotile.cloud'])
+    conf_vars.append(["trusted", "bool", "whether the server certificates are trusted", "true"])
 
     return prefix, conf_vars

--- a/iotile_ext_cloud/iotile/cloud/config.py
+++ b/iotile_ext_cloud/iotile/cloud/config.py
@@ -68,6 +68,6 @@ def get_variables():
 
     conf_vars = []
     conf_vars.append(["server", "string", "The domain name to talk to for iotile.cloud operations (including https:// prefix)", 'https://iotile.cloud'])
-    conf_vars.append(["trusted", "bool", "whether the server certificates are trusted", "true"])
+    conf_vars.append(["verify", "bool", "whether or not to verify the server certificate", "true"])
 
     return prefix, conf_vars


### PR DESCRIPTION
adds the config variable `verify` to conditionally verify certs against trusted CA. this was motivated by the need for creating gateways on the development/staging server.