### PR TITLE
Add support for two conditions in an on block

### DIFF
--- a/iotilesensorgraph/RELEASE.md
+++ b/iotilesensorgraph/RELEASE.md
@@ -2,6 +2,12 @@
 
 All major changes in each released version of IOTileTest are listed here.
 
+## 0.3.1
+
+- Add support for specifying a second condition in an on block.  You can
+  specify up to two named events or stream conditions with a combiner of either
+  'and' or 'or'.
+
 ## 0.3.0
 
 - Add support for generic when blocks that support clock gating on any stream

--- a/iotilesensorgraph/iotile/sg/node.py
+++ b/iotilesensorgraph/iotile/sg/node.py
@@ -205,6 +205,27 @@ class SGNode(object):
 
         self.inputs[index] = (walker, trigger)
 
+    def input_streams(self):
+        """Return a list of DataStream objects for all singular input streams.
+
+        This function only returns individual streams, not the streams that would
+        be selected from a selector like 'all outputs' for example.
+
+        Returns:
+            list(DataStream): A list of all of the individual DataStreams that are inputs
+                of the node.  Input selectors that select multiple streams are not included
+        """
+
+        streams = []
+
+        for walker, _trigger in self.inputs:
+            if walker.selector is None or not walker.selector.singular:
+                continue
+
+            streams.append(walker.selector.as_stream())
+
+        return streams
+
     def find_input(self, stream):
         """Find the input that responds to this stream.
 

--- a/iotilesensorgraph/iotile/sg/parser/language.py
+++ b/iotilesensorgraph/iotile/sg/parser/language.py
@@ -113,11 +113,13 @@ def _create_block_bnf():
     if block_bnf is not None:
         return
 
+    trigger_clause = Group(stream_trigger | Group(stream).setResultsName('stream_always') | Group(ident).setResultsName('identifier'))
+
     every_block_id = Group(Literal(u'every').suppress() - time_interval).setResultsName('every_block')
     when_block_id = Group(Literal(u'when').suppress() + Literal("connected").suppress() - Literal("to").suppress() - slot_id).setResultsName('when_block')
     latch_block_id = Group(Literal(u'when').suppress() - stream_trigger).setResultsName('latch_block')
     config_block_id = Group(Literal(u'config').suppress() - slot_id).setResultsName('config_block')
-    on_block_id = Group(Literal(u'on').suppress() + (stream_trigger | Group(stream).setResultsName('stream_always') | Group(ident).setResultsName('identifier'))).setResultsName('on_block')
+    on_block_id = Group(Literal(u'on').suppress() - trigger_clause.setResultsName('triggerA') - Optional((Literal("and") | Literal("or")) - trigger_clause.setResultsName('triggerB'))).setResultsName('on_block')
 
     block_id = every_block_id | when_block_id | latch_block_id | config_block_id | on_block_id
 

--- a/iotilesensorgraph/iotile/sg/parser/parser_v1.py
+++ b/iotilesensorgraph/iotile/sg/parser/parser_v1.py
@@ -103,6 +103,8 @@ class SensorGraphFileParser(object):
         for statement in self.statements:
             statement.execute(self.sensor_graph, self._scope_stack)
 
+        self.sensor_graph.initialize_remaining_constants()
+
     def parse_statement(self, statement, orig_contents):
         """Parse a statement, possibly called recursively.
 

--- a/iotilesensorgraph/iotile/sg/parser/statements/on_block.py
+++ b/iotilesensorgraph/iotile/sg/parser/statements/on_block.py
@@ -1,12 +1,15 @@
 """On blocks trigger functions when an event occurs on a stream."""
 
 from builtins import str
+from collections import namedtuple
 from future.utils import python_2_unicode_compatible
 from .statement import SensorGraphStatement
 from ..scopes import TriggerScope
 from ...node import InputTrigger, TrueTrigger
 from ... import DataStream
 from iotile.core.exceptions import ArgumentError
+
+TriggerDefinition = namedtuple("TriggerDefinition", ['named_event', 'explicit_stream', 'explicit_trigger'])
 
 
 @python_2_unicode_compatible
@@ -21,15 +24,49 @@ class OnBlock(SensorGraphStatement):
     """
 
     def __init__(self, parsed, children):
-        cond = parsed[0]
+        trigger_a = parsed[0]
 
-        self.named_event = None
-        self.explicit_stream = None
-        self.explcit_trigger = None
+        self.trigger_a = self._parse_trigger(trigger_a)
+
+        if len(parsed) > 1:
+            self.combiner = parsed[1]
+            self.trigger_b = self._parse_trigger(parsed[2])
+        else:
+            self.trigger_b = None
+            self.combiner = None
+
+        super(OnBlock, self).__init__(children)
+
+    def _format_trigger(self, trigger_def):
+        if trigger_def.explicit_stream is not None:
+            return trigger_def.explicit_trigger.format_trigger(trigger_def.explicit_stream)
+
+        return u"{}".format(trigger_def.named_event)
+
+    def _convert_trigger(self, trigger_def, parent):
+        """Convert a TriggerDefinition into a stream, trigger pair."""
+
+        if trigger_def.explicit_stream is None:
+            stream = parent.resolve_identifier(trigger_def.named_event, DataStream)
+            trigger = TrueTrigger()
+        else:
+            stream = trigger_def.explicit_stream
+            trigger = trigger_def.explicit_trigger
+
+        return (stream, trigger)
+
+    def _parse_trigger(self, trigger_clause):
+        """Parse a named event or explicit stream trigger into a TriggerDefinition."""
+
+        cond = trigger_clause[0]
+
+        named_event = None
+        explicit_stream = None
+        explicit_trigger = None
 
         # Identifier parse tree is Group(Identifier)
         if cond.getName() == 'identifier':
-            self.named_event = cond[0]
+            named_event = cond[0]
         elif cond.getName() == 'stream_trigger':
             trigger_type = cond[0]
             stream = cond[1]
@@ -37,23 +74,23 @@ class OnBlock(SensorGraphStatement):
             ref = cond[3]
 
             trigger = InputTrigger(trigger_type, oper, ref)
-            self.explicit_stream = stream
-            self.explicit_trigger = trigger
+            explicit_stream = stream
+            explicit_trigger = trigger
         elif cond.getName() == 'stream_always':
             stream = cond[0]
             trigger = TrueTrigger()
-            self.explicit_stream = stream
-            self.explicit_trigger = trigger
+            explicit_stream = stream
+            explicit_trigger = trigger
         else:
-            raise ArgumentError("OnBlock created from an invalid ParseResults object", parse_results=parsed)
+            raise ArgumentError("OnBlock created from an invalid ParseResults object", parse_results=trigger_clause)
 
-        super(OnBlock, self).__init__(children)
+        return TriggerDefinition(named_event, explicit_stream, explicit_trigger)
 
     def __str__(self):
-        if self.explicit_stream is not None:
-            return u"on " + self.explicit_trigger.format_trigger(self.explicit_stream)
+        if self.combiner is None:
+            return u"on {}".format(self._format_trigger(self.trigger_a))
 
-        return u"on {}".format(self.named_event)
+        return u"on {} {} {}".format(self._format_trigger(self.trigger_a), self.combiner, self._format_trigger(self.trigger_b))
 
     def execute_before(self, sensor_graph, scope_stack):
         """Execute statement before children are executed.
@@ -66,15 +103,24 @@ class OnBlock(SensorGraphStatement):
         """
 
         parent = scope_stack[-1]
+        alloc = parent.allocator
 
-        if self.explicit_stream is None:
-            stream = parent.resolve_identifier(self.named_event, DataStream)
-            trigger = TrueTrigger()
+        stream_a, trigger_a = self._convert_trigger(self.trigger_a, parent)
+
+        if self.trigger_b is None:
+            new_scope = TriggerScope(sensor_graph, scope_stack, (stream_a, trigger_a))
         else:
-            stream = self.explicit_stream
-            trigger = self.explicit_trigger
+            stream_b, trigger_b = self._convert_trigger(self.trigger_b, parent)
+            trigger_stream = alloc.allocate_stream(DataStream.UnbufferedType)
 
-        new_scope = TriggerScope(sensor_graph, scope_stack, (stream, trigger))
+            if self.combiner == u'and':
+                combiner = '&&'
+            else:
+                combiner = '||'
+
+            sensor_graph.add_node(u"({} {} {} {} {}) => {} using copy_latest_a".format(stream_a, trigger_a, combiner, stream_b, trigger_b, trigger_stream))
+            new_scope = TriggerScope(sensor_graph, scope_stack, (trigger_stream, TrueTrigger()))
+
         scope_stack.append(new_scope)
 
     def execute_after(self, sensor_graph, scope_stack):

--- a/iotilesensorgraph/iotile/sg/stream.py
+++ b/iotilesensorgraph/iotile/sg/stream.py
@@ -211,12 +211,30 @@ class DataStreamSelector(object):
         return self.match_type == DataStream.ConstantType
 
     @property
+    def singular(self):
+        """Whether this selector matches only a single stream."""
+
+        return self.match_id is not None
+
+    @property
     def buffered(self):
         return self.match_type == DataStream.BufferedType or self.match_type == DataStream.OutputType
 
     @property
     def output(self):
         return self.match_type == DataStream.OutputType
+
+    def as_stream(self):
+        """Convert this selector to a DataStream.
+
+        This function will only work if this is a singular selector that
+        matches exactly one DataStream.
+        """
+
+        if not self.singular:
+            raise ArgumentError("Attempted to convert a non-singular selector to a data stream, it matches multiple", selector=self)
+
+        return DataStream(self.match_type, self.match_id, self.match_spec == DataStreamSelector.MatchSystemOnly)
 
     @classmethod
     def FromStream(cls, stream):

--- a/iotilesensorgraph/test/sensor_graphs/basic_on_dual.sgf
+++ b/iotilesensorgraph/test/sensor_graphs/basic_on_dual.sgf
@@ -1,0 +1,15 @@
+meta file_format = "sensorgraph-1.0";
+
+meta name = "NFC300";
+meta version = "1.0.0";
+meta cloud_name = "nfc300-1-0-0";
+
+on value(input 1) == 5 and value(constant 1) == 1
+{
+	call 0x5001 on slot 1 => counter 1;
+}
+
+on input 2
+{
+	copy => constant 1;
+}

--- a/iotilesensorgraph/test/test_compiler.py
+++ b/iotilesensorgraph/test/test_compiler.py
@@ -231,6 +231,40 @@ def test_on_block(parser):
     assert counter3.count() == 5
 
 
+def test_on_block_dual(parser):
+    """Make sure on with two conditions works."""
+
+    parser.parse_file(get_path(u'basic_on_dual.sgf'))
+
+    model = DeviceModel()
+    parser.compile(model=model)
+
+    sg = parser.sensor_graph
+    log = sg.sensor_log
+    for x in sg.dump_nodes():
+        print(x)
+
+    sg.load_constants()
+
+    counter1 = log.create_walker(DataStreamSelector.FromString('counter 1'))
+
+    sim = SensorGraphSimulator()
+    sim.step(sg, DataStream.FromString('input 1'), 5)
+
+    assert counter1.count() == 0
+
+    sim.step(sg, DataStream.FromString('input 2'), 1)
+    for _i in range(0, 10):
+        sim.step(sg, DataStream.FromString('input 1'), 5)
+
+    assert counter1.count() == 10
+
+    sim.step(sg, DataStream.FromString('input 2'), 0)
+    for _i in range(0, 10):
+        sim.step(sg, DataStream.FromString('input 1'), 5)
+
+    assert counter1.count() == 10
+
 def test_latch_block(parser):
     """Make sure that we can compile and run latch blocks."""
 

--- a/iotilesensorgraph/test/test_parsing.py
+++ b/iotilesensorgraph/test/test_parsing.py
@@ -54,15 +54,28 @@ def test_language_constructs():
 
     # Test parsing on block with identifier
     parsed = language.block_bnf.parseString(u'on test_identifier {}')
-    assert parsed[0][0][0].getName() == u'identifier'
-    assert parsed[0][0][0][0] == u'test_identifier'
+    assert parsed[0][0][0][0].getName() == u'identifier'
+    assert parsed[0][0][0][0][0] == u'test_identifier'
 
     parsed = language.block_bnf.parseString(u'on value(input 2) >= 5 {}')
-    assert parsed[0][0][0].getName() == u'stream_trigger'
-    assert parsed[0][0][0][0] == u'value'
-    assert parsed[0][0][0][1] == DataStream.FromString('input 2')
-    assert parsed[0][0][0][2] == u'>='
-    assert parsed[0][0][0][3] == 5
+    assert parsed[0][0][0][0].getName() == u'stream_trigger'
+    assert parsed[0][0][0][0][0] == u'value'
+    assert parsed[0][0][0][0][1] == DataStream.FromString('input 2')
+    assert parsed[0][0][0][0][2] == u'>='
+    assert parsed[0][0][0][0][3] == 5
+
+    # Test parsing on block with 2 conditions
+    parsed = language.block_bnf.parseString(u'on test_identifier and hello_id {}')
+    assert parsed[0][0][0][0].getName() == u'identifier'
+    assert parsed[0][0][0][0][0] == u'test_identifier'
+    assert parsed[0][0][2][0].getName() == u'identifier'
+    assert parsed[0][0][2][0][0] == u'hello_id'
+    assert parsed[0][0][1] == u'and'
+
+    parsed = language.block_bnf.parseString(u'on test_identifier or value(constant 1) == 2 {}')
+    assert parsed[0][0][0][0].getName() == u'identifier'
+    assert parsed[0][0][0][0][0] == u'test_identifier'
+    assert parsed[0][0][1] == u'or'
 
     # Test parser streamer statements
     parsed = language.streamer_stmt.parseString(u'manual streamer on output 1;')

--- a/iotilesensorgraph/version.py
+++ b/iotilesensorgraph/version.py
@@ -1,1 +1,1 @@
-version = "0.3.0"
+version = "0.3.1"


### PR DESCRIPTION
This PR adds support for on block syntax like:

```
on value(input 5) and value(constant 1) == 2
{
    # Do something
}
```
Closes #293