### PR TITLE
Add support for parsing binary node descriptors in iotile-sensorgraph

### DIFF
--- a/iotilecore/iotile/core/dev/annotated_registry.py
+++ b/iotilecore/iotile/core/dev/annotated_registry.py
@@ -1,6 +1,6 @@
 # Annotated Registry
 # A wrapper to make the IOTile component registry accessible in the iotile
-# tool.  Since the registry is used internally in the type system it cannot 
+# tool.  Since the registry is used internally in the type system it cannot
 # itself make use of typedargs annotations
 from iotile.core.utilities.typedargs import annotated, param, return_type, context, iprint
 
@@ -29,7 +29,7 @@ class AnnotatedRegistry:
     @param("component", "path", "exists", desc="folder containing component to register")
     def add_component(self, component):
         """
-        Register a component with ComponentRegistry. 
+        Register a component with ComponentRegistry.
 
         Component must be a buildable object with a module_settings.json file that
         describes its name and the domain that it is part of.

--- a/iotilecore/iotile/core/scripts/iotile_script.py
+++ b/iotilecore/iotile/core/scripts/iotile_script.py
@@ -23,9 +23,22 @@ import iotile.core.hw.transport.cmdstream as cmdstream
 from multiprocessing import freeze_support
 import traceback
 
-def main():
+def main(argv=None):
+    """Run the iotile shell tool.
+
+    You can optionally pass the arguments that should be run
+    in the argv parameter.  If nothing is passed, the args
+    are pulled from sys.argv.
+
+    The return value of this function is the return value
+    of the shell command.
+    """
+
+    if argv is None:
+        argv = sys.argv[1:]
+
     type_system.interactive = True
-    line = sys.argv[1:]
+    line = argv
 
     shell = HierarchicalShell('iotile')
 
@@ -41,6 +54,7 @@ def main():
     finished = False
 
     try:
+        if len(line) > 0:
             finished = shell.invoke(line)
     except APIError:
         traceback.print_exc()

--- a/iotilecore/test/test_shell/test_iotile_cmd.py
+++ b/iotilecore/test/test_shell/test_iotile_cmd.py
@@ -1,0 +1,19 @@
+from iotile.core.scripts.iotile_script import main
+
+
+def test_basic_functionality():
+    """Make sure that we can load and quit the shell."""
+
+    assert main(['quit']) == 0
+
+
+def test_unicode_strings():
+    """Make sure that unicode strings are properly parsed."""
+
+    assert main([u'quit']) == 0
+
+
+def test_components():
+    """Make sure that we can call non-builtin functions."""
+
+    assert main(['registry', 'list_components']) == 0

--- a/iotilesensorgraph/iotile/sg/node.py
+++ b/iotilesensorgraph/iotile/sg/node.py
@@ -144,7 +144,6 @@ class TrueTrigger(object):
             str: The formatted string
         """
 
-
         return u"{}".format(stream)
 
 

--- a/iotilesensorgraph/iotile/sg/node_descriptor.py
+++ b/iotilesensorgraph/iotile/sg/node_descriptor.py
@@ -1,8 +1,11 @@
 """A grammer for specifying sensor graph nodes."""
 
+from __future__ import (unicode_literals, absolute_import, print_function)
 from builtins import str
+import struct
 from pyparsing import Word, Regex, nums, hexnums, Literal, Optional, Group, oneOf, QuotedString, ParseException
-from .node import SGNode, InputTrigger
+from typedargs.exceptions import ArgumentError
+from .node import SGNode, InputTrigger, FalseTrigger, TrueTrigger
 from .stream import DataStream, DataStreamSelector
 
 number = Regex('((0x[a-fA-F0-9]+)|[0-9]+)')
@@ -79,3 +82,99 @@ def parse_node_descriptor(desc, model):
 
     processing = data['processor']
     return node, inputs, processing
+
+
+def parse_binary_descriptor(bindata):
+    """Convert a binary node descriptor into a string descriptor.
+
+    Binary node descriptor are 20-byte binary structures that encode all
+    information needed to create a graph node.  They are used to communicate
+    that information to an embedded device in an efficent format.  This
+    function exists to turn such a compressed node description back into
+    an understandable string.
+
+    Args:
+        bindata (bytes): The raw binary structure that contains the node
+            description.
+
+    Returns:
+        str: The corresponding string description of the same sensor_graph node
+    """
+
+    func_names = {0: 'copy_latest_a', 1: 'average_a',
+                  2: 'copy_all_a', 3: 'sum_a',
+                  4: 'copy_count_a', 5: 'trigger_streamer',
+                  6: 'call_rpc', 7: 'subtract_afromb'}
+
+    if len(bindata) != 20:
+        raise ArgumentError("Invalid binary node descriptor with incorrect size", size=len(bindata), expected=20, bindata=bindata)
+
+    a_trig, b_trig, stream_id, a_id, b_id, proc, a_cond, b_cond, trig_combiner = struct.unpack("<LLHHHBBBB2x", bindata)
+
+    node_stream = DataStream.FromEncoded(stream_id)
+
+    if a_id == 0xFFFF:
+        raise ArgumentError("Invalid binary node descriptor with invalid first import", input_selector=a_id)
+
+    a_selector = DataStreamSelector.FromEncoded(a_id)
+    a_trigger = _process_binary_trigger(a_trig, a_cond)
+
+    b_selector = None
+    b_trigger = None
+    if b_id != 0xFFFF:
+        b_selector = DataStreamSelector.FromEncoded(b_id)
+        b_trigger = _process_binary_trigger(b_trig, b_cond)
+
+    if trig_combiner == SGNode.AndTriggerCombiner:
+        comb = '&&'
+    elif trig_combiner == SGNode.OrTriggerCombiner:
+        comb = '||'
+    else:
+        raise ArgumentError("Invalid trigger combiner in binary node descriptor", combiner=trig_combiner)
+
+    if proc not in func_names:
+        raise ArgumentError("Unknown processing function", function_id=proc, known_functions=func_names)
+
+    func_name = func_names[proc]
+
+    # Handle one input nodes
+    if b_selector is None:
+        return '({} {}) => {} using {}'.format(a_selector, a_trigger, node_stream, func_name)
+
+    return '({} {} {} {} {}) => {} using {}'.format(a_selector, a_trigger, comb,
+                                                     b_selector, b_trigger,
+                                                     node_stream, func_name)
+
+
+def _process_binary_trigger(trigger_value, condition):
+    """Create an InputTrigger object."""
+
+    ops = {
+        0: ">",
+        1: "<",
+        2: ">=",
+        3: "<=",
+        4: "==",
+        5: 'always'
+    }
+
+    sources = {
+        0: 'value',
+        1: 'count'
+    }
+
+    encoded_source = condition & 0b1
+    encoded_op = condition >> 1
+
+    op = ops.get(encoded_op, None)
+    source = sources.get(encoded_source, None)
+
+    if op is None:
+        raise ArgumentError("Unknown operation in binary trigger", condition=condition, operation=encoded_op, known_ops=ops)
+    if source is None:
+        raise ArgumentError("Unknown value source in binary trigger", source=source, known_sources=sources)
+
+    if op == 'always':
+        return TrueTrigger()
+
+    return InputTrigger(source, op, trigger_value)

--- a/iotilesensorgraph/iotile/sg/processors.py
+++ b/iotilesensorgraph/iotile/sg/processors.py
@@ -130,4 +130,4 @@ def trigger_streamer(*inputs, **kwargs):
     """
 
     # TODO: This function does nothing currently
-    return [IOTIleReading(0, 0, 0)]
+    return [IOTileReading(0, 0, 0)]

--- a/iotilesensorgraph/test/test_datastream.py
+++ b/iotilesensorgraph/test/test_datastream.py
@@ -189,3 +189,25 @@ def test_encoding():
 
     stream = DataStream.FromString('unbuffered 10')
     assert stream.encode() == 0x100a
+
+
+def test_selector_from_encoded():
+    """Make sure we can create a selector from an encoded value."""
+
+    sel = DataStreamSelector.FromEncoded(0x5FFF)
+    assert str(sel) == 'all system outputs'
+
+    sel = DataStreamSelector.FromEncoded(0xD7FF)
+    assert str(sel) == 'all outputs'
+
+    sel = DataStreamSelector.FromEncoded(0x100a)
+    assert str(sel) == 'unbuffered 10'
+
+    assert str(DataStreamSelector.FromEncoded(DataStreamSelector.FromString('all combined output').encode())) == 'all combined outputs'
+
+
+def test_buffered_pluralization():
+    """Make sure we don't incorrectly pluralize buffered streams."""
+
+    sel = DataStreamSelector.FromString('all buffered')
+    assert str(sel) == 'all buffered'

--- a/iotilesensorgraph/test/test_nodeparsing.py
+++ b/iotilesensorgraph/test/test_nodeparsing.py
@@ -1,7 +1,7 @@
 from builtins import str
 import pytest
 
-from iotile.sg.node_descriptor import parse_node_descriptor
+from iotile.sg.node_descriptor import parse_node_descriptor, parse_binary_descriptor
 from iotile.sg.model import DeviceModel
 from iotile.sg import SensorGraph, SensorLog, DataStream
 
@@ -32,3 +32,15 @@ def test_string_generation():
     sg = SensorGraph(log, model=model)
     sg.add_node('(input 1 when value < 0x10) => buffered node 1 using copy_all_a')
     assert str(sg.nodes[-1]) == u'(input 1 when value < 16) => buffered 1 using copy_all_a'
+
+
+def test_binary_parsing():
+    """Make sure we can parse binary node descriptors."""
+
+    bin_node = b'\x00\x00\x00\x00\x00\x00\x00\x00\x0f\x10\x008\xff\xff\x00\n\n\x00\x00\x00'
+    str_node = parse_binary_descriptor(bin_node)
+    assert str_node == '(system input 0 always) => unbuffered 15 using copy_latest_a'
+
+    bin_node = b'\x00\x00\x00\x00\x01\x00\x00\x00\x01\x00\x010\x020\x02\n\x05\x00\x00\x00'
+    str_node = parse_binary_descriptor(bin_node)
+    assert str_node == '(input 1 always && input 2 when count >= 1) => buffered 1 using copy_all_a'


### PR DESCRIPTION
Major changes:

- iotile-sensorgraph can now parse the binary RPC payloads that generate embedded sensorgraph nodes.
- fix the incorrect pluralization of buffered streams
- add some basic unit test coverage of the `iotile` shell tool.

Closes #311
Closes #306