### PR TITLE
Upgrade to using iotile_cloud v0.8.11

### DIFF
--- a/iotile_ext_cloud/iotile/cloud/utilities.py
+++ b/iotile_ext_cloud/iotile/cloud/utilities.py
@@ -21,7 +21,7 @@ def device_slug_to_id(slug):
         raise ArgumentError("Invalid device slug that is not a string", slug=slug)
 
     try:
-        device_slug = IOTileDeviceSlug(slug)
+        device_slug = IOTileDeviceSlug(slug, allow_64bits=False)
     except ValueError:
         raise ArgumentError("Unable to recognize {} as a device id".format(slug))
 
@@ -41,7 +41,7 @@ def device_id_to_slug(id):
     """
 
     try:
-        device_slug = IOTileDeviceSlug(id)
+        device_slug = IOTileDeviceSlug(id, allow_64bits=False)
     except ValueError:
         raise ArgumentError("Unable to recognize {} as a device id".format(id))
 

--- a/iotile_ext_cloud/setup.py
+++ b/iotile_ext_cloud/setup.py
@@ -9,7 +9,7 @@ setup(
     license="LGPLv3",
     install_requires=[
         "iotile-core>=3.6.2",
-        "iotile_cloud>=0.8.10"
+        "iotile_cloud>=0.8.11"
     ],
 
     entry_points={'iotile.config_function': ['link_cloud = iotile.cloud.config:link_cloud'],


### PR DESCRIPTION
Which requires IOTileDeviceSlug users to pass a `allow_64bits=False` if
they want a check for 48bit limit. If this change is not done, test
will fail next time somebody pip installs v0.8.11. No need to release
this change