### PR TITLE
Add support for custom build steps as part of component builds.

### DIFF
--- a/iotilebuild/RELEASE.md
+++ b/iotilebuild/RELEASE.md
@@ -2,6 +2,10 @@
 
 All major changes in each released version of IOTileBuild are listed here.
 
+## 2.5.9
+
+- Add support for building custom build_steps in python support wheels.
+
 ## 2.5.8
 
 - autobuild_bootstrap_file creates only one command so that temporary hex files

--- a/iotilebuild/iotile/build/config/site_scons/pythondist.py
+++ b/iotilebuild/iotile/build/config/site_scons/pythondist.py
@@ -98,7 +98,7 @@ def generate_setup_py(target, source, env):
         entry_points['iotile.type_package'] = ["{0} = {1}.{0}".format(x, tile.support_distribution) for x in typelibs]
     if len(appentries) > 0:
         entry_points['iotile.app'] = ["{0} = {1}.{0}".format(x, tile.support_distribution) for x in appentries]
-    if len(appentries) > 0:
+    if len(buildentries) > 0:
         entry_points['iotile.recipe_action'] = ["{0} = {1}.{0}".format(x, tile.support_distribution) for x in buildentries]
 
     data['name'] = tile.support_distribution

--- a/iotilebuild/iotile/build/config/site_scons/pythondist.py
+++ b/iotilebuild/iotile/build/config/site_scons/pythondist.py
@@ -88,6 +88,7 @@ def generate_setup_py(target, source, env):
     modentries = [os.path.splitext(os.path.basename(x))[0] for x in tile.proxy_modules()]
     pluginentries = [os.path.splitext(os.path.basename(x))[0] for x in tile.proxy_plugins()]
     appentries = [os.path.splitext(os.path.basename(x))[0] for x in tile.app_modules()]
+    buildentries = [os.path.splitext(os.path.basename(x))[0] for x in tile.build_steps()]
 
     if len(modentries) > 0:
         entry_points['iotile.proxy'] = ["{0} = {1}.{0}".format(x, tile.support_distribution) for x in modentries]
@@ -97,6 +98,8 @@ def generate_setup_py(target, source, env):
         entry_points['iotile.type_package'] = ["{0} = {1}.{0}".format(x, tile.support_distribution) for x in typelibs]
     if len(appentries) > 0:
         entry_points['iotile.app'] = ["{0} = {1}.{0}".format(x, tile.support_distribution) for x in appentries]
+    if len(appentries) > 0:
+        entry_points['iotile.recipe_action'] = ["{0} = {1}.{0}".format(x, tile.support_distribution) for x in buildentries]
 
     data['name'] = tile.support_distribution
     data['package'] = tile.support_distribution

--- a/iotilebuild/version.py
+++ b/iotilebuild/version.py
@@ -1,1 +1,1 @@
-version = "2.5.8"
+version = "2.5.9"

--- a/iotilecore/RELEASE.md
+++ b/iotilecore/RELEASE.md
@@ -10,6 +10,8 @@ All major changes in each released version of IOTileCore are listed here.
 - Add iotile-updateinfo script that will print out everything that a `.trub
   update file does.
 - Update TileBusProxyObject to add support for hardware_version RPC calls.
+- Add support for having components create custom build steps as part of their
+  build products.
 
 ## 3.19.3
 

--- a/iotilecore/iotile/core/dev/iotileobj.py
+++ b/iotilecore/iotile/core/dev/iotileobj.py
@@ -179,7 +179,8 @@ class IOTile(object):
         self.support_wheel = "{0}-{1}-py2-none-any.whl".format(self.support_distribution, self.parsed_version.pep440_string())
         self.has_wheel = False
 
-        if len(self.proxy_modules()) > 0 or len(self.proxy_plugins()) > 0 or len(self.type_packages()) > 0 or len(self.app_modules()) > 0:
+        if len(self.proxy_modules()) > 0 or len(self.proxy_plugins()) > 0 or len(self.type_packages()) > 0 or len(self.app_modules()) > 0 or \
+           len(self.build_steps()) > 0:
             self.has_wheel = True
 
     def include_directories(self):
@@ -262,6 +263,17 @@ class IOTile(object):
         """Return a list of all of the python app module that are provided by this tile."""
 
         libs = [x[0] for x in self.products.iteritems() if x[1] == 'app_module']
+
+        if self.filter_prods:
+            libs = [x for x in libs if x in self.desired_prods]
+
+        libs = [os.path.join(self.folder, x) for x in libs]
+        return libs
+
+    def build_steps(self):
+        """Return a list of all of the python build steps that are provided by this tile."""
+
+        libs = [x[0] for x in self.products.iteritems() if x[1] == 'build_step']
 
         if self.filter_prods:
             libs = [x for x in libs if x in self.desired_prods]


### PR DESCRIPTION
@x24ling Take a look at this then I'll merge and release.

You can now specify a custom `iotile-ship` build step in `module_settings.json` products using:

```typescript
"products":
{
     "python/build_step_whatever.py": "build_step"
}
```

The value of the product key should be `build_step`.  