### PR TITLE
Fix regression in snippet output format and add test coverage

### DIFF
--- a/iotile_ext_cloud/iotile/cloud/cloud.py
+++ b/iotile_ext_cloud/iotile/cloud/cloud.py
@@ -1,6 +1,7 @@
 """Routines for interacting with IOTile cloud from the command line
 """
 
+from builtins import input
 from io import BytesIO
 import getpass
 import datetime
@@ -60,7 +61,7 @@ class IOTileCloud(object):
             # session rather than making them call link_cloud to store a cloud token
             if type_system.interactive:
                 if username is None:
-                    username = raw_input("Please enter your (%s) username: " % domain)
+                    username = input("Please enter your (%s) username: " % domain)
 
                 password = getpass.getpass('Please enter the (%s) password for %s: ' % (domain, username))
                 ok_resp = self.api.login(email=username, password=password)

--- a/iotilecore/iotile/core/scripts/iotile_script.py
+++ b/iotilecore/iotile/core/scripts/iotile_script.py
@@ -47,6 +47,7 @@ def create_parser():
     parser.add_argument('-l', '--logfile', help="The file where we should log all logging messages")
     parser.add_argument('-i', '--include', action="append", default=[], help="Only include the specified loggers")
     parser.add_argument('-e', '--exclude', action="append", default=[], help="Exclude the specified loggers, including all others")
+    parser.add_argument('-q', '--quit', action="store_true", help="Do not spawn a shell after executing any commands")
     parser.add_argument('commands', nargs=argparse.REMAINDER, help="The command(s) to execute")
 
     return parser
@@ -63,8 +64,9 @@ def parse_global_args(argv):
         argv (list): The command line for this command
 
     Returns:
-        list: The remaining arguments if any that should be passed to the
-            HierarchicalShell.
+        list, bool: The remaining arguments if any that should be passed to the
+            HierarchicalShell and a bool indicating if we should immediately quit
+            after executing commands passed on the command line.
     """
 
     parser = create_parser()
@@ -112,7 +114,7 @@ def parse_global_args(argv):
     else:
         root.addHandler(logging.NullHandler())
 
-    return args.commands
+    return args.commands, args.quit
 
 
 def setup_completion(shell):
@@ -158,7 +160,7 @@ def main(argv=None):
     if argv is None:
         argv = sys.argv[1:]
 
-    argv = parse_global_args(argv)
+    argv, quit_immediately = parse_global_args(argv)
 
     type_system.interactive = True
     line = argv
@@ -191,6 +193,10 @@ def main(argv=None):
         traceback.print_exc()
         cmdstream.do_final_close()
         return 1
+
+    # If the user tells us to never spawn a shell, make sure we don't
+    if quit_immediately:
+        finished = True
 
     if finished:
         cmdstream.do_final_close()

--- a/iotilecore/iotile/core/scripts/iotile_script.py
+++ b/iotilecore/iotile/core/scripts/iotile_script.py
@@ -8,7 +8,7 @@
 
 from __future__ import (absolute_import, division,
                         print_function, unicode_literals)
-from builtins import str
+from builtins import str, input
 from future.utils import viewitems
 import sys
 import os
@@ -174,13 +174,11 @@ def main(argv=None):
     for key, val in viewitems(plugins):
         shell.root_add(key, val)
 
-    if len(line) == 0:
-        return 0
-
     finished = False
 
     try:
-        finished = shell.invoke(line)
+        if len(line) > 0:
+            finished = shell.invoke(line)
     except IOTileException as exc:
         print(exc.format())
         #if the command passed on the command line fails, then we should
@@ -204,7 +202,7 @@ def main(argv=None):
     try:
         while True:
             try:
-                linebuf = raw_input("(%s) " % shell.context_name())
+                linebuf = input("(%s) " % shell.context_name())
 
                 # Skip comments automatically
                 if len(linebuf) > 0 and linebuf[0] == '#':

--- a/iotilecore/test/test_shell/test_iotile_cmd.py
+++ b/iotilecore/test/test_shell/test_iotile_cmd.py
@@ -22,6 +22,6 @@ def test_components():
 def test_logging():
     """Make sure we can enable logging."""
 
-    assert main(['-v']) == 0
-    assert main(['-vv', '-i', 'test.logger']) == 0
-    assert main(['-vv', '-e', 'test.logger']) == 0
+    assert main(['-v', '-q']) == 0
+    assert main(['-vv', '-i', 'test.logger', '-q']) == 0
+    assert main(['-vv', '-e', 'test.logger', '-q']) == 0

--- a/iotilesensorgraph/RELEASE.md
+++ b/iotilesensorgraph/RELEASE.md
@@ -2,6 +2,10 @@
 
 All major changes in each released version of iotile-sensorgraph are listed here.
 
+## 0.6.1
+
+- Fix regression in ascii and snippet output formats caused by changes in 0.6.0.
+
 ## 0.6.0
 
 - Add support for directly creating binary device updating scripts from an sgf

--- a/iotilesensorgraph/iotile/sg/output_formats/ascii.py
+++ b/iotilesensorgraph/iotile/sg/output_formats/ascii.py
@@ -43,7 +43,7 @@ def format_ascii(sensor_graph):
         if streamer.with_other is not None:
             other = streamer.with_other
 
-        args = [streamer.walker.selector, streamer.dest, streamer.automatic, streamer.format, streamer.report_type, other]
+        args = [streamer.selector, streamer.dest, streamer.automatic, streamer.format, streamer.report_type, other]
         cmdfile.add('add_streamer', *args)
 
     # Load all the constants

--- a/iotilesensorgraph/iotile/sg/output_formats/ascii.py
+++ b/iotilesensorgraph/iotile/sg/output_formats/ascii.py
@@ -5,6 +5,7 @@ the load_from_file method.  It closely mirrors the snippet format
 with the arguments enclosed in brackets for easier parsing.
 """
 
+from future.utils import viewitems
 from iotile.core.utilities.command_file import CommandFile
 
 
@@ -47,7 +48,7 @@ def format_ascii(sensor_graph):
         cmdfile.add('add_streamer', *args)
 
     # Load all the constants
-    for stream, value in sensor_graph.constant_database.items():
+    for stream, value in sorted(viewitems(sensor_graph.constant_database), key=lambda x: x[0].encode()):
         cmdfile.add("push_reading", stream, value)
 
     # Persist the sensor graph

--- a/iotilesensorgraph/iotile/sg/output_formats/config.py
+++ b/iotilesensorgraph/iotile/sg/output_formats/config.py
@@ -7,6 +7,7 @@ static configuration information that defines how the IOTile device is configure
 
 from iotile.core.utilities.command_file import CommandFile
 from binascii import hexlify
+from future.utils import viewitems
 
 
 def format_config(sensor_graph):
@@ -21,8 +22,8 @@ def format_config(sensor_graph):
 
     cmdfile = CommandFile("Config Variables", "1.0")
 
-    for slot, conf_vars in sensor_graph.config_database.items():
-        for conf_var, conf_def in conf_vars.items():
+    for slot in sorted(sensor_graph.config_database, key=lambda x: x.encode()):
+        for conf_var, conf_def in sorted(viewitems(sensor_graph.config_database[slot])):
             conf_type, conf_val = conf_def
 
             if conf_type == 'binary':

--- a/iotilesensorgraph/iotile/sg/output_formats/snippet.py
+++ b/iotilesensorgraph/iotile/sg/output_formats/snippet.py
@@ -1,6 +1,8 @@
 """A snippet is a series of commands that can be piped into the iotile tool connected to a device."""
 
 from binascii import hexlify
+from future.utils import viewitems
+
 
 def format_snippet(sensor_graph):
     """Format this sensor graph as iotile command snippets.
@@ -33,7 +35,7 @@ def format_snippet(sensor_graph):
         output.append(line)
 
     # Load all the constants
-    for stream, value in sensor_graph.constant_database.items():
+    for stream, value in sorted(viewitems(sensor_graph.constant_database), key=lambda x: x[0].encode()):
         output.append("set_constant '{}' {}".format(stream, value))
 
     # Persist the sensor graph

--- a/iotilesensorgraph/iotile/sg/output_formats/snippet.py
+++ b/iotilesensorgraph/iotile/sg/output_formats/snippet.py
@@ -25,7 +25,7 @@ def format_snippet(sensor_graph):
 
     # Load in the streamers
     for streamer in sensor_graph.streamers:
-        line = "add_streamer '{}' '{}' {} {} {}".format(streamer.walker.selector, streamer.dest, streamer.automatic, streamer.format, streamer.report_type)
+        line = "add_streamer '{}' '{}' {} {} {}".format(streamer.selector, streamer.dest, streamer.automatic, streamer.format, streamer.report_type)
 
         if streamer.with_other is not None:
             line += ' --withother {}'.format(streamer.with_other)

--- a/iotilesensorgraph/test/test_integration/reference_output/usertick_optimized_ascii.txt
+++ b/iotilesensorgraph/test/test_integration/reference_output/usertick_optimized_ascii.txt
@@ -1,0 +1,64 @@
+Sensor Graph
+Format: 1.0
+Type: ASCII
+
+set_online {False}
+clear
+reset
+add_node {(system input 3 always) => counter 1025 using copy_latest_a}
+add_node {(system input 5 always) => counter 1026 using copy_latest_a}
+add_node {(input 1 always) => unbuffered 1024 using copy_latest_a}
+add_node {(system input 1034 when value == 0) => unbuffered 1025 using copy_latest_a}
+add_node {(system input 1034 when value == 1) => unbuffered 1028 using copy_latest_a}
+add_node {(system input 1025 always) => unbuffered 1035 using copy_latest_a}
+add_node {(system input 1026 always) => unbuffered 1036 using copy_latest_a}
+add_node {(unbuffered 1024 always) => output 36 using copy_latest_a}
+add_node {(unbuffered 1025 always) => constant 1 using copy_latest_a}
+add_node {(unbuffered 1025 when count == 1 && constant 1024 always) => unbuffered 1026 using call_rpc}
+add_node {(unbuffered 1025 when count == 1 && constant 1025 always) => unbuffered 1027 using call_rpc}
+add_node {(unbuffered 1028 always) => constant 1 using copy_latest_a}
+add_node {(unbuffered 1028 when count == 1 && constant 1026 always) => unbuffered 1029 using call_rpc}
+add_node {(unbuffered 1028 when count == 1 && constant 1027 always) => unbuffered 1030 using call_rpc}
+add_node {(constant 1035 always && unbuffered 1035 when value == 8) => constant 1034 using copy_latest_a}
+add_node {(constant 1036 always && unbuffered 1036 when value == 8) => constant 1034 using copy_latest_a}
+add_node {(system input 1024 always && constant 1 when value == 1) => unbuffered 1031 using copy_latest_a}
+add_node {(counter 1026 always && constant 1 when value == 1) => counter 1028 using copy_latest_a}
+add_node {(counter 1025 always && constant 1034 when value == 1) => counter 1031 using copy_latest_a}
+add_node {(unbuffered 1031 when count == 1 && constant 1028 always) => unbuffered 1033 using call_rpc}
+add_node {(counter 1028 when count >= 60 && constant 1030 always) => unbuffered 1034 using call_rpc}
+add_node {(counter 1028 when count >= 60 && constant 1031 always) => output 34 using call_rpc}
+add_node {(counter 1028 when count >= 60 && constant 1032 always) => output 33 using call_rpc}
+add_node {(counter 1031 when count >= 1 && constant 1039 always) => unbuffered 18 using call_rpc}
+add_node {(counter 1031 when count >= 1 && constant 1040 always) => unbuffered 1039 using call_rpc}
+add_node {(counter 1031 when count >= 1 && constant 1041 always) => unbuffered 15 using call_rpc}
+add_node {(counter 1031 when count >= 1) => counter 1033 using copy_latest_a}
+add_node {(counter 1028 when count >= 60 && constant 1033 always) => output 35 using call_rpc}
+add_node {(counter 1033 when count == 1 && constant 1042 always) => unbuffered 22 using call_rpc}
+add_node {(counter 1033 when count == 1 && constant 1043 always) => unbuffered 25 using call_rpc}
+add_streamer {all outputs,controller,False,hashedlist,telegram,255}
+add_streamer {all system outputs,controller,False,hashedlist,telegram,0}
+add_streamer {all buffered,controller,False,hashedlist,telegram,0}
+add_streamer {unbuffered 18,controller,True,individual,telegram,255}
+add_streamer {unbuffered 15,controller,True,individual,telegram,255}
+add_streamer {unbuffered 22,controller,True,individual,telegram,255}
+add_streamer {unbuffered 25,controller,True,individual,telegram,255}
+push_reading {constant 1028,819254}
+push_reading {constant 1039,819203}
+push_reading {constant 1033,884737}
+push_reading {constant 1035,1}
+push_reading {constant 1034,0}
+push_reading {constant 1024,532494}
+push_reading {constant 1025,819253}
+push_reading {constant 1026,532494}
+push_reading {constant 1027,819254}
+push_reading {constant 1031,884739}
+push_reading {constant 1032,884738}
+push_reading {constant 1,0}
+push_reading {constant 1040,884736}
+push_reading {constant 1030,884736}
+push_reading {constant 1042,884738}
+push_reading {constant 1043,884737}
+push_reading {constant 1036,0}
+push_reading {constant 1041,884739}
+persist
+set_online {True}

--- a/iotilesensorgraph/test/test_integration/reference_output/usertick_optimized_ascii.txt
+++ b/iotilesensorgraph/test/test_integration/reference_output/usertick_optimized_ascii.txt
@@ -42,23 +42,23 @@ add_streamer {unbuffered 18,controller,True,individual,telegram,255}
 add_streamer {unbuffered 15,controller,True,individual,telegram,255}
 add_streamer {unbuffered 22,controller,True,individual,telegram,255}
 add_streamer {unbuffered 25,controller,True,individual,telegram,255}
-push_reading {constant 1028,819254}
-push_reading {constant 1039,819203}
-push_reading {constant 1033,884737}
-push_reading {constant 1035,1}
-push_reading {constant 1034,0}
+push_reading {constant 1,0}
 push_reading {constant 1024,532494}
 push_reading {constant 1025,819253}
 push_reading {constant 1026,532494}
 push_reading {constant 1027,819254}
+push_reading {constant 1028,819254}
+push_reading {constant 1030,884736}
 push_reading {constant 1031,884739}
 push_reading {constant 1032,884738}
-push_reading {constant 1,0}
+push_reading {constant 1033,884737}
+push_reading {constant 1034,0}
+push_reading {constant 1035,1}
+push_reading {constant 1036,0}
+push_reading {constant 1039,819203}
 push_reading {constant 1040,884736}
-push_reading {constant 1030,884736}
+push_reading {constant 1041,884739}
 push_reading {constant 1042,884738}
 push_reading {constant 1043,884737}
-push_reading {constant 1036,0}
-push_reading {constant 1041,884739}
 persist
 set_online {True}

--- a/iotilesensorgraph/test/test_integration/reference_output/usertick_optimized_config.txt
+++ b/iotilesensorgraph/test/test_integration/reference_output/usertick_optimized_config.txt
@@ -1,0 +1,6 @@
+Config Variables
+Format: 1.0
+Type: ASCII
+
+set_variable {controller,8192,uint32_t,1}
+set_variable {controller,8194,uint32_t,10}

--- a/iotilesensorgraph/test/test_integration/reference_output/usertick_optimized_snippet.txt
+++ b/iotilesensorgraph/test/test_integration/reference_output/usertick_optimized_snippet.txt
@@ -1,0 +1,66 @@
+disable
+clear
+reset
+add_node "(system input 3 always) => counter 1025 using copy_latest_a"
+add_node "(system input 5 always) => counter 1026 using copy_latest_a"
+add_node "(input 1 always) => unbuffered 1024 using copy_latest_a"
+add_node "(system input 1034 when value == 0) => unbuffered 1025 using copy_latest_a"
+add_node "(system input 1034 when value == 1) => unbuffered 1028 using copy_latest_a"
+add_node "(system input 1025 always) => unbuffered 1035 using copy_latest_a"
+add_node "(system input 1026 always) => unbuffered 1036 using copy_latest_a"
+add_node "(unbuffered 1024 always) => output 36 using copy_latest_a"
+add_node "(unbuffered 1025 always) => constant 1 using copy_latest_a"
+add_node "(unbuffered 1025 when count == 1 && constant 1024 always) => unbuffered 1026 using call_rpc"
+add_node "(unbuffered 1025 when count == 1 && constant 1025 always) => unbuffered 1027 using call_rpc"
+add_node "(unbuffered 1028 always) => constant 1 using copy_latest_a"
+add_node "(unbuffered 1028 when count == 1 && constant 1026 always) => unbuffered 1029 using call_rpc"
+add_node "(unbuffered 1028 when count == 1 && constant 1027 always) => unbuffered 1030 using call_rpc"
+add_node "(constant 1035 always && unbuffered 1035 when value == 8) => constant 1034 using copy_latest_a"
+add_node "(constant 1036 always && unbuffered 1036 when value == 8) => constant 1034 using copy_latest_a"
+add_node "(system input 1024 always && constant 1 when value == 1) => unbuffered 1031 using copy_latest_a"
+add_node "(counter 1026 always && constant 1 when value == 1) => counter 1028 using copy_latest_a"
+add_node "(counter 1025 always && constant 1034 when value == 1) => counter 1031 using copy_latest_a"
+add_node "(unbuffered 1031 when count == 1 && constant 1028 always) => unbuffered 1033 using call_rpc"
+add_node "(counter 1028 when count >= 60 && constant 1030 always) => unbuffered 1034 using call_rpc"
+add_node "(counter 1028 when count >= 60 && constant 1031 always) => output 34 using call_rpc"
+add_node "(counter 1028 when count >= 60 && constant 1032 always) => output 33 using call_rpc"
+add_node "(counter 1031 when count >= 1 && constant 1039 always) => unbuffered 18 using call_rpc"
+add_node "(counter 1031 when count >= 1 && constant 1040 always) => unbuffered 1039 using call_rpc"
+add_node "(counter 1031 when count >= 1 && constant 1041 always) => unbuffered 15 using call_rpc"
+add_node "(counter 1031 when count >= 1) => counter 1033 using copy_latest_a"
+add_node "(counter 1028 when count >= 60 && constant 1033 always) => output 35 using call_rpc"
+add_node "(counter 1033 when count == 1 && constant 1042 always) => unbuffered 22 using call_rpc"
+add_node "(counter 1033 when count == 1 && constant 1043 always) => unbuffered 25 using call_rpc"
+add_streamer 'all outputs' 'controller' False hashedlist telegram
+add_streamer 'all system outputs' 'controller' False hashedlist telegram --withother 0
+add_streamer 'all buffered' 'controller' False hashedlist telegram --withother 0
+add_streamer 'unbuffered 18' 'controller' True individual telegram
+add_streamer 'unbuffered 15' 'controller' True individual telegram
+add_streamer 'unbuffered 22' 'controller' True individual telegram
+add_streamer 'unbuffered 25' 'controller' True individual telegram
+set_constant 'constant 1028' 819254
+set_constant 'constant 1039' 819203
+set_constant 'constant 1033' 884737
+set_constant 'constant 1035' 1
+set_constant 'constant 1034' 0
+set_constant 'constant 1024' 532494
+set_constant 'constant 1025' 819253
+set_constant 'constant 1026' 532494
+set_constant 'constant 1027' 819254
+set_constant 'constant 1031' 884739
+set_constant 'constant 1032' 884738
+set_constant 'constant 1' 0
+set_constant 'constant 1040' 884736
+set_constant 'constant 1030' 884736
+set_constant 'constant 1042' 884738
+set_constant 'constant 1043' 884737
+set_constant 'constant 1036' 0
+set_constant 'constant 1041' 884739
+persist
+back
+config_database
+clear_variables
+set_variable 'controller' 8192 uint32_t 1
+set_variable 'controller' 8194 uint32_t 10
+back
+reset

--- a/iotilesensorgraph/test/test_integration/reference_output/usertick_optimized_snippet.txt
+++ b/iotilesensorgraph/test/test_integration/reference_output/usertick_optimized_snippet.txt
@@ -38,24 +38,24 @@ add_streamer 'unbuffered 18' 'controller' True individual telegram
 add_streamer 'unbuffered 15' 'controller' True individual telegram
 add_streamer 'unbuffered 22' 'controller' True individual telegram
 add_streamer 'unbuffered 25' 'controller' True individual telegram
-set_constant 'constant 1028' 819254
-set_constant 'constant 1039' 819203
-set_constant 'constant 1033' 884737
-set_constant 'constant 1035' 1
-set_constant 'constant 1034' 0
+set_constant 'constant 1' 0
 set_constant 'constant 1024' 532494
 set_constant 'constant 1025' 819253
 set_constant 'constant 1026' 532494
 set_constant 'constant 1027' 819254
+set_constant 'constant 1028' 819254
+set_constant 'constant 1030' 884736
 set_constant 'constant 1031' 884739
 set_constant 'constant 1032' 884738
-set_constant 'constant 1' 0
+set_constant 'constant 1033' 884737
+set_constant 'constant 1034' 0
+set_constant 'constant 1035' 1
+set_constant 'constant 1036' 0
+set_constant 'constant 1039' 819203
 set_constant 'constant 1040' 884736
-set_constant 'constant 1030' 884736
+set_constant 'constant 1041' 884739
 set_constant 'constant 1042' 884738
 set_constant 'constant 1043' 884737
-set_constant 'constant 1036' 0
-set_constant 'constant 1041' 884739
 persist
 back
 config_database

--- a/iotilesensorgraph/test/test_integration/test_output_formats.py
+++ b/iotilesensorgraph/test/test_integration/test_output_formats.py
@@ -1,6 +1,6 @@
 import os.path
 import binascii
-from iotile.sg.output_formats import format_script
+from iotile.sg.output_formats import format_script, format_snippet, format_config, format_ascii
 
 def compare_binary_data(data, reference_file):
     """Compare binary data with a reference file."""
@@ -21,3 +21,21 @@ def test_script_output_format(usertick_gate_opt):
     output = format_script(sg)
 
     compare_binary_data(output, 'usertick_optimized_script.trub')
+
+
+def test_snippet_output_format(usertick_gate_opt):
+    """Make sure the snippet output format works."""
+
+    snippet = format_snippet(usertick_gate_opt)
+
+
+def test_config_output_format(usertick_gate_opt):
+    """Make sure the config output format works."""
+
+    config = format_config(usertick_gate_opt)
+
+
+def test_ascii_output_format(usertick_gate_opt):
+    """Make sure the ascii output format works."""
+
+    config = format_ascii(usertick_gate_opt)

--- a/iotilesensorgraph/test/test_integration/test_output_formats.py
+++ b/iotilesensorgraph/test/test_integration/test_output_formats.py
@@ -13,6 +13,17 @@ def compare_binary_data(data, reference_file):
     assert data == bytearray(ref_data)
 
 
+def compare_string_data(data, reference_file):
+    """Compare utf-8 data with a reference file."""
+
+    in_path = os.path.join(os.path.dirname(__file__), 'reference_output', reference_file)
+
+    with open(in_path, "rb") as in_file:
+        ref_data = in_file.read()
+
+    assert data == ref_data.decode('utf-8')
+
+
 def test_script_output_format(usertick_gate_opt):
     """Make sure the output script format works."""
 
@@ -27,15 +38,17 @@ def test_snippet_output_format(usertick_gate_opt):
     """Make sure the snippet output format works."""
 
     snippet = format_snippet(usertick_gate_opt)
-
+    compare_string_data(snippet, 'usertick_optimized_snippet.txt')
 
 def test_config_output_format(usertick_gate_opt):
     """Make sure the config output format works."""
 
     config = format_config(usertick_gate_opt)
+    compare_string_data(config, 'usertick_optimized_config.txt')
 
 
 def test_ascii_output_format(usertick_gate_opt):
     """Make sure the ascii output format works."""
 
-    config = format_ascii(usertick_gate_opt)
+    ascii_txt = format_ascii(usertick_gate_opt)
+    compare_string_data(ascii_txt, 'usertick_optimized_ascii.txt')

--- a/iotilesensorgraph/version.py
+++ b/iotilesensorgraph/version.py
@@ -1,1 +1,1 @@
-version = "0.6.0"
+version = "0.6.1"


### PR DESCRIPTION
This fixes a regression in `0.6.0` introduced by a change to `DataStreamer` to fix some technical debt that prevented generation of binary scripts containing a compiled sensorgraph.  

It also patches some python 3 compatibility issues in `iotile-core` and adds an option to help with unit testing of the `iotile` tool.

Closes #398.