### PR TITLE
Fix unit test generation for qemu.

### DIFF
--- a/iotilebuild/RELEASE.md
+++ b/iotilebuild/RELEASE.md
@@ -2,6 +2,11 @@
 
 All major changes in each released version of IOTileBuild are listed here.
 
+## 2.6.6
+
+- Fix unit test generation to properly copy over referenced C modules and all
+  potentially useful header files.
+
 ## 2.6.5
 
 - Fix regression building firmware with tilebus_definition or

--- a/iotilebuild/iotile/build/config/site_scons/cfileparser.py
+++ b/iotilebuild/iotile/build/config/site_scons/cfileparser.py
@@ -42,6 +42,7 @@ class ParsedCFile(object):
         #only preprocess the file (-E) and get rid of gcc extensions that aren't
         #supported in ISO C.
         args = utilities.build_includes(self.arch.includes())
+
         #args.append('-mcpu=%s' % self.arch.property('chip'))
         args.append('-E')
         args.append('-D__attribute__(x)=')

--- a/iotilebuild/test/test_iotilebuild/comp_with_tests/firmware/test/test_utilities.c
+++ b/iotilebuild/test/test_iotilebuild/comp_with_tests/firmware/test/test_utilities.c
@@ -1,7 +1,13 @@
 //name: test_utilities
 //type: qemu_semihost_unit
+//module: utilities.c
+
+#include "utilities.h"
+#include "unity.h"
 
 void test_utilities()
 {
+	int result = add(1, 2);
 
+	TEST_ASSERT(result == 3)
 }

--- a/iotilebuild/version.py
+++ b/iotilebuild/version.py
@@ -1,1 +1,1 @@
-version = "2.6.5"
+version = "2.6.6"


### PR DESCRIPTION
- Properly copy over headers and referenced C modules
- Improve unit test to actually check and make sure the copying process is done correctly.