### PR TITLE
Add QEMU to Travis, fix semihost.c on recent gcc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ python:
 before_install:
 - pwd
 - cd ~
-- "[ -f arm_gcc/bin/arm-none-eabi-gcc && -f arm_qemu/bin/arm_qemu/bin/qemu-system-gnuarmeclipse ] || ${TRAVIS_BUILD_DIR}/scripts/install_arm_gcc.sh"
+- "[[ -f arm_gcc/bin/arm-none-eabi-gcc && -f arm_qemu/bin/arm_qemu/bin/qemu-system-gnuarmeclipse ]] || ${TRAVIS_BUILD_DIR}/scripts/install_arm_gcc.sh"
 - export PATH=$PATH:~/arm_gcc/bin:~/arm_qemu/bin
 - cd ${TRAVIS_BUILD_DIR}
 - arm-none-eabi-gcc --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ cache:
   pip: true
   directories:
   - ~/arm_gcc
+  - ~/arm_qemu
 sudo: false
 python:
 - '2.7'
@@ -11,9 +12,11 @@ python:
 before_install:
 - pwd
 - cd ~
-- "[ -f arm_gcc/bin/arm-none-eabi-gcc ] || ${TRAVIS_BUILD_DIR}/scripts/install_arm_gcc.sh"
-- export PATH=$PATH:~/arm_gcc/bin
+- "[ -f arm_gcc/bin/arm-none-eabi-gcc && -f arm_qemu/bin/arm_qemu/bin/qemu-system-gnuarmeclipse ] || ${TRAVIS_BUILD_DIR}/scripts/install_arm_gcc.sh"
+- export PATH=$PATH:~/arm_gcc/bin:~/arm_qemu/bin
 - cd ${TRAVIS_BUILD_DIR}
+- arm-none-eabi-gcc --version
+- qemu-system-gnuarmeclipse --version
 
 install:
 - pip install tox-travis

--- a/iotilebuild/RELEASE.md
+++ b/iotilebuild/RELEASE.md
@@ -2,6 +2,12 @@
 
 All major changes in each released version of IOTileBuild are listed here.
 
+## 2.6.7
+
+- Add qemu testing to continuous integration on linux
+- Fix semihost.c template to properly mark svc params as volatile in order to
+  prevent recent gcc versions from optimizing them out.
+
 ## 2.6.6
 
 - Fix unit test generation to properly copy over referenced C modules and all

--- a/iotilebuild/iotile/build/config/templates/qemu_semihost_unit/semihost.c
+++ b/iotilebuild/iotile/build/config/templates/qemu_semihost_unit/semihost.c
@@ -3,7 +3,7 @@
 /*!\brief Trigger a semihosting service call on qemu
  */
 
-void __attribute__((noinline)) svc(unsigned int arg0, void *arg1)
+void __attribute__((noinline)) svc(volatile unsigned int arg0, volatile void *arg1)
 {
 	(void)arg0;
 	(void)arg1;

--- a/iotilebuild/iotile/build/config/templates/qemu_semihost_unit/semihost.h
+++ b/iotilebuild/iotile/build/config/templates/qemu_semihost_unit/semihost.h
@@ -7,7 +7,7 @@
 #define kSYS_EXIT		0x18
 
 //Internal API, calling it externally should not be needed (the below functions wrap it)
-void __attribute__((noinline)) svc(unsigned int arg0, void *arg1);
+void __attribute__((noinline)) svc(volatile unsigned int arg0, volatile void *arg1);
 
 //Semihosting service calls
 void qemu_semihost_putc(int c);

--- a/iotilebuild/version.py
+++ b/iotilebuild/version.py
@@ -1,1 +1,1 @@
-version = "2.6.6"
+version = "2.6.7"

--- a/scripts/install_arm_gcc.sh
+++ b/scripts/install_arm_gcc.sh
@@ -1,6 +1,16 @@
 #!/usr/bin/env bash
 
-curl -L -o gcc-arm-none-eabi.tar.gz https://developer.arm.com/-/media/Files/downloads/gnu-rm/7-2017q4/gcc-arm-none-eabi-7-2017-q4-major-linux.tar.bz2?revision=375265d4-e9b5-41c8-bf23-56cbe927e156?product=GNU%20Arm%20Embedded%20Toolchain,64-bit,,Linux,7-2017-q4-major
+set -e
 
+rm -rf arm_gcc
+rm -rf arm_qemu
+
+curl -L -o gcc-arm-none-eabi.tar.gz https://s3.amazonaws.com/arch-public-static-files-11ca2993de6b03471b7b1f1f704cb58f/gcc-arm-none-eabi-7-2017-q4-major-linux.tar.bz2
 mkdir -p arm_gcc
-tar -jxvf gcc-arm-none-eabi.tar.gz -C arm_gcc --strip-components 1
+tar -jxf gcc-arm-none-eabi.tar.gz -C arm_gcc --strip-components 1
+rm gcc-arm-none-eabi.tar.gz
+
+curl -L -o qemu.tar.gz https://s3.amazonaws.com/arch-public-static-files-11ca2993de6b03471b7b1f1f704cb58f/gnuarmeclipse-qemu-debian64-2.8.0-201612271623-dev.tgz
+mkdir -p arm_qemu
+tar -zxf qemu.tar.gz -C arm_qemu --strip-components 2
+rm qemu.tar.gz


### PR DESCRIPTION
Semihost.c `svc()` did not properly mark its arguments as volatile, causing recent gcc versions to optimize them away resulting in undefined behavior.  The error was masked before `qemu` was not run on continuous integration to see this issue on linux.  
