### PR TITLE
Fix advertising data on python 3 in virtual devices.

### DIFF
--- a/transport_plugins/bled112/RELEASE.md
+++ b/transport_plugins/bled112/RELEASE.md
@@ -2,6 +2,11 @@
 
 All major changes in each released version of the bled112 transport plugin are listed here.
 
+## 1.7.1
+
+- Resolve issue with advertising data and rpc responses for virtual devices on
+  python 3.
+
 ## 1.7.0
 
 - Add support for python 3.

--- a/transport_plugins/bled112/iotile_transport_bled112/virtual_bled112.py
+++ b/transport_plugins/bled112/iotile_transport_bled112/virtual_bled112.py
@@ -182,7 +182,7 @@ class BLED112VirtualInterface(VirtualIOTileInterface):
         header = struct.pack("<BBH", 19, 0xFF, ArchManuID)
         voltage = struct.pack("<H", int(3.8*256))  # FIXME: Hardcoded 3.8V voltage
         reading = struct.pack("<HLLL", 0xFFFF, 0, 0, 0)
-        name = struct.pack("<BB6s", 7, 0x09, "IOTile")
+        name = struct.pack("<BB6s", 7, 0x09, b"IOTile")
         reserved = struct.pack("<BBB", 0, 0, 0)
 
         response = header + voltage + reading + name + reserved
@@ -313,14 +313,14 @@ class BLED112VirtualInterface(VirtualIOTileInterface):
             header (bytearray): The RPC header we should call
         """
 
-        length, _, cmd, feature, address = struct.unpack("<BBBBB", str(header))
+        length, _, cmd, feature, address = struct.unpack("<BBBBB", bytes(header))
         rpc_id = (feature << 8) | cmd
 
         payload = self.rpc_payload[:length]
 
         status = (1 << 6)
         try:
-            response = self.device.call_rpc(address, rpc_id, str(payload))
+            response = self.device.call_rpc(address, rpc_id, bytes(payload))
             if len(response) > 0:
                 status |= (1 << 7)
         except (RPCInvalidIDError, RPCNotFoundError):

--- a/transport_plugins/bled112/version.py
+++ b/transport_plugins/bled112/version.py
@@ -1,1 +1,1 @@
-version = "1.7.0"
+version = "1.7.1"


### PR DESCRIPTION
There were `str` vs `bytes` issues on python 3 that prevented the bled112 virtual interface from functioning.

Closes #470