### PR TITLE
Set max report size before downloading reports

### DIFF
--- a/iotile_ext_cloud/RELEASE.md
+++ b/iotile_ext_cloud/RELEASE.md
@@ -2,6 +2,10 @@
 
 All major changes in each released version of the iotile-ext-cloud plugin are listed here.
 
+## 0.5.2
+
+- Set max report size to max in cloud uploader so that chopping of reports is disabled. 
+
 ## 0.5.1
 
 - Bug fix to prevent coretools from acknowledging stream ids that are larger than 255. 

--- a/iotile_ext_cloud/iotile/cloud/apps/cloud_uploader.py
+++ b/iotile_ext_cloud/iotile/cloud/apps/cloud_uploader.py
@@ -158,6 +158,8 @@ class CloudUploader(IOTileApp):
         else:
             self.logger.info("Not acknowledging readings from cloud per user request")
 
+        # Configure Downloader to not break up the report
+        self._con.config_streaming(max_packet=0xFFFFFFF0)
         self._hw.enable_streaming()
 
         if trigger is not None:

--- a/iotile_ext_cloud/version.py
+++ b/iotile_ext_cloud/version.py
@@ -1,1 +1,1 @@
-version = "0.5.1"
+version = "0.5.2"


### PR DESCRIPTION
Set max_report size to maximum to essentially disable report chopping. 