### PR TITLE
Feat watch 445

### DIFF
--- a/iotilecore/RELEASE.md
+++ b/iotilecore/RELEASE.md
@@ -2,6 +2,10 @@
 
 All major changes in each released version of IOTileCore are listed here.
 
+## HEAD
+
+- Add "watch_reports" command, which enables a user to live view reports from the connected device
+
 ## 3.22.12
 
 - SetDeviceTagRecord allows setting of both os and app tag.

--- a/iotilecore/iotile/core/utilities/linebuffer_ui.py
+++ b/iotilecore/iotile/core/utilities/linebuffer_ui.py
@@ -44,7 +44,7 @@ from iotile.core.exceptions import ExternalError
 LineEntry = namedtuple("LineEntry", ['text', 'id', 'sort_key', 'object'])
 
 
-class LinebufferUI(object):
+class LinebufferUI:
     """A simple console UI that displays a list of items and updates them in place."""
 
     def __init__(self, poll_func, id_func, draw_func, sortkey_func=None, title=None):
@@ -61,7 +61,7 @@ class LinebufferUI(object):
         self.items = {}
 
     def run(self, refresh_interval=0.05):
-
+        """Set up the loop, check that the tool is installed"""
         try:
             from asciimatics.screen import Screen
         except ImportError:

--- a/iotilecore/iotile/core/utilities/linebuffer_ui.py
+++ b/iotilecore/iotile/core/utilities/linebuffer_ui.py
@@ -78,7 +78,7 @@ class LinebufferUI:
             new_items = [new_items]
 
         for item in new_items:
-            id_val, entry = self._parse_and_format(item, screen)
+            id_val, entry = self._parse_and_format(item)
             if id_val is None:
                 continue
 
@@ -95,22 +95,24 @@ class LinebufferUI:
                 items = sorted(viewvalues(self.items), key=lambda x: x.sort_key)
 
                 if self.title_func is not None:
-                    screen.print_at(self.title_func(self.items), 0, 0)
+                    lines = self.title_func(self.items)
+                    for i, line in enumerate(lines):
+                        screen.print_at(line, 0, i)
 
                 for line_no, item in enumerate(items):
-                    screen.print_at(item.text, 0, line_no + 2)
+                    screen.print_at(item.text, 0, line_no + len(lines)+1)
 
                 screen.refresh()
                 time.sleep(refresh_interval)
         except KeyboardInterrupt:
             pass
 
-    def _parse_and_format(self, item, screen):
+    def _parse_and_format(self, item):
         id_val = self.id_func(item)
         if id_val is None:
             return None, None
 
-        text = self.draw_func(item, screen.width)
+        text = self.draw_func(item)
 
         sort_key = id_val
         if self.sortkey_func is not None:

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -44,7 +44,7 @@ class TestProcessor(cmdln.Cmdln):
 
         output_status, output = run_test(component, args)
         if output_status:
-            sys.stdout.write(output)
+            sys.stdout.write(output.decode('utf-8'))
             sys.stdout.flush()
 
         return output_status


### PR DESCRIPTION
Addresses #445 and cleans up some of the code in affected files WRT pylint. 

Testing done:
* Executed function against multiple virtual devices (connect/disconnect, enable_streaming, etc)
* Executed function against real devices and verified that report results were showing up and changing over time
* Ran tests locally in the iotilecore/tests folder (this prompted the do_test changes) against python3 

Other review notes:
* travis-ci tests passing with @ekkizogloy 's fix on master
