### PR TITLE
Improve iotile utility quit behavior

### DIFF
--- a/transport_plugins/bled112/iotile_transport_bled112/async_packet.py
+++ b/transport_plugins/bled112/iotile_transport_bled112/async_packet.py
@@ -1,8 +1,12 @@
 from threading import Thread, Event
 from queue import Queue, Empty
 import logging
+from serial import SerialException
 
 class InternalTimeoutError(Exception):
+    pass
+
+class DeviceNotConfiguredError(Exception):
     pass
 
 class AsyncPacketBuffer:
@@ -21,7 +25,10 @@ class AsyncPacketBuffer:
         self._thread.start()
 
     def write(self, value):
-        self.file.write(value)
+        try:
+            self.file.write(value)
+        except SerialException:
+            raise DeviceNotConfiguredError("Device not configured properly")
 
     def stop(self):
         self._stop.set()

--- a/transport_plugins/bled112/iotile_transport_bled112/bled112_cmd.py
+++ b/transport_plugins/bled112/iotile_transport_bled112/bled112_cmd.py
@@ -13,7 +13,7 @@ from iotile.core.exceptions import HardwareError
 from .tilebus import *
 from .bgapi_structures import process_gatt_service, process_attribute, process_read_handle, process_notification
 from .bgapi_structures import parse_characteristic_declaration
-from .async_packet import InternalTimeoutError
+from .async_packet import InternalTimeoutError, DeviceNotConfiguredError
 
 BGAPIPacket = namedtuple("BGAPIPacket", ["is_event", "command_class", "command", "payload"])
 
@@ -158,6 +158,8 @@ class BLED112CommandProcessor(threading.Thread):
                 return False, {'reason': "Could not stop scan for ble devices"}
         except InternalTimeoutError:
             return False, {'reason': "Timeout waiting for response"}
+        except DeviceNotConfiguredError:
+            return True, {'reason': "Device not connected (did you disconnect the dongle?"}
 
         return True, None
 


### PR DESCRIPTION
As described in #515, quit doesn't finish gracefully if the bled112 dongle gets disconnected during use. Added some error handling to catch that and return the appropriate response for this modality.

Tested in both py2 and py3 by doing the following:

1) Turn on bled112 dongle
2) run ```iotile hw --port=bled112```
3) after utility opens, run ```quit```
4) verify that the python process actually quit

Right now, the user doesn't get feedback that something like this happened, but the root behavior of the program checking that the bled112 connection is "cleared" is still in place.