### PR TITLE
Update sgcompile to correctly write the supported formats to the give…

### DIFF
--- a/iotilesensorgraph/iotile/sg/scripts/iotile_sgcompile.py
+++ b/iotilesensorgraph/iotile/sg/scripts/iotile_sgcompile.py
@@ -35,7 +35,7 @@ def main():
         outfile = open(args.output, "wb")
 
     if args.format == u'ast':
-        outfile.write(parser.dump_tree())
+        outfile.write(parser.dump_tree().encode())
         outfile.close()
         sys.exit(0)
 
@@ -47,7 +47,8 @@ def main():
 
     if args.format == u'nodes':
         for node in parser.sensor_graph.dump_nodes():
-            outfile.write(node + u'\n')
+            outfile.write((node + u'\n').encode())
+
     else:
         if args.format not in known_formats:
             print("Unknown output format: {}".format(args.format))
@@ -55,6 +56,10 @@ def main():
             sys.exit(1)
 
         output = known_formats[args.format](parser.sensor_graph)
-        outfile.write(output)
+
+        if args.format in (u'snippet', u'ascii', u'config'):
+            outfile.write(output.encode())
+        else:
+            outfile.write(output)
 
     outfile.close()


### PR DESCRIPTION
…n output file

In python3, opening a file in 'wb' requires encoding for strings.

Testing done - ran the sgcompile command with all supported formats and verified they correctly ran for both py2 and py3.
```
(py2) Matts-Macbook-Pro:coretools mrunchey$ iotile-sgcompile -f snippet -o TESTFILE ../production_devices/prod_nfc300/scripts/nfc300.sgf 
(py2) Matts-Macbook-Pro:coretools mrunchey$ iotile-sgcompile -f script -o TESTFILE ../production_devices/prod_nfc300/scripts/nfc300.sgf 
(py2) Matts-Macbook-Pro:coretools mrunchey$ iotile-sgcompile -f ast -o TESTFILE ../production_devices/prod_nfc300/scripts/nfc300.sgf  
(py2) Matts-Macbook-Pro:coretools mrunchey$ iotile-sgcompile -f config -o TESTFILE ../production_devices/prod_nfc300/scripts/nfc300.sgf 
(py2) Matts-Macbook-Pro:coretools mrunchey$ iotile-sgcompile -f nodes -o TESTFILE ../production_devices/prod_nfc300/scripts/nfc300.sgf 
(py2) Matts-Macbook-Pro:coretools mrunchey$ iotile-sgcompile -f ascii -o TESTFILE ../production_devices/prod_nfc300/scripts/nfc300.sgf 
```

