### PR TITLE
Add EmulatedDeviceAdapter device adapter.

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -133,7 +133,7 @@ function-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
 function-rgx=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
 
 # Good variable names which should always be accepted, separated by a comma
-good-names=i,j,k,ex,Run,_
+good-names=i,j,k,ex,Run,_,hw
 
 # Include a hint for the correct naming format with invalid-name
 include-naming-hint=no

--- a/iotilecore/RELEASE.md
+++ b/iotilecore/RELEASE.md
@@ -8,6 +8,14 @@ All major changes in each released version of IOTileCore are listed here.
   for the creation of virtual devices that emulate physical devices with support
   for state snapshotting to save/load device state and test scenarios to allow
   easy creation of complex device states for integration testing.
+- Add support for new DeviceAdapter named EmulatedDeviceAdapter.  This is a 
+  subclass of VirtualDeviceAdapter will all of the same features except that it
+  only works with EmulatedDevices and it provides a debug interface that allows
+  you to save and load state as well as load scenarios and track changes on your
+  emulated devices.
+
+  It includes additional methods on DebugManager in order to make these new
+  functions accessible.
 
 ## 3.22.13
 

--- a/iotilecore/iotile/core/hw/debug/debug_manager.py
+++ b/iotilecore/iotile/core/hw/debug/debug_manager.py
@@ -155,7 +155,7 @@ class DebugManager(object):
 
     @docannotate
     def track_changes(self, enabled=True):
-        """Start of stop tracking all internal state changes made to an emulated device.
+        """Start or stop tracking all internal state changes made to an emulated device.
 
         This debug routine is only supported for emulated devices and will
         causes the device to create an internal log of all state changes.

--- a/iotilecore/iotile/core/hw/transport/adapter.py
+++ b/iotilecore/iotile/core/hw/transport/adapter.py
@@ -247,7 +247,7 @@ class DeviceAdapter(object):
         Args:
             interface (string): The interface to open
             conn_id (int): A unique identifier that will refer to this connection
-            connection_string (string): An optional DeviceAdapter specific string that can 
+            connection_string (string): An optional DeviceAdapter specific string that can
                 be used to connect to a device using this DeviceAdapter.
         Returns:
             dict: A dictionary with four elements
@@ -370,8 +370,8 @@ class DeviceAdapter(object):
                 'connection_id': the connection id
                 'adapter_id': this adapter's id
                 'success': a bool indicating whether we received a response to our attempted RPC
-                'failure_reason': a string with the reason for the failure if success == False
                 'retval': A command specific dictionary of return value information
+                'failure_reason': a string with the reason for the failure if success == False
         """
 
         callback(conn_id, self.id, False, None, "Debug commands are not supported by this DeviceAdapter")

--- a/iotilecore/iotile/core/hw/transport/emulatedadapter.py
+++ b/iotilecore/iotile/core/hw/transport/emulatedadapter.py
@@ -1,0 +1,109 @@
+"""Subclass of VirtualDeviceAdapter that supports emulated devices.
+
+This DeviceAdapter provides additional DebugManager functionality such as
+saving and loading internal state snapshots and loading test scenarios
+into the emulated devices.
+"""
+
+import logging
+from ..virtual import EmulatedDevice
+from .virtualadapter import VirtualDeviceAdapter
+
+
+class EmulatedDeviceAdapter(VirtualDeviceAdapter):
+    """DeviceAdapter for connecting to EmulatedDevices.
+
+    This adapter is used the exact same way as VirtualDeviceAdapter, except
+    that it only supported EmulatedDevice subclasses and it implements the
+    debug interface to allow for dumping and loading the state of the
+    emulated device.
+
+    Args:
+        port (string): A port description that should be in the form of
+            device_name1@<optional_config_json1;device_name2@optional_config_json2
+    """
+
+    def __init__(self, port):
+        super(EmulatedDeviceAdapter, self).__init__(port)
+        self._logger = logging.getLogger(__name__)
+
+    @classmethod
+    def _validate_device(cls, device):
+        """Hook for subclases to ensure that only specific kinds of devices are loaded.
+
+        Returns:
+            bool: Whether the virtual device is allowed to load.
+        """
+
+        return isinstance(device, EmulatedDevice)
+
+    def debug_async(self, conn_id, cmd_name, cmd_args, progress_callback, callback):
+        """Asynchronously complete a named debug command.
+
+        The command name and arguments are passed to the underlying device adapter
+        and interpreted there.  If the command is long running, progress_callback
+        may be used to provide status updates.  Callback is called when the command
+        has finished.
+
+        Args:
+            conn_id (int): A unique identifer that will refer to this connection
+            cmd_name (string): the name of the debug command we want to invoke
+            cmd_args (dict): any arguments that we want to send with this command.
+            progress_callback (callable): A function to be called with status on our progress, called as:
+                progress_callback(done_count, total_count)
+            callback (callable): A callback for when we have finished the debug command, called as:
+                callback(connection_id, adapter_id, success, retval, failure_reason)
+                'connection_id': the connection id
+                'adapter_id': this adapter's id
+                'success': a bool indicating whether we received a response to our attempted RPC
+                'failure_reason': a string with the reason for the failure if success == False
+                'retval': A command specific dictionary of return value information
+        """
+
+        device = self.connections.get(conn_id)
+
+        if device is None:
+            callback(conn_id, self.id, False, None, 'Could not find connection to device.')
+            return
+
+        success = True
+        reason = None
+        retval = None
+
+        try:
+            if cmd_name == 'dump_state':
+                retval = device.dump_state()
+            elif cmd_name == 'restore_state':
+                state = cmd_args['snapshot']
+                device.restore_state(state)
+            elif cmd_name == 'load_scenario':
+                scenario = cmd_args['scenario']
+                device.load_metascenario(scenario)
+            elif cmd_name == 'track_changes':
+                if cmd_args['enabled']:
+                    device.state_history.enable()
+                else:
+                    device.state_history.disable()
+            elif cmd_name == 'dump_changes':
+                outpath = cmd_args['path']
+                device.state_history.dump(outpath)
+            else:
+                success = False
+                reason = "Unknown command %s" % cmd_name
+        except Exception as exc:  #pylint:disable=broad-except;We need to turn all exceptions into a callback
+            self._logger.exception("Error processing debug command %s: args=%s", cmd_name, cmd_args)
+            success = False
+            reason = "Exception %s occurred during processing" % str(exc)
+
+        callback(conn_id, self.id, success, retval, reason)
+
+    def _open_debug_interface(self, conn_id, callback, connection_string=None):
+        """Enable debug interface for this IOTile device
+
+        Args:
+            conn_id (int): the unique identifier for the connection
+            callback (callback): Callback to be called when this command finishes
+                callback(conn_id, adapter_id, success, failure_reason)
+        """
+
+        callback(conn_id, self.id, True, None)

--- a/iotilecore/iotile/core/hw/virtual/emulation/emulated_device.py
+++ b/iotilecore/iotile/core/hw/virtual/emulation/emulated_device.py
@@ -55,9 +55,10 @@ class EmulatedDevice(EmulationMixin, VirtualIOTileDevice):
         tile_states = state.get('tile_states', {})
 
         for address, tile_state in viewitems(tile_states):
+            address = int(address)
             tile = self._tiles.get(address)
             if tile is None:
-                raise DataError("Invalid dumped state, tile does not address", address=address)
+                raise DataError("Invalid dumped state, tile does not exist at address %d" % address, address=address)
 
             tile.restore_state(tile_state)
 

--- a/iotilecore/setup.py
+++ b/iotilecore/setup.py
@@ -45,7 +45,8 @@ setup(
             'recorded = iotile.core.hw.transport.recordedstream:RecordedStream'
         ],
         'iotile.device_adapter': [
-            'virtual = iotile.core.hw.transport.virtualadapter:VirtualDeviceAdapter'
+            'virtual = iotile.core.hw.transport.virtualadapter:VirtualDeviceAdapter',
+            'emulated = iotile.core.hw.transport.emulatedadapter:EmulatedDeviceAdapter'
             ],
         'iotile.report_format': [
             'individual = iotile.core.hw.reports:IndividualReadingReport',

--- a/iotilecore/test/test_hw/test_emulatedadapter.py
+++ b/iotilecore/test/test_hw/test_emulatedadapter.py
@@ -1,0 +1,91 @@
+"""Tests for the EmulatedDeviceAdapter class."""
+
+import json
+from iotile.core.hw import HardwareManager
+
+def save_device_args(tmpdir, filename, data, parent=None):
+    """Helper function to dump a config json."""
+
+    if parent is not None:
+        data = {parent: data}
+
+    path = tmpdir.join(filename)
+    path.write(json.dumps(data), mode="w")
+    return str(path)
+
+
+def test_basic_functionality():
+    """Make sure we can connect to a device."""
+
+    with HardwareManager(port='emulated:emulation_test') as hw:
+        results = hw.scan()
+        assert len(results) == 1
+        assert results[0]['uuid'] == 1
+
+        hw.connect(1)
+        _con = hw.controller()
+        hw.disconnect()
+
+
+def test_saving_and_loading_state(tmpdir):
+    """Make sure we can save and load state."""
+
+    saved = str(tmpdir.join("state.json"))
+    with HardwareManager(port='emulated:emulation_test') as hw:
+        hw.connect(1)
+        debug = hw.debug()
+
+        debug.save_snapshot(saved)
+        debug.load_snapshot(saved)
+
+
+def test_loading_scenario(tmpdir):
+    """Make sure we can load a test scenario."""
+
+    scen_file = save_device_args(tmpdir, 'scenario.json', data=[{
+        'name': 'loaded_counters',
+        'args': {
+            'tracked_counter': 15,
+            'manual_counter': 10
+        }
+    }])
+
+    saved = str(tmpdir.join("state.json"))
+
+    with HardwareManager(port='emulated:emulation_test') as hw:
+        hw.connect(1)
+        debug = hw.debug()
+
+        debug.open_scenario(scen_file)
+        debug.save_snapshot(saved)
+
+    with open(saved, "r") as infile:
+        state = json.load(infile)
+
+    assert state['tracked_counter'] == 15
+    assert state['manual_counter'] == 10
+
+
+def test_saving_changes(tmpdir):
+    """Make sure we can track and save changes to a device."""
+
+    scen_file = save_device_args(tmpdir, 'scenario.json', data=[{
+        'name': 'loaded_counters',
+        'args': {
+            'tracked_counter': 15,
+            'manual_counter': 10
+        }
+    }])
+
+    change_file = tmpdir.join('out.csv')
+
+    with HardwareManager(port='emulated:emulation_test') as hw:
+        hw.connect(1)
+        debug = hw.debug()
+
+        debug.track_changes()
+        debug.open_scenario(scen_file)
+        debug.track_changes(enabled=False)
+        debug.save_changes(str(change_file))
+
+    assert change_file.exists()

--- a/iotilesensorgraph/RELEASE.md
+++ b/iotilesensorgraph/RELEASE.md
@@ -2,6 +2,13 @@
 
 All major changes in each released version of iotile-sensorgraph are listed here.
 
+## HEAD
+
+- Move ReferenceDevice and ReferenceController to EmulatedDevice and
+  EmulatedTile subclasses and begin refactor to split out individual controller
+  subsystems to allow for the rest of the reference IOTile controller
+  functionality to be added.
+
 ## 0.7.2
 
 - Add support for broadcast streamers that indicate to the receiving tile that

--- a/iotilesensorgraph/iotile/sg/virtual/feature_mixins/__init__.py
+++ b/iotilesensorgraph/iotile/sg/virtual/feature_mixins/__init__.py
@@ -1,0 +1,10 @@
+"""Mixin classes that implement specific controller subsystems.
+
+Since the IOTile controller has a lot of different subsystems, it's more
+clear to break each one up as a separate mixin class to its easier to
+see how each bit of functionality relates.
+"""
+
+from .remote_bridge import RemoteBridgeMixin
+
+__all__ = ['RemoteBridgeMixin']

--- a/iotilesensorgraph/iotile/sg/virtual/feature_mixins/remote_bridge.py
+++ b/iotilesensorgraph/iotile/sg/virtual/feature_mixins/remote_bridge.py
@@ -1,0 +1,136 @@
+"""Mixin for device updating via signed scripts."""
+
+import base64
+from iotile.core.hw.virtual import tile_rpc
+from iotile.core.hw.update import UpdateScript
+
+
+class BRIDGE_STATUS(object):
+    """Enum for valid remote bridge statuses."""
+    IDLE = 0
+    WAITING = 1
+    RECEIVING = 2
+    RECEIVED = 3
+    VALIDATED = 4
+    EXECUTING = 5
+
+
+class RemoteBridgeState(object):
+    """Serializeable state object for all remote bridge state.
+
+    Note that the script_error property is just a convenience property
+    for looking at internal exceptions when executing scripts.  It does
+    not reflect a real emulated device state and is not dumped or restored
+    when dump() or restore() is called.
+    """
+
+    def __init__(self):
+        self.status = BRIDGE_STATUS.IDLE
+        self.error = 0
+        self.parsed_script = None
+        self.script_error = None
+
+    def dump(self):
+        """Serialize this state to a dictionary."""
+
+        return {
+            'status': self.status,
+            'error': self.error,
+            'parsed_script': self._dump_script()
+        }
+
+    def _dump_script(self):
+        if self.parsed_script is None:
+            return None
+
+        encoded = self.parsed_script.encode()
+        return base64.b64encode(encoded)
+
+    @classmethod
+    def _restore_script(cls, b64encoded):
+        if b64encoded is None:
+            return None
+
+        encoded = base64.b64decode(b64encoded)
+        return UpdateScript.FromBinary(encoded)
+
+    def restore(self, state):
+        """Restore this state from a dictionary."""
+
+        self.status = state.get('status', BRIDGE_STATUS.IDLE)
+        self.error = state.get('error', 0)
+        self.parsed_script = self._restore_script(state.get('parsed_script'))
+
+
+class RemoteBridgeMixin(object):
+    """Reference controller subsystem for device updating.
+
+    This class must be used as a mixin with a ReferenceController base class.
+    """
+
+
+    def __init__(self):
+        self.remote_bridge = RemoteBridgeState()
+
+    @tile_rpc(0x2100, "", "L")
+    def begin_script(self):
+        """Indicate we are going to start loading a script."""
+
+        if self.remote_bridge.status in (BRIDGE_STATUS.RECEIVED, BRIDGE_STATUS.VALIDATED, BRIDGE_STATUS.EXECUTING):
+            return [1]  #FIXME: Return correct error here
+
+        self.remote_bridge.status = BRIDGE_STATUS.WAITING
+        self.remote_bridge.error = 0
+        self.remote_bridge.script_error = None
+        self.remote_bridge.parsed_script = None
+
+        self._device.script = bytearray()
+
+        return [0]
+
+    @tile_rpc(0x2102, "", "L")
+    def end_script(self):
+        """Indicate that we have finished receiving a script."""
+
+        if self.remote_bridge.status not in (BRIDGE_STATUS.RECEIVED, BRIDGE_STATUS.WAITING):
+            return [1] #FIXME: State change
+
+        self.remote_bridge.status = BRIDGE_STATUS.RECEIVED
+        return [0]
+
+    @tile_rpc(0x2103, "", "L")
+    def trigger_script(self):
+        """Actually process a script."""
+
+        if self.remote_bridge.status not in (BRIDGE_STATUS.RECEIVED,):
+            return [1] #FIXME: State change
+
+        # This is asynchronous in real life so just cache the error
+        try:
+            self.remote_bridge.parsed_script = UpdateScript.FromBinary(self._device.script)
+            #FIXME: Actually run the script
+
+            self.remote_bridge.status = BRIDGE_STATUS.IDLE
+        except Exception as exc:
+            self._logger.exception("Error parsing script streamed to device")
+            self.remote_bridge.script_error = exc
+            self.remote_bridge.error = 1 # FIXME: Error code
+
+        return [0]
+
+    @tile_rpc(0x2104, "", "LL")
+    def query_status(self):
+        """Get the status and last error."""
+
+        return [self.remote_bridge.status, self.remote_bridge.error]
+
+    @tile_rpc(0x2105, "", "L")
+    def reset_script(self):
+        """Clear any partially received script."""
+
+        self.remote_bridge.status = BRIDGE_STATUS.IDLE
+        self.remote_bridge.error = 0
+        self.remote_bridge.parsed_script = None
+        self._device.script = bytearray()
+
+        return [0]

--- a/iotilesensorgraph/iotile/sg/virtual/reference_controller.py
+++ b/iotilesensorgraph/iotile/sg/virtual/reference_controller.py
@@ -2,22 +2,12 @@
 
 from __future__ import print_function, absolute_import, unicode_literals
 import logging
-from iotile.core.hw.virtual import VirtualTile, tile_rpc
-from iotile.core.hw.update import UpdateScript
+from iotile.core.hw.virtual import EmulatedTile, tile_rpc
 from iotile.core.exceptions import ArgumentError
-from iotile.sg.update import *
-from iotile.core.hw.update.records import *
-
-class BRIDGE_STATUS(object):
-    IDLE = 0
-    WAITING = 1
-    RECEIVING = 2
-    RECEIVED = 3
-    VALIDATED = 4
-    EXECUTING = 5
+from .feature_mixins import RemoteBridgeMixin
 
 
-class ReferenceController(VirtualTile):
+class ReferenceController(RemoteBridgeMixin, EmulatedTile):
     """A reference iotile controller implementation.
 
     This tile implements the major behavior of an IOTile controller including
@@ -37,10 +27,18 @@ class ReferenceController(VirtualTile):
         device (TileBasedVirtualDevice) : optional, device on which this tile is running
     """
 
+    STATE_NAME = "reference_controller"
+    STATE_VERSION = "0.1.0"
+
     def __init__(self, address, args, device=None):
         name = args.get('name', 'refcn1')
+        self._device = device
+        self._logger = logging.getLogger(__name__)
 
-        super(ReferenceController, self).__init__(address, name, device)
+        EmulatedTile.__init__(self, address, name, device)
+
+        # Initialize all of the controller subsystems
+        RemoteBridgeMixin.__init__(self)
 
         self.sensor_graph = {
             "nodes": [],
@@ -51,104 +49,42 @@ class ReferenceController(VirtualTile):
         self.app_info = (0, "0.0")
         self.os_info = (0, "0.0")
 
-        self.bridge_status = BRIDGE_STATUS.IDLE
-        self.bridge_error = 0
-        self.parsed_script = None
-        self.script_error = None
+    def dump_state(self):
+        """Dump the current state of this emulated object as a dictionary.
 
-        self._device = device
-        self._logger = logging.getLogger(__name__)
+        Returns:
+            dict: The current state of the object that could be passed to load_state.
+        """
 
-    @tile_rpc(0x2100, "", "L")
-    def begin_script(self):
-        """Indicate we are going to start loading a script."""
+        return {
+            'state_name': self.STATE_NAME,
+            'state_version': self.STATE_VERSION,
+            'app_info': self.app_info,
+            'os_info': self.os_info,
 
-        if self.bridge_status in (BRIDGE_STATUS.RECEIVED, BRIDGE_STATUS.VALIDATED, BRIDGE_STATUS.EXECUTING):
-            return [1]  #FIXME: Return correct error here
+            # Dump all of the subsystems
+            'remote_bridge': self.remote_bridge.dump()
+        }
 
-        self.bridge_status = BRIDGE_STATUS.WAITING
-        self.bridge_error = 0
-        self.script_error = None
-        self.parsed_script = None
+    def restore_state(self, state):
+        """Restore the current state of this emulated object.
 
-        self._device.script = bytearray()
+        Args:
+            state (dict): A previously dumped state produced by dump_state.
+        """
 
-        return [0]
+        state_name = state.get('state_name')
+        state_version = state.get('state_version')
 
-    @tile_rpc(0x2102, "", "L")
-    def end_script(self):
-        """Indicate that we have finished receiving a script."""
+        if state_name != self.STATE_NAME or state_version != self.STATE_VERSION:
+            raise ArgumentError("Invalid emulated device state name or version", found=(state_name, state_version),
+                                expected=(self.STATE_NAME, self.STATE_VERSION))
 
-        if self.bridge_status not in (BRIDGE_STATUS.RECEIVED, BRIDGE_STATUS.WAITING):
-            return [1] #FIXME: State change
+        self.app_info = state.get('app_info', (0, "0.0"))
+        self.os_info = state.get('os_info', (0, "0.0"))
 
-        self.bridge_status = BRIDGE_STATUS.RECEIVED
-        return [0]
-
-    def _run_script(self):
-        """Actually run an UpdateScript."""
-
-        for record in self.parsed_script.records:
-            pass
-
-    @tile_rpc(0x2103, "", "L")
-    def trigger_script(self):
-        """Actually process a script."""
-
-        if self.bridge_status not in (BRIDGE_STATUS.RECEIVED,):
-            return [1] #FIXME: State change
-
-        # This is asynchronous in real life so just cache the error
-        try:
-            self.parsed_script = UpdateScript.FromBinary(self._device.script)
-            #self._run_script()
-
-            self.bridge_status = BRIDGE_STATUS.IDLE
-        except Exception as exc:
-            self._logger.exception("Error parsing script streamed to device")
-            self.script_error = exc
-            self.bridge_error = 1 # FIXME: Error code
-
-        return [0]
-
-    @tile_rpc(0x2104, "", "LL")
-    def query_status(self):
-        """Get the status and last error."""
-
-        return [self.bridge_status, self.bridge_error]
-
-    @tile_rpc(0x2105, "", "L")
-    def reset_script(self):
-        """Clear any partially received script."""
-
-        self.bridge_status = BRIDGE_STATUS.IDLE
-        self.bridge_error = 0
-        self.parsed_script = None
-        self._device.script = bytearray()
-
-        return [0]
-
-    @classmethod
-    def _pack_version(cls, tag, version):
-        if tag >= (1 << 20):
-            raise ArgumentError("The tag number is too high.  It must fit in 20-bits", max_tag=1 << 20, tag=tag)
-
-        if "." not in version:
-            raise ArgumentError("You must pass a version number in X.Y format", version=version)
-
-        major, _, minor = version.partition('.')
-        try:
-            major = int(major)
-            minor = int(minor)
-        except ValueError:
-            raise ArgumentError("Unable to convert version string into major and minor version numbers", version=version)
-
-        if major < 0 or minor < 0 or major >= (1 << 6) or minor >= (1 << 6):
-            raise ArgumentError("Invalid version numbers that must be in the range [0, 63]", major=major, minor=minor, version_string=version)
-
-        version_number = (major << 6) | minor
-        combined_tag = (version_number << 20) | tag
-        return combined_tag
+        # Restore all of the subsystems
+        self.remote_bridge.restore(state.get('remote_bridge', {}))
 
     @tile_rpc(1, "", "")
     def reset(self):
@@ -161,4 +97,26 @@ class ReferenceController(VirtualTile):
     def controller_info(self):
         """Get the controller UUID, app tag and os tag."""
 
-        return [self._device.iotile_id, self._pack_version(*self.os_info), self._pack_version(*self.app_info)]
+        return [self._device.iotile_id, _pack_version(*self.os_info), _pack_version(*self.app_info)]
+
+
+def _pack_version(tag, version):
+    if tag >= (1 << 20):
+        raise ArgumentError("The tag number is too high.  It must fit in 20-bits", max_tag=1 << 20, tag=tag)
+
+    if "." not in version:
+        raise ArgumentError("You must pass a version number in X.Y format", version=version)
+
+    major, _, minor = version.partition('.')
+    try:
+        major = int(major)
+        minor = int(minor)
+    except ValueError:
+        raise ArgumentError("Unable to convert version string into major and minor version numbers", version=version)
+
+    if major < 0 or minor < 0 or major >= (1 << 6) or minor >= (1 << 6):
+        raise ArgumentError("Invalid version numbers that must be in the range [0, 63]", major=major, minor=minor, version_string=version)
+
+    version_number = (major << 6) | minor
+    combined_tag = (version_number << 20) | tag
+    return combined_tag

--- a/iotilesensorgraph/iotile/sg/virtual/reference_device.py
+++ b/iotilesensorgraph/iotile/sg/virtual/reference_device.py
@@ -1,11 +1,13 @@
 """A reference device with properties for inspecting what has been set by update scripts."""
 
-from iotile.core.hw.virtual import VirtualIOTileDevice
-from .reference_controller import ReferenceController
+import base64
 from past.builtins import basestring
+from iotile.core.exceptions import ArgumentError
+from iotile.core.hw.virtual import EmulatedDevice
+from .reference_controller import ReferenceController
 
 
-class ReferenceDevice(VirtualIOTileDevice):
+class ReferenceDevice(EmulatedDevice):
     """A reference implementation of an IOTile device.
 
     This is useful for testing the effects of updates and other build
@@ -18,14 +20,55 @@ class ReferenceDevice(VirtualIOTileDevice):
                 defaults to 1 if not specified.
     """
 
+    STATE_NAME = "reference_device"
+    STATE_VERSION = "0.1.0"
+
     def __init__(self, args):
         iotile_id = args.get('iotile_id', 1)
+        controller_name = args.get('controller_name', 'refcn1')
 
         if isinstance(iotile_id, basestring):
             iotile_id = int(iotile_id, 16)
 
-        super(ReferenceDevice, self).__init__(iotile_id, 'refcn1')
+        super(ReferenceDevice, self).__init__(iotile_id, controller_name)
 
-        self.controller = ReferenceController(8, {'name':'refcn1'}, device=self)
+        self.controller = ReferenceController(8, {'name': controller_name}, device=self)
         self.add_tile(8, self.controller)
         self.reset_count = 0
+
+    def dump_state(self):
+        """Dump the current state of this emulated object as a dictionary.
+
+        Returns:
+            dict: The current state of the object that could be passed to load_state.
+        """
+
+        # Dump the state of all of the tiles
+        state = super(ReferenceDevice, self).dump_state()
+
+        state['state_name'] = self.STATE_NAME
+        state['state_version'] = self.STATE_VERSION
+        state['reset_count'] = self.reset_count
+        state['received_script'] = base64.b64encode(self.script)
+
+        return state
+
+    def restore_state(self, state):
+        """Restore the current state of this emulated device.
+
+        Args:
+            state (dict): A previously dumped state produced by dump_state.
+        """
+
+        state_name = state.get('state_name')
+        state_version = state.get('state_version')
+
+        if state_name != self.STATE_NAME or state_version != self.STATE_VERSION:
+            raise ArgumentError("Invalid emulated device state name or version", found=(state_name, state_version),
+                                expected=(self.STATE_NAME, self.STATE_VERSION))
+
+        # Restore the state of all of the tiles
+        super(ReferenceDevice, self).restore_state(state)
+
+        self.reset_count = state.get('reset_count', 0)
+        self.script = base64.b64decode(state.get('received_script'))

--- a/iotilesensorgraph/test/test_reference.py
+++ b/iotilesensorgraph/test/test_reference.py
@@ -1,0 +1,13 @@
+"""Test coverage of the ReferenceDevice and ReferenceController emulated objects."""
+
+from iotile.core.hw import HardwareManager
+
+def test_basic_usage():
+    """Make sure we can import and use the objects."""
+
+    with HardwareManager(port='emulated:reference_1_0') as hw:
+        hw.connect(1)
+        debug = hw.debug()
+
+        state = debug.dump_snapshot()
+        debug.restore_snapshot(state)

--- a/iotileship/test/test_recipe_manager/test_on_reference_device.py
+++ b/iotileship/test/test_recipe_manager/test_on_reference_device.py
@@ -47,8 +47,8 @@ def test_ota_script(recipe_fixture):
 
     recipe, hw, device = recipe_fixture
 
-    assert device.controller.script_error is None
-    assert len(device.controller.parsed_script.records) == 2
+    assert device.controller.remote_bridge.script_error is None
+    assert len(device.controller.remote_bridge.parsed_script.records) == 2
 
 
 @pytest.mark.parametrize("recipe_fixture", [('archived_ota')], indirect=True)
@@ -57,5 +57,5 @@ def test_archived_script(recipe_fixture):
 
     recipe, hw, device = recipe_fixture
 
-    assert device.controller.script_error is None
-    assert len(device.controller.parsed_script.records) == 2
+    assert device.controller.remote_bridge.script_error is None
+    assert len(device.controller.remote_bridge.parsed_script.records) == 2


### PR DESCRIPTION
This PR adds a new DeviceAdapter for use with emulated devices that provides access to their state {load,save,track} and scenario loading functionality from the `debug` interface in the `iotile` tool.

The adapter can be used by passing `--port=emulated:<args>` to `iotile hw` and has all of the same features as using the virtual device adapter except that it only works with emulated devices and it provides additional debug routines:

- save_snapshot, load_snapshot: Save and load the current internal state on a connected emulated device.
- open_scenario: Load a test scenario from a file into the currently connected device.
- track_changes: Start or stop tracking all internal state changes on your emulated device.
- save_changes: Save the log of all internal changes on your connected device to a CSV file.

The purpose of EmulatedDeviceAdapter is to make it easy to use emulated devices from the iotile tool and to access their specific state loading and inspection functionality without needing to serve them using the virtual_device script.

## Example Usage
> There is a single emulated device included in `iotile-test` for the purposes of exercising the emulation subsystem of `iotile-core`.

```
$ iotile hw --port=emulated:emulation_test
(HardwareManager) scan
{
    "connection_string": "1",
    "expiration_time": "2018-11-06 08:23:53.737000",
    "signal_strength": 100,
    "slug": "d--0000-0000-0000-0001",
    "uuid": 1
}
(HardwareManager) connect 1
(HardwareManager) debug
(DebugManager)<TAB>
open_scenario load_snapshot track_changes save_changes  back
flash         save_snapshot dump_ram      quit          help
(DebugManager) track_changes
(DebugManager) save<TAB>
save_snapshot save_changes
(DebugManager) save_snapshot snap.json
(DebugManager) load_snapshot snap.json
(DebugManager) back
(HardwareManager) con<TAB>
connect_direct controller     connect
(HardwareManager) controller
(TestEmulatedDevice)<TAB>
reset               check_hardware      tile_name           help
status              hardware_version    tile_status
config_manager      set_manual_counter  quit
set_tracked_counter tile_version        back
(TestEmulatedDevice) set_manual_counter 15
(TestEmulatedDevice) quit
```