### PR TITLE
Add test coverage of config_database and tile_manager subsystems.

### DIFF
--- a/iotilecore/RELEASE.md
+++ b/iotilecore/RELEASE.md
@@ -7,6 +7,9 @@ All major changes in each released version of IOTileCore are listed here.
 - Add additional call to periodic_callback in AdapterStream to support the
   EmulatedDeviceAdapter better.
 
+- Add support for passing premade DeviceAdapter classes into HardwareManager
+  (Issue #545).  This is very useful for setting up complex test scenarios.
+
 ## 3.22.13
 
 - Add "watch_reports" command, which enables a user to live view reports from the connected device

--- a/iotilecore/iotile/core/hw/virtual/common_types.py
+++ b/iotilecore/iotile/core/hw/virtual/common_types.py
@@ -36,7 +36,7 @@ def _create_argcode(code, arg_bytes):
         return "<" + code
 
     code = code[:-1]
-    fixed_size = struct.calcsize(code)
+    fixed_size = struct.calcsize("<" + code)
     var_size = len(arg_bytes) - fixed_size
 
     if var_size < 0:
@@ -54,7 +54,7 @@ def _create_respcode(code, resp):
     code = code[:-1]
 
     final_length = len(resp[-1])
-    fixed_size = struct.calcsize(code)
+    fixed_size = struct.calcsize("<" + code)
 
     if fixed_size + final_length > 20:
         raise RPCInvalidReturnValueError("Variable length return value is too large for rpc response payload (20 bytes)",

--- a/iotileemulate/RELEASE.md
+++ b/iotileemulate/RELEASE.md
@@ -25,3 +25,5 @@ All major changes in each released version of iotile-emulate are listed here.
 
 - Start adding global constants with good docstring descriptions to be used as
   a basis for automatic help text generation or documentation.
+
+- Adds test coverage of tile_manager and config_database subsystems.

--- a/iotileemulate/iotile/emulate/constants/rpc_tilemanager.py
+++ b/iotileemulate/iotile/emulate/constants/rpc_tilemanager.py
@@ -62,7 +62,7 @@ Returns:
  - uint16_t: The number of currently registered tiles.
 """
 
-DESCRIBE_TILE = RPCDeclaration(0x2a02, "H", "")
+DESCRIBE_TILE = RPCDeclaration(0x2a02, "H", "3B6s6BBL")
 """Describes the tile at the given index in the TileManager cache.
 
 The information returned is the exact same data as what REGISTER_TILE

--- a/iotileemulate/iotile/emulate/transport/emulatedadapter.py
+++ b/iotileemulate/iotile/emulate/transport/emulatedadapter.py
@@ -22,10 +22,12 @@ class EmulatedDeviceAdapter(VirtualDeviceAdapter):
     Args:
         port (string): A port description that should be in the form of
             device_name1@<optional_config_json1;device_name2@optional_config_json2
+        devices (list of EmulatedDevice): Optional list of specif, precreated emulated
+            devices that should be added to the device adapter.
     """
 
-    def __init__(self, port):
-        super(EmulatedDeviceAdapter, self).__init__(port)
+    def __init__(self, port, devices=None):
+        super(EmulatedDeviceAdapter, self).__init__(port, devices)
         self._logger = logging.getLogger(__name__)
 
     @classmethod

--- a/iotileemulate/iotile/emulate/virtual/emulated_device.py
+++ b/iotileemulate/iotile/emulate/virtual/emulated_device.py
@@ -1,6 +1,7 @@
 """Base class for virtual devices designed to emulate physical devices."""
 
 from __future__ import unicode_literals, absolute_import, print_function
+import logging
 from future.utils import viewitems
 from iotile.core.exceptions import DataError
 from iotile.core.hw.virtual import VirtualIOTileDevice
@@ -31,6 +32,7 @@ class EmulatedDevice(EmulationMixin, VirtualIOTileDevice):
         VirtualIOTileDevice.__init__(self, iotile_id, name)
         EmulationMixin.__init__(self, None, self.state_history)
 
+        self._logger = logging.getLogger(__name__)
         self._deferred_rpcs = []
 
     def dump_state(self):
@@ -84,6 +86,7 @@ class EmulatedDevice(EmulationMixin, VirtualIOTileDevice):
         if arg_format is not None:
             arg_payload = pack_rpc_payload(arg_format, args)
 
+        self._logger.debug("Sending rpc to %d:%04X, payload=%s", address, rpc_id, args)
         resp_payload = self.call_rpc(address, rpc_id, arg_payload)
         if resp_format is None:
             return []

--- a/iotileemulate/iotile/emulate/virtual/emulated_tile.py
+++ b/iotileemulate/iotile/emulate/virtual/emulated_tile.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals, absolute_import, print_function
 import struct
 import base64
 import logging
-from future.utils import viewitems
+from future.utils import viewitems, viewvalues
 from iotile.core.exceptions import ArgumentError
 from iotile.core.hw.virtual import VirtualTile
 from iotile.core.hw.virtual import tile_rpc
@@ -156,9 +156,13 @@ class EmulatedTile(EmulationMixin, VirtualTile):
         Subclasses that override this method should always call
         super()._handle_reset() to make sure their base classes properly
         initialize their reset state.
+
+        The only thing we need to properly do is make sure our config
+        variables return to their reset states.
         """
 
-        pass
+        for config in viewvalues(self._config_variables):
+            config.clear()
 
     @tile_rpc(*rpcs.RESET)
     def reset(self):

--- a/iotileemulate/iotile/emulate/virtual/peripheral_tile.py
+++ b/iotileemulate/iotile/emulate/virtual/peripheral_tile.py
@@ -86,6 +86,7 @@ class EmulatedPeripheralTile(EmulatedTile):
         needs to clear app_running.
         """
 
+        super(EmulatedPeripheralTile, self)._handle_reset()
         #TODO: If we have background tasks running, we need to cleanly stop them here and wait until they have stopped
         self._app_started.clear()
         self._device.deferred_rpc(8, rpcs.REGISTER_TILE, *self._registration_tuple(), callback=self._process_registration)

--- a/iotileemulate/test/test_reference.py
+++ b/iotileemulate/test/test_reference.py
@@ -2,9 +2,11 @@
 
 import pytest
 from iotile.core.hw import HardwareManager
+from iotile.core.hw.proxy.external_proxy import find_proxy_plugin
 from iotile.emulate.virtual import EmulatedPeripheralTile
 from iotile.emulate.reference import ReferenceDevice
 from iotile.emulate.constants import rpcs, Error
+from iotile.emulate.transport import EmulatedDeviceAdapter
 
 
 @pytest.fixture(scope="function")
@@ -18,6 +20,25 @@ def reference():
     device.start()
     yield device, peripheral
     device.stop()
+
+
+@pytest.fixture(scope="function")
+def reference_hw():
+    """Get a reference device and connected HardwareManager."""
+
+    device = ReferenceDevice({})
+    peripheral = EmulatedPeripheralTile(11, b'abcdef', device)
+    peripheral.declare_config_variable("test 1", 0x8000, 'uint16_t')
+    peripheral.declare_config_variable('test 2', 0x8001, 'uint32_t[5]')
+
+    device.add_tile(11, peripheral)
+
+    adapter = EmulatedDeviceAdapter(None, devices=[device])
+
+    with HardwareManager(adapter=adapter) as hw:
+        hw.connect(1)
+
+        yield hw, device, peripheral
 
 
 def test_basic_usage():
@@ -116,3 +137,113 @@ def test_snapshot_save_load(reference):
 
     state = device.dump_state()
     device.restore_state(state)
+
+
+def test_config_database(reference_hw):
+    """Test the controller config database RPCs using the canonical proxy plugin."""
+
+    hw, _device, _peripheral = reference_hw
+
+    con = hw.get(8, basic=True)
+    slot = hw.get(11, basic=True)
+    config_db = find_proxy_plugin('iotile_standard_library/lib_controller', 'ConfigDatabasePlugin')(con)
+
+    # Make sure all of the basic RPCs work
+    assert config_db.count_variables() == 0
+    config_db.clear_variables()
+
+    # Make sure we can set and get config variables
+    config_db.set_variable('slot 1', 0x8000, 'uint16_t', 15)
+    config_db.set_variable('slot 1', 0x8001, 'uint32_t[]', "[5, 6, 7]")
+
+    assert config_db.count_variables() == 2
+    var8000 = config_db.get_variable(1)
+    var8001 = config_db.get_variable(2)
+
+    var8000['metadata'] = str(var8000['metadata'])
+    var8001['metadata'] = str(var8001['metadata'])
+
+    assert var8000 == {
+        'metadata': 'Target: slot 1\nData Offset: 0\nData Length: 4\nValid: True',
+        'name': 0x8000,
+        'data': bytearray([15, 0])
+    }
+    assert var8001 == {
+        'metadata': 'Target: slot 1\nData Offset: 4\nData Length: 14\nValid: True',
+        'name': 0x8001,
+        'data': bytearray([5, 0, 0, 0, 6, 0, 0, 0, 7, 0, 0, 0])
+    }
+
+    slot_conf = slot.config_manager()
+
+    # Make sure we stream all variables on a reset
+    slot.reset(wait=0)
+    assert slot_conf.get_variable(0x8000) == bytearray([15, 0])
+    assert slot_conf.get_variable(0x8001) == bytearray([5, 0, 0, 0, 6, 0, 0, 0, 7, 0, 0, 0])
+
+    # Make sure invalidated variables are not streamed and the tile resets them on reset
+    config_db.invalidate_variable(1)
+    assert config_db.count_variables() == 2
+    slot.reset(wait=0)
+    assert slot_conf.get_variable(0x8000) == bytearray()
+    assert slot_conf.get_variable(0x8001) == bytearray([5, 0, 0, 0, 6, 0, 0, 0, 7, 0, 0, 0])
+
+    # Check memory limits before and after compaction
+    usage = config_db.memory_limits()
+    assert usage == {
+        'data_usage': 18,
+        'data_compactable': 4,
+        'data_limit': 4096,
+        'entry_usage': 2,
+        'entry_compactable': 1,
+        'entry_limit': 255
+    }
+
+    # Make sure we remove invalid and keep valid entries upon compaction
+    config_db.compact_database()
+    usage = config_db.memory_limits()
+    assert usage == {
+        'data_usage': 14,
+        'data_compactable': 0,
+        'data_limit': 4096,
+        'entry_usage': 1,
+        'entry_compactable': 0,
+        'entry_limit': 255
+    }
+
+    assert config_db.count_variables() == 1
+    slot.reset(wait=0)
+    assert slot_conf.get_variable(0x8000) == bytearray()
+    assert slot_conf.get_variable(0x8001) == bytearray([5, 0, 0, 0, 6, 0, 0, 0, 7, 0, 0, 0])
+
+
+def test_tile_manager(reference_hw):
+    """Test the controller tile_manager RPCs using the canonical proxy plugin."""
+
+    hw, _device, _peripheral = reference_hw
+
+    con = hw.get(8, basic=True)
+    slot = hw.get(11, basic=True)
+    tileman = find_proxy_plugin('iotile_standard_library/lib_controller', 'TileManagerPlugin')(con)
+
+    assert tileman.count_tiles() == 2
+
+    con = tileman.describe_tile(0)
+    peri = tileman.describe_tile(1)
+    assert str(con) == 'refcn1, version 1.0.0 at slot 0'
+    assert str(peri) == 'abcdef, version 1.0.0 at slot 1'
+
+    # Make sure reseting a tile doesn't add a new entry
+    slot.reset(wait=0)
+
+    assert tileman.count_tiles() == 2
+
+    con = tileman.describe_tile(0)
+    peri = tileman.describe_tile(1)
+    assert str(con) == 'refcn1, version 1.0.0 at slot 0'
+    assert str(peri) == 'abcdef, version 1.0.0 at slot 1'
+
+    con = tileman.describe_selector('controller')
+    peri = tileman.describe_selector('slot 1')
+    assert str(con) == 'refcn1, version 1.0.0 at slot 0'
+    assert str(peri) == 'abcdef, version 1.0.0 at slot 1'

--- a/iotileemulate/test/test_reference.py
+++ b/iotileemulate/test/test_reference.py
@@ -1,6 +1,7 @@
 """Test coverage of the ReferenceDevice and ReferenceController emulated objects."""
 
 import pytest
+import sys
 from iotile.core.hw import HardwareManager
 from iotile.core.hw.proxy.external_proxy import find_proxy_plugin
 from iotile.emulate.virtual import EmulatedPeripheralTile
@@ -220,6 +221,14 @@ def test_config_database(reference_hw):
 def test_tile_manager(reference_hw):
     """Test the controller tile_manager RPCs using the canonical proxy plugin."""
 
+    # Work around inconsistency in output of iotile-support-lib-controller-3 on python 2 and 3
+    if sys.version_info.major < 3:
+        con_str = 'refcn1, version 1.0.0 at slot 0'
+        peri_str = 'abcdef, version 1.0.0 at slot 1'
+    else:
+        con_str = "b'refcn1', version 1.0.0 at slot 0"
+        peri_str = "b'abcdef', version 1.0.0 at slot 1"
+
     hw, _device, _peripheral = reference_hw
 
     con = hw.get(8, basic=True)
@@ -230,8 +239,8 @@ def test_tile_manager(reference_hw):
 
     con = tileman.describe_tile(0)
     peri = tileman.describe_tile(1)
-    assert str(con) == b'refcn1, version 1.0.0 at slot 0'
-    assert str(peri) == b'abcdef, version 1.0.0 at slot 1'
+    assert str(con) == con_str
+    assert str(peri) == peri_str
 
     # Make sure reseting a tile doesn't add a new entry
     slot.reset(wait=0)
@@ -240,10 +249,10 @@ def test_tile_manager(reference_hw):
 
     con = tileman.describe_tile(0)
     peri = tileman.describe_tile(1)
-    assert str(con) == b'refcn1, version 1.0.0 at slot 0'
-    assert str(peri) == b'abcdef, version 1.0.0 at slot 1'
+    assert str(con) == con_str
+    assert str(peri) == peri_str
 
     con = tileman.describe_selector('controller')
     peri = tileman.describe_selector('slot 1')
-    assert str(con) == b'refcn1, version 1.0.0 at slot 0'
-    assert str(peri) == b'abcdef, version 1.0.0 at slot 1'
+    assert str(con) == con_str
+    assert str(peri) == peri_str

--- a/iotileemulate/test/test_reference.py
+++ b/iotileemulate/test/test_reference.py
@@ -230,8 +230,8 @@ def test_tile_manager(reference_hw):
 
     con = tileman.describe_tile(0)
     peri = tileman.describe_tile(1)
-    assert str(con) == 'refcn1, version 1.0.0 at slot 0'
-    assert str(peri) == 'abcdef, version 1.0.0 at slot 1'
+    assert str(con) == b'refcn1, version 1.0.0 at slot 0'
+    assert str(peri) == b'abcdef, version 1.0.0 at slot 1'
 
     # Make sure reseting a tile doesn't add a new entry
     slot.reset(wait=0)
@@ -240,10 +240,10 @@ def test_tile_manager(reference_hw):
 
     con = tileman.describe_tile(0)
     peri = tileman.describe_tile(1)
-    assert str(con) == 'refcn1, version 1.0.0 at slot 0'
-    assert str(peri) == 'abcdef, version 1.0.0 at slot 1'
+    assert str(con) == b'refcn1, version 1.0.0 at slot 0'
+    assert str(peri) == b'abcdef, version 1.0.0 at slot 1'
 
     con = tileman.describe_selector('controller')
     peri = tileman.describe_selector('slot 1')
-    assert str(con) == 'refcn1, version 1.0.0 at slot 0'
-    assert str(peri) == 'abcdef, version 1.0.0 at slot 1'
+    assert str(con) == b'refcn1, version 1.0.0 at slot 0'
+    assert str(peri) == b'abcdef, version 1.0.0 at slot 1'

--- a/iotileemulate/tox.ini
+++ b/iotileemulate/tox.ini
@@ -9,5 +9,6 @@ deps=
     ../iotilecore
     ../iotiletest
     ../iotilesensorgraph
+    iotile-support-lib-controller-3
 commands=
 	py.test {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,7 @@ deps =
     ./transport_plugins/awsiot
     ./transport_plugins/jlink
     ./transport_plugins/websocket
+    iotile-support-lib-controller-3
     linux_only: ./transport_plugins/native_ble
     ./iotile_ext_cloud
     requests-mock


### PR DESCRIPTION
Fixes a few bugs found during testing.  There is now test coverage on all RPCs in the config_database and tile_manager subsystems.

Additionally there is test covergae of config variable streaming to a peripheral tile and proper clearing of config variables on reset with streaming of new data from the controller.

@mattrunchey 
For ease of testing, this adds the ability to pass premade DeviceAdapter classes to HardwareManager.  This obviates in some cases the need to serialize device states and pass them as base64 encoded strings.

Closes #545 