### PR TITLE
Move RPC dispatch to a background workqueue

### DIFF
--- a/iotilecore/RELEASE.md
+++ b/iotilecore/RELEASE.md
@@ -10,6 +10,11 @@ All major changes in each released version of IOTileCore are listed here.
 - Add support for passing premade DeviceAdapter classes into HardwareManager
   (Issue #545).  This is very useful for setting up complex test scenarios.
 
+- Add support for WorkQueueThread to support dispatching work to background work
+  queues and inserting sequence points where all prior work needs to be
+  finished.
+
+
 ## 3.22.13
 
 - Add "watch_reports" command, which enables a user to live view reports from the connected device

--- a/iotilecore/iotile/core/hw/virtual/__init__.py
+++ b/iotilecore/iotile/core/hw/virtual/__init__.py
@@ -2,10 +2,14 @@
 
 from .virtualtile import VirtualTile
 from .virtualdevice import VirtualIOTileDevice
-from .common_types import (tile_rpc, RPCDispatcher, RPCNotFoundError, RPCInvalidArgumentsError,
-                           RPCInvalidReturnValueError, TileNotFoundError)
+
+from .common_types import (tile_rpc, RPCDispatcher, RPCInvalidIDError,
+                           RPCNotFoundError, RPCInvalidArgumentsError,
+                           RPCInvalidReturnValueError, TileNotFoundError,
+                           RPCErrorCode)
 from .virtualinterface import VirtualIOTileInterface
 
 __all__ = ['VirtualTile', 'VirtualIOTileDevice', 'tile_rpc',
-           'RPCDispatcher', 'TileNotFoundError', 'RPCNotFoundError', 'RPCInvalidArgumentsError',
-           'RPCInvalidReturnValueError', 'VirtualIOTileInterface']
+           'RPCDispatcher', 'RPCInvalidIDError', 'TileNotFoundError',
+           'RPCNotFoundError', 'RPCInvalidArgumentsError',
+           'RPCInvalidReturnValueError', 'RPCErrorCode', 'VirtualIOTileInterface']

--- a/iotilecore/iotile/core/hw/virtual/common_types.py
+++ b/iotilecore/iotile/core/hw/virtual/common_types.py
@@ -30,6 +30,12 @@ class TileNotFoundError(IOTileException):
     """Exception thrown when an RPC is sent to a tile that does not exist."""
     pass
 
+class RPCErrorCode(IOTileException):
+    """Exception thrown from an RPC implementation to set the status code."""
+
+    def __init__(self, status_code):
+        super(RPCErrorCode, self).__init__("RPC returned application defined status code %d" % status_code, code=status_code)
+
 
 def _create_argcode(code, arg_bytes):
     if not code.endswith('V'):

--- a/iotilecore/iotile/core/utilities/__init__.py
+++ b/iotilecore/iotile/core/utilities/__init__.py
@@ -1,5 +1,6 @@
 """Commonly used utility functions shared throughout CoreTools."""
 
 from .validating_dispatcher import ValidatingDispatcher
+from .workqueue_thread import WorkQueueThread
 
-__all__ = ['ValidatingDispatcher']
+__all__ = ['ValidatingDispatcher', 'WorkQueueThread']

--- a/iotilecore/iotile/core/utilities/workqueue_thread.py
+++ b/iotilecore/iotile/core/utilities/workqueue_thread.py
@@ -1,0 +1,205 @@
+"""A thread that hands workqueue items to a user function."""
+
+import threading
+import logging
+import sys
+from collections import namedtuple
+from queue import Queue
+from future.utils import raise_
+from iotile.core.exceptions import TimeoutExpiredError
+
+STOP_WORKER_ITEM = object()
+MarkLocationItem = namedtuple('_MARK_LOCATION_ITEM', ['callback'])
+WorkItem = namedtuple("WorkItem", ['arg', 'callback'])
+
+
+class WorkQueueThread(threading.Thread):
+    """A worker thread that handles queued work.
+
+    This class takes a single callable as a parameter in __init__
+    and starts a background thread with a shared queue.  Whenever
+    an item is put in the shared queue, the callable is called with
+    that work item.
+
+    The return value of that callable is passed back to the caller
+    or given via a callback function.
+
+    The key methods of this class are:
+
+    - dispatch(item, callback=None): Synchronously dispatches a work item to
+      the queue and waits for the result.  If callback is not None, this
+      function will return immediately and the result will be passed to the
+      callback when it is ready.
+    - stop(): Synchronously stop the background thread.  This will wait for
+      all currently queued work items to finish and then cleanly shut down the
+      background thread.
+    - flush(): Wait until the work queue is momentarily empty().  This method
+      is useful for ensuring that all work items received up until this method
+      was called have been processed.
+
+    Args:
+        handler (callable): The handler function that will be pasesd all of the
+            work items queued in dispatch() and should return a result that will
+            be the return value of dispatch().  If this function throws an exception,
+            it will be rethrown from dispatch.
+    """
+
+    def __init__(self, handler):
+        super(WorkQueueThread, self).__init__()
+        self.daemon = True
+
+        self._routine = handler
+        self._work_queue = Queue()
+        self._logger = logging.getLogger(__name__)
+
+    def dispatch(self, value, callback=None):
+        """Dispatch an item to the workqueue and optionally wait.
+
+        This is the only way to add work to the background work queue. Unless
+        you also pass a callback object, this method will synchronously wait
+        for the work to finish and return the result. If the work raises an
+        exception, the exception will be reraised in this method.
+
+        If you pass an optional callback(exc_info, return_value), this method
+        will not block and instead your callback will be called when the work
+        finishes.  If an exception was raised during processing, exc_info will
+        be set with the contents of sys.exc_info().  Otherwise, exc_info will
+        be None and whatever the work_queue handler returned will be passed as
+        the return_value parameter to the supplied callback.
+
+        Args:
+            value (object): Arbitrary object that will be passed to the work
+                queue handler.
+
+            callback (callable): Optional callback to receive the result of
+                the work queue when it finishes.  If not passed, this method
+                will be synchronous and return the result from the dispatch()
+                method itself
+
+        Returns:
+            object: The result of the work_queue handler function or None.
+
+            If callback is not None, then this method will return immediately
+            with a None return value.  Otherwise it will block until the work
+            item is finished (including any work items ahead in the queue) and
+            return whatever the work item handler returned.
+        """
+
+        done = None
+
+        if callback is None:
+            done = threading.Event()
+            shared_data = [None, None]
+
+            def _callback(exc_info, return_value):
+                shared_data[0] = exc_info
+                shared_data[1] = return_value
+
+                done.set()
+
+            callback = _callback
+
+        workitem = WorkItem(value, callback)
+        self._work_queue.put(workitem)
+        if done is None:
+            return None
+
+        done.wait()
+        exc_info, return_value = shared_data
+        if exc_info is not None:
+            raise_(*exc_info)  #pylint:disable=not-an-iterable;We know it is iterable when done is not None
+
+        return return_value
+
+    def flush(self):
+        """Synchronously wait until this work item is processed.
+
+        This has the effect of waiting until all work items queued before this
+        method has been called have finished.
+        """
+
+        done = threading.Event()
+
+        def _callback():
+            done.set()
+
+        self._work_queue.put(MarkLocationItem(_callback))
+        done.wait()
+
+    def run(self):
+        """The target routine called to start thread activity."""
+
+        while True:
+            try:
+                item = self._work_queue.get()
+
+                # Handle special actions that are not RPCs
+                if item is STOP_WORKER_ITEM:
+                    return
+                elif isinstance(item, MarkLocationItem):
+                    item.callback()
+                    continue
+                elif not isinstance(item, WorkItem):
+                    self._logger.error("Invalid item passed to WorkQueueThread: %s, ignoring", item)
+                    continue
+
+                try:
+                    exc_info = None
+                    retval = None
+
+                    retval = self._routine(item.arg)
+                except:  #pylint:disable=bare-except;We need to capture the exception and feed it back to the caller
+                    exc_info = sys.exc_info()
+
+                if item.callback is not None:
+                    item.callback(exc_info, retval)
+            except:  #pylint:disable=bare-except;We cannot let this background thread die until we are told to stop()
+                self._logger.exception("Error inside background workqueue thread")
+
+    def stop(self, timeout=None, force=False):
+        """Stop the worker thread and synchronously wait for it to finish.
+
+        Args:
+            timeout (float): The maximum time to wait for the thread to stop
+                before raising a TimeoutExpiredError.  If force is True, TimeoutExpiredError
+                is not raised and the thread is just marked as a daemon thread
+                so that it does not block cleanly exiting the process.
+            force (bool): If true and the thread does not exit in timeout seconds
+                no error is raised since the thread is marked as daemon and will
+                be killed when the process exits.
+        """
+
+        self.signal_stop()
+        self.wait_stopped(timeout, force)
+
+    def signal_stop(self):
+        """Signal that the worker thread should stop but don't wait.
+
+        This function is useful for stopping multiple threads in parallel when
+        combined with wait_stopped().
+        """
+
+        self._work_queue.put(STOP_WORKER_ITEM)
+
+    def wait_stopped(self, timeout=None, force=False):
+        """Wait for the thread to stop.
+
+        You must have previously called signal_stop or this function will
+        hang.
+
+        Args:
+
+            timeout (float): The maximum time to wait for the thread to stop
+                before raising a TimeoutExpiredError.  If force is True,
+                TimeoutExpiredError is not raised and the thread is just
+                marked as a daemon thread so that it does not block cleanly
+                exiting the process.
+            force (bool): If true and the thread does not exit in timeout seconds
+                no error is raised since the thread is marked as daemon and will
+                be killed when the process exits.
+        """
+
+        self.join(timeout)
+
+        if self.is_alive() and force is False:
+            raise TimeoutExpiredError("Error waiting for background thread to exit", timeout=timeout)

--- a/iotilecore/test/test_utilities/test_workqueue.py
+++ b/iotilecore/test/test_utilities/test_workqueue.py
@@ -1,0 +1,37 @@
+"""Tests of WorkQueueThread."""
+
+import pytest
+from iotile.core.utilities import WorkQueueThread
+
+def _handler(arg):
+    if arg == "raise":
+        raise ValueError("I was told to raise an exception")
+
+    return arg
+
+
+def test_basic_usage():
+    """Make sure all methods on WorkQueueThread work."""
+    shared = [None, None]
+
+    def _callback(exc_info, return_value):
+        shared[0] = exc_info
+        shared[1] = return_value
+
+    workqueue = WorkQueueThread(_handler)
+
+    workqueue.start()
+
+    assert workqueue.dispatch('test') == 'test'
+
+    with pytest.raises(ValueError):
+        workqueue.dispatch('raise')
+
+    # Make sure stop
+    workqueue.dispatch('test 2', callback=_callback)
+    workqueue.flush()
+    assert shared == [None, 'test 2']
+
+    workqueue.dispatch('test 3', callback=_callback)
+    workqueue.stop()
+    assert shared == [None, 'test 3']

--- a/iotileemulate/RELEASE.md
+++ b/iotileemulate/RELEASE.md
@@ -27,3 +27,6 @@ All major changes in each released version of iotile-emulate are listed here.
   a basis for automatic help text generation or documentation.
 
 - Adds test coverage of tile_manager and config_database subsystems.
+
+- Moves all emulated RPCs to a single background thread so that we can support
+  sending rpcs from multiple threads without race conditions.

--- a/iotileemulate/iotile/emulate/constants/__init__.py
+++ b/iotileemulate/iotile/emulate/constants/__init__.py
@@ -9,8 +9,6 @@ from .const_tilemanager import RunLevel, TileState
 _RPC_NAME_MAP = {rpc_decl.rpc_id: name for name, rpc_decl in
                  getmembers(rpcs, lambda x: isinstance(x, rpcs.RPCDeclaration))}
 
-print(_RPC_NAME_MAP)
-
 def rpc_name(rpc_id):
     """Map an RPC id to a string name.
 

--- a/iotileemulate/iotile/emulate/constants/__init__.py
+++ b/iotileemulate/iotile/emulate/constants/__init__.py
@@ -1,7 +1,35 @@
 """Declarations of all important constants related to physical IOTile devices."""
 
+from inspect import getmembers
 from .errors import Error, ConfigDatabaseError
 from . import rpcs as rpcs
 from .const_tilemanager import RunLevel, TileState
 
-__all__ = ['Error', 'ConfigDatabaseError', 'rpcs', 'RunLevel', 'TileState']
+
+_RPC_NAME_MAP = {rpc_decl.rpc_id: name for name, rpc_decl in
+                 getmembers(rpcs, lambda x: isinstance(x, rpcs.RPCDeclaration))}
+
+print(_RPC_NAME_MAP)
+
+def rpc_name(rpc_id):
+    """Map an RPC id to a string name.
+
+    This function looks the RPC up in a map of all globally declared RPCs,
+    and returns a nice name string.  if the RPC is not found in the global
+    name map, returns a generic name string such as 'rpc 0x%04X'.
+
+    Args:
+        rpc_id (int): The id of the RPC that we wish to look up.
+
+    Returns:
+        str: The nice name of the RPC.
+    """
+
+    name = _RPC_NAME_MAP.get(rpc_id)
+    if name is None:
+        name = 'RPC 0x%04X' % rpc_id
+
+    return name
+
+
+__all__ = ['Error', 'ConfigDatabaseError', 'rpcs', 'rpc_name', 'RunLevel', 'TileState']

--- a/iotileemulate/iotile/emulate/constants/rpc_config_variables.py
+++ b/iotileemulate/iotile/emulate/constants/rpc_config_variables.py
@@ -1,0 +1,128 @@
+"""These RPCs implement the configuration variable interface of any tile.
+
+Config variables are used to stream configuration information to a tile when
+it resets, before any application firmware is run.  All tiles must implement
+these RPCs in order to allow for boot-time configuration.
+
+The local IOTile controller is in charge of persisting and streaming the
+actual config variables to each tile, these RPCs just provide the API that it
+can use in order to do so.
+"""
+
+from .rpc_declaration import RPCDeclaration
+
+
+LIST_CONFIG_VARIABLES = RPCDeclaration(10, "H", "H9H")
+"""Iteratively list all defined config variables on this tile.
+
+This method returns a chunk of the tile's internal config variable declaration
+table.  You pass an offset as an argument and it returns the config_variable
+ids of the next 9 config variables prepended with a valid count.  The return
+value of this RPC is fixed size so the count value will tell you how many
+entries are valid.
+
+Clients should call this function repeatedly incrementing the offset until
+count is returned as 0 indicating that the table has been exhausted.
+
+Args:
+  - uint16_t: An offset into the tile's config variable table.
+
+Returns:
+  - uint16_t: The count of valid config variable ids that follow.  This will
+    always be [0, 9] inclusive.
+  - uint16_t[9]: An array of 16 bit config variable ids.  Only the first count
+    entries are valid and the order is unspecified but usually sorted lowest
+    to highest.
+"""
+
+DESCRIBE_CONFIG_VARIABLE = RPCDeclaration(11, "H", "HHLHH")
+"""Describe the type, size and internal address of a config variable by id.
+
+This method returns the internal config variable descriptor for a given
+config variable by its 16-bit config id.  When an error is returned the
+contents of the rest of the response are undefined.
+
+Args:
+  - uint16_t: The config variable ID you wish to inspect.  This should
+    be in the list returned by LIST_CONFIG_VARIABLES or an error will
+    be returned.
+
+Returns:
+  - uint16_t: An error code, otherwise NO_ERROR to indicate success.
+  - uint16_t: Reserved for alignment, value is undefined.
+  - uint32_t: The internal RAM address of this config variable.  There
+    is typically no need to use this value for anything but it could
+    be useful for advanced debugging scenarios.
+  - uint16_t: The config variable id of this variable, will always
+    match what you passed in the arguments.
+  - uint16_t: Encoded bit field.  The low 15 bits are the total
+    size of the space allocated for this config variable in bytes.
+    The high bit indicates whether this is an array or a single
+    value.
+
+Possible Errors:
+  - INVALID_ARRAY_KEY: The config variable id could not be found
+"""
+
+SET_CONFIG_VARIABLE = RPCDeclaration(12, "HHV", "H")
+"""Set a chunk (possibly all) of the config variable's value.
+
+Config variables for the purposes of set and get are treated as binary strings
+of bytes.  This function lets you stream in up to 20 bytes of data into the
+config variable at the specified offset.
+
+Variable length config variables keep track of the highest offset written to
+by a call SET_CONFIG_VARIABLE and report that as their size.  For that reason
+it is important to send data to a long config variable from low to high
+offsets so that the final length is correct.  Writing to a low offset after
+having previously written to a high offset will truncate the stored data.
+
+If an error is returned, the state of the config variable is unchanged by this
+call.
+
+Args:
+  - uint16_t: the id of the config variable that you want to set.
+  - uint16_t: The offset that you want to start writing at.
+  - char[]: Variable length buffer up to the end of the RPC payload that will
+    be copied into the variable's value starting at the specified offset.
+
+Returns:
+  - uint16_t: An error code.
+
+Possible Errors:
+  - INVALID_ARRAY_KEY: The config variable id could not be found
+  - STATE_CHANGE_AT_INVALID_TIME: This RPC was called after a peripheral
+    tile's firmware had already started execution. Config variable are not
+    allowed to change while a tile is running.
+  - INPUT_BUFFER_TOO_LONG: The data would overflow the space allocated for the
+    config variable.
+"""
+
+GET_CONFIG_VARIABLE = RPCDeclaration(13, "HH", "V")
+"""Get a chunk (possibly all) of the config variable's value.
+
+Config variables for the purposes of set and get are treated as binary strings
+of bytes.  This function lets you get up to 20 bytes of data into the config
+variable at the specified offset.
+
+Callers should call this function repeatedly with incrementing offset until
+it returns 0 bytes indicating that you have received all data from that
+config variable.
+
+There is no way for the tile to communicate to you that the call failed except
+by returning a 0-length result so you cannot tell the difference with this
+call between a config variable that does not exist and one that has variable
+size and no data written yet.
+
+Fixed size config variables will always return their fixed size regardless of
+how much data has been written to them.
+
+Args:
+  - uint16_t: the id of the config variable that you want to set.
+  - uint16_t: The offset that you want to start writing at.
+
+Returns:
+  - char[]: Up to 20 bytes of data from the config variable starting at the
+    given offset.  The return value may be smaller than 20 bytes if the end
+    of the data is reached.
+"""

--- a/iotileemulate/iotile/emulate/constants/rpcs.py
+++ b/iotileemulate/iotile/emulate/constants/rpcs.py
@@ -13,6 +13,7 @@ the RPCDeclaration itself.
 from .rpc_declaration import RPCDeclaration
 from .rpc_tilemanager import *
 from .rpc_config_database import *
+from .rpc_config_variables import *
 
 # Tile Lifecycle Related RPCS
 
@@ -26,128 +27,31 @@ not a straightforward, portable way to determine the response code caused by
 the tile resetting from a response code caused by an issue running this RPC.
 """
 
+TILE_STATUS = RPCDeclaration(4, "", "H6s3BB")
+"""Query the tile's name and status.
+
+This RPC must be implemented by all tiles and is primarily used to return the
+6-character name string that identifies the firmware image running on the
+tile. This string is matched against installed proxy classes to find the
+appropriate proxy object to use for wrapping the tile.
+
+It can also be used to query the firmware version of the tile or a set of flag
+bits about the tile's current state.
+
+Returns:
+  - uint16_t: A numerical hardware identifier for the architecture the tile
+    is running on.
+  - char[6]: The tile firmware's 6-character module identifier that is used to
+    match the tile with an appropriate proxy class.
+  - uint8_t[3]: The tile's firmware version stored as major, minor, patch.
+  - uint8_t: A set of bit flags defining the current state of the tile such as
+    whether it is running, trapped in a panic routine, etc.
+"""
+
 START_APPLICATION = RPCDeclaration(6, "", "")
 """Inform the peripheral tile that it should pass control to its application firmware.
 
 Once the controller has finished streaming all configuration information to a tile
 it sends the tile this RPC so that it can check its configuration state and if
 everything is valid pass control to application firmware.
-"""
-
-
-# Config Variable Related RPCs
-
-LIST_CONFIG_VARIABLES = RPCDeclaration(10, "H", "H9H")
-"""Iteratively list all defined config variables on this tile.
-
-This method returns a chunk of the tile's internal config variable declaration
-table.  You pass an offset as an argument and it returns the config_variable
-ids of the next 9 config variables prepended with a valid count.  The return
-value of this RPC is fixed size so the count value will tell you how many
-entries are valid.
-
-Clients should call this function repeatedly incrementing the offset until
-count is returned as 0 indicating that the table has been exhausted.
-
-Args:
-  - uint16_t: An offset into the tile's config variable table.
-
-Returns:
-  - uint16_t: The count of valid config variable ids that follow.  This will
-    always be [0, 9] inclusive.
-  - uint16_t[9]: An array of 16 bit config variable ids.  Only the first count
-    entries are valid and the order is unspecified but usually sorted lowest
-    to highest.
-"""
-
-DESCRIBE_CONFIG_VARIABLE = RPCDeclaration(11, "H", "HHLHH")
-"""Describe the type, size and internal address of a config variable by id.
-
-This method returns the internal config variable descriptor for a given
-config variable by its 16-bit config id.  When an error is returned the
-contents of the rest of the response are undefined.
-
-Args:
-  - uint16_t: The config variable ID you wish to inspect.  This should
-    be in the list returned by LIST_CONFIG_VARIABLES or an error will
-    be returned.
-
-Returns:
-  - uint16_t: An error code, otherwise NO_ERROR to indicate success.
-  - uint16_t: Reserved for alignment, value is undefined.
-  - uint32_t: The internal RAM address of this config variable.  There
-    is typically no need to use this value for anything but it could
-    be useful for advanced debugging scenarios.
-  - uint16_t: The config variable id of this variable, will always
-    match what you passed in the arguments.
-  - uint16_t: Encoded bit field.  The low 15 bits are the total
-    size of the space allocated for this config variable in bytes.
-    The high bit indicates whether this is an array or a single
-    value.
-
-Possible Errors:
-  - INVALID_ARRAY_KEY: The config variable id could not be found
-"""
-
-SET_CONFIG_VARIABLE = RPCDeclaration(12, "HHV", "H")
-"""Set a chunk (possibly all) of the config variable's value.
-
-Config variables for the purposes of set and get are treated as binary strings
-of bytes.  This function lets you stream in up to 20 bytes of data into the
-config variable at the specified offset.
-
-Variable length config variables keep track of the highest offset written to
-by a call SET_CONFIG_VARIABLE and report that as their size.  For that reason
-it is important to send data to a long config variable from low to high
-offsets so that the final length is correct.  Writing to a low offset after
-having previously written to a high offset will truncate the stored data.
-
-If an error is returned, the state of the config variable is unchanged by this
-call.
-
-Args:
-  - uint16_t: the id of the config variable that you want to set.
-  - uint16_t: The offset that you want to start writing at.
-  - char[]: Variable length buffer up to the end of the RPC payload that will
-    be copied into the variable's value starting at the specified offset.
-
-Returns:
-  - uint16_t: An error code.
-
-Possible Errors:
-  - INVALID_ARRAY_KEY: The config variable id could not be found
-  - STATE_CHANGE_AT_INVALID_TIME: This RPC was called after a peripheral
-    tile's firmware had already started execution. Config variable are not
-    allowed to change while a tile is running.
-  - INPUT_BUFFER_TOO_LONG: The data would overflow the space allocated for the
-    config variable.
-"""
-
-GET_CONFIG_VARIABLE = RPCDeclaration(13, "HH", "V")
-"""Get a chunk (possibly all) of the config variable's value.
-
-Config variables for the purposes of set and get are treated as binary strings
-of bytes.  This function lets you get up to 20 bytes of data into the config
-variable at the specified offset.
-
-Callers should call this function repeatedly with incrementing offset until
-it returns 0 bytes indicating that you have received all data from that
-config variable.
-
-There is no way for the tile to communicate to you that the call failed except
-by returning a 0-length result so you cannot tell the difference with this
-call between a config variable that does not exist and one that has variable
-size and no data written yet.
-
-Fixed size config variables will always return their fixed size regardless of
-how much data has been written to them.
-
-Args:
-  - uint16_t: the id of the config variable that you want to set.
-  - uint16_t: The offset that you want to start writing at.
-
-Returns:
-  - char[]: Up to 20 bytes of data from the config variable starting at the
-    given offset.  The return value may be smaller than 20 bytes if the end
-    of the data is reached.
 """

--- a/iotileemulate/iotile/emulate/reference/reference_device.py
+++ b/iotileemulate/iotile/emulate/reference/reference_device.py
@@ -53,7 +53,8 @@ class ReferenceDevice(EmulatedDevice):
 
         self.controller.start(channel)
 
-        for address, tile in viewitems(self._tiles):
+        # Guarantee an initialization order so that our trace files are deterministic
+        for address, tile in sorted(viewitems(self._tiles)):
             if address == 8:
                 continue
 
@@ -64,8 +65,9 @@ class ReferenceDevice(EmulatedDevice):
             tile.start(channel)
 
         # This should have triggered all of the tiles to register themselves with the controller,
-        # causing it to queue up config variable and start_application rpcs back to them.
-        self.send_deferred_rpcs()
+        # causing it to queue up config variable and start_application rpcs back to them, make
+        # sure all such RPCs have been flushed.
+        self.wait_deferred_rpcs()
 
         for address, tile in viewitems(self._tiles):
             if address == 8:

--- a/iotileemulate/iotile/emulate/utilities/__init__.py
+++ b/iotileemulate/iotile/emulate/utilities/__init__.py
@@ -1,1 +1,5 @@
 """Shared utility classes and functions."""
+
+from .format_rpc import format_rpc
+
+__all__ = ['format_rpc']

--- a/iotileemulate/iotile/emulate/utilities/format_rpc.py
+++ b/iotileemulate/iotile/emulate/utilities/format_rpc.py
@@ -1,0 +1,32 @@
+"""Utility function to pretty print an rpc call and response."""
+
+from binascii import hexlify
+from ..constants import rpc_name
+
+def format_rpc(data):
+    """Format an RPC call and response.
+
+    Args:
+        data (tuple): A tuple containing the address, rpc_id, argument and response
+            payloads and any error code.
+
+    Returns:
+        str: The formated RPC string.
+    """
+
+    address, rpc_id, args, resp, _status = data
+
+    name = rpc_name(rpc_id)
+
+    if isinstance(args, (bytes, bytearray)):
+        arg_str = hexlify(args)
+    else:
+        arg_str = repr(args)
+
+    if isinstance(resp, (bytes, bytearray)):
+        resp_str = hexlify(resp)
+    else:
+        resp = repr(resp)
+
+    #FIXME: Check and print status as well
+    return "%s called on address %d, payload=%s, response=%s" % (name, address, arg_str, resp_str)

--- a/iotileemulate/iotile/emulate/virtual/__init__.py
+++ b/iotileemulate/iotile/emulate/virtual/__init__.py
@@ -1,13 +1,15 @@
 """Base classes for virtual IOTile devices designed to emulate physical IOTile Devices.
 
-Classes that derive from EmulatedDevice and EmulatedTile have additional funtionality
-for saving and loading their state to provide for easy creation of testing scenarios.
+Classes that derive from EmulatedDevice and EmulatedTile have additional
+funtionality for saving and loading their state to provide for easy creation
+of testing scenarios.
 
-For example, you may have an IOTile Device that serves as a shock and vibration data
-logger.  In reality it would take time to load it up with real captured shocks and
-vibrations in order to test that we could properly create software that read those
-waveforms.  With an EmulatedDevice, you can just load in a `has 100 waveforms`
-scenario and use that as part of automated integration test cases.
+For example, you may have an IOTile Device that serves as a shock and
+vibration data logger.  In reality it would take time to load it up with real
+captured shocks and vibrations in order to test that we could properly create
+software that read those waveforms.  With an EmulatedDevice, you can just load
+in a `has 100 waveforms` scenario and use that as part of automated
+integration test cases.
 
 EmulatedDevice vs VirtualIOTileDevice
 =====================================
@@ -33,9 +35,9 @@ interact with that physical device.
 Lifecycle of an Emulated Device
 ===============================
 
-Unlike normal virtual devices, which have no specific lifecycle imposed on them,
-emulated devices are designed to act as standins for physical IOTile devices that
-do need to follow a very specific initialization process.
+Unlike normal virtual devices, which have no specific lifecycle imposed on
+them, emulated devices are designed to act as standins for physical IOTile
+devices that do need to follow a very specific initialization process.
 
 The process is as follows:
 - First the controller tile for the device boots and initializes itself.
@@ -48,7 +50,7 @@ The process is as follows:
 In an EmulatedDevice class, this process happens when start() is called on the
 device and when the controller is reset().  Each tile can also be reset
 independently in order to trigger it to go through its initialization process
-again (including registering.
+again (including registering and receiving new config variables).
 """
 
 from .emulated_device import EmulatedDevice

--- a/iotileemulate/iotile/emulate/virtual/__init__.py
+++ b/iotileemulate/iotile/emulate/virtual/__init__.py
@@ -11,6 +11,7 @@ software that read those waveforms.  With an EmulatedDevice, you can just load
 in a `has 100 waveforms` scenario and use that as part of automated
 integration test cases.
 
+
 EmulatedDevice vs VirtualIOTileDevice
 =====================================
 
@@ -32,6 +33,7 @@ stays in sync with the features of the physical {tile,device} and provides a
 good way to do integration tests of other software components that need to
 interact with that physical device.
 
+
 Lifecycle of an Emulated Device
 ===============================
 
@@ -51,6 +53,46 @@ In an EmulatedDevice class, this process happens when start() is called on the
 device and when the controller is reset().  Each tile can also be reset
 independently in order to trigger it to go through its initialization process
 again (including registering and receiving new config variables).
+
+
+Technical Details of Emulation
+==============================
+
+All emulation happens inside the EmulatedDevice subclass.  Nothing happens
+on __init__ except for internal class initialization.  Emulation begins
+when EmulatedDevice.start() is called and finishes when EmulatedDevice.stop()
+is called.
+
+Both start() and stop() are synchronous calls in that emulation is guaranteed
+to be running when start() returns and guaranteed to be finished when stop()
+returns.
+
+Conceptually start() is equivalent to powering on the emulated device and
+stop() is equivalent to powering it off.
+
+Internally, most emulated devices are made up of one or more emulated tiles.
+The tiles all run in their own execution thread and are not synchronized with
+each other in any way, just as would be the case in a physical IOTile device.
+
+There is a single background thread spawned by EmulatedDevice during the
+start() method that is in charge of dispatching rpcs to each tile.  Any time a
+tile wishes to communicate with another tile, it calls self.device.rpc() and
+this queues the rpc for completion on the background rpc dispatcher task.
+
+Since all RPCs are guaranteed to only execute on a single thread, only one RPC
+at a time can execute, as is the case in a physical IOTile device.
+
+If you want to directly interact with an EmulatedDevice from a control script,
+you can call the EmulatedDevice.rpc() method directly from your control
+script.
+
+Even though you are synchronously invoking the rpc() method, the rpc that you
+specify will still be executed in the background rpc dispatch thread while
+your thread blocks waiting for it to finish.
+
+If you want to queue an RPC without blocking, you can use the deferred_rpc()
+method, optionally passing a callback that will be invoked when the RPC
+finishes.
 """
 
 from .emulated_device import EmulatedDevice

--- a/iotileemulate/iotile/emulate/virtual/emulated_device.py
+++ b/iotileemulate/iotile/emulate/virtual/emulated_device.py
@@ -2,6 +2,10 @@
 
 from __future__ import unicode_literals, absolute_import, print_function
 import logging
+import threading
+import sys
+from collections import namedtuple
+from queue import Queue
 from future.utils import viewitems
 from iotile.core.exceptions import DataError
 from iotile.core.hw.virtual import VirtualIOTileDevice
@@ -9,6 +13,14 @@ from iotile.core.hw.virtual.common_types import pack_rpc_payload, unpack_rpc_pay
 from .emulation_mixin import EmulationMixin
 from .state_log import EmulationStateLog
 from ..constants.rpcs import RPCDeclaration
+from ..constants import rpc_name
+from ..utilities import format_rpc
+
+# Kill signal to stop our background RPC worker thread
+_STOP_RPC_WORKER = object()
+
+# Signal to synchronously wait for all previous rpcs to be dispatched
+_WAIT_FOR_RPCS = namedtuple('_WAIT_FOR_RPCS', ['callback'])  #pylint:disable=invalid-name;
 
 
 #pylint:disable=abstract-method;This is an abstract base class
@@ -18,6 +30,12 @@ class EmulatedDevice(EmulationMixin, VirtualIOTileDevice):
     This class adds additional state and test scenario loading functionality
     as well as tracing of state changes on the emulated device for comparison
     and verification purposes.
+
+    Since all IOTile devices have a single TileBus interface that serializes
+    RPCs between tiles so that only one runs at a time, this class spawns a
+    single background rpc to work through the queue of RPCs that should be
+    sent, sending them one at a time.  The rpc dispatch queue is started when
+    start() is called and stopped synchronously when stop() is called.
 
     Args:
         iotile_id (int): A 32-bit integer that specifies the globally unique ID
@@ -33,7 +51,68 @@ class EmulatedDevice(EmulationMixin, VirtualIOTileDevice):
         EmulationMixin.__init__(self, None, self.state_history)
 
         self._logger = logging.getLogger(__name__)
-        self._deferred_rpcs = []
+        self._rpc_queue = Queue()
+        self._rpc_thread = threading.Thread(target=self._rpc_dispatch_loop)
+
+    def _rpc_dispatch_loop(self):
+        """Background thread routine to dispatch RPCs."""
+
+        while True:
+            try:
+                action = self._rpc_queue.get()
+
+                # Handle special actions that are not RPCs
+                if action is _STOP_RPC_WORKER:
+                    return
+                elif isinstance(action, _WAIT_FOR_RPCS):
+                    action.callback()
+                    continue
+
+                # Otherwise, we are supposed to send an RPC
+                address, rpc_id, arg_payload, callback = action
+
+                try:
+                    exc_status = None
+                    exc_info = None
+                    resp = None
+
+                    # Send the RPC immediately and wait for the respones
+                    resp = super(EmulatedDevice, self).call_rpc(address, rpc_id, arg_payload)
+                except:
+                    exc_info = sys.exc_info()
+                    exc_status = exc_info[1]
+                finally:
+                    self._track_change('device.rpc_sent', (address, rpc_id, arg_payload, resp, exc_status), formatter=format_rpc)
+
+                if callback is not None:
+                    callback(exc_info, resp)
+            except:
+                self._logger.exception("Error dispatching %s to tile %d", rpc_name(rpc_id), address)
+
+
+    def start(self, channel=None):
+        """Start this emulated device.
+
+        This triggers the controller to call start on all peripheral tiles in the device to make sure
+        they start after the controller does and then it waits on each one to make sure they have
+        finished initializing before returning.
+
+        Args:
+            channel (IOTilePushChannel): the channel with a stream and trace
+                routine for streaming and tracing data through a VirtualInterface
+        """
+
+        super(EmulatedDevice, self).start(channel)
+        self._rpc_thread.start()
+
+    def stop(self):
+        """Stop running this virtual device including any worker threads."""
+
+        if self._rpc_thread.is_alive():
+            self._rpc_queue.put(_STOP_RPC_WORKER)
+            self._rpc_thread.join()
+
+        super(EmulatedDevice, self).stop()
 
     def dump_state(self):
         """Dump the current state of this emulated object as a dictionary.
@@ -56,10 +135,10 @@ class EmulatedDevice(EmulationMixin, VirtualIOTileDevice):
 
         This function is meant to be used for testing purposes as well as by
         tiles inside a complex EmulatedDevice subclass that need to communicate
-        with each other.  It may only be called from the main virtual device
+        with each other.  It should only be called from the main virtual device
         thread where start() was called from.
 
-        **Background workers may not call this method since it is unsynchronized.**
+        **Background workers may not call this method since it may cause them to deadlock.**
 
         Args:
             address (int): The address of the tile that has the RPC.
@@ -87,6 +166,7 @@ class EmulatedDevice(EmulationMixin, VirtualIOTileDevice):
             arg_payload = pack_rpc_payload(arg_format, args)
 
         self._logger.debug("Sending rpc to %d:%04X, payload=%s", address, rpc_id, args)
+
         resp_payload = self.call_rpc(address, rpc_id, arg_payload)
         if resp_format is None:
             return []
@@ -94,13 +174,45 @@ class EmulatedDevice(EmulationMixin, VirtualIOTileDevice):
         resp = unpack_rpc_payload(resp_format, resp_payload)
         return resp
 
+    def call_rpc(self, address, rpc_id, payload=b""):
+        """Call an RPC by its address and ID.
+
+        This will send the RPC to the background rpc dispatch thread and
+        synchronously wait for the response.
+
+        Args:
+            address (int): The address of the mock tile this RPC is for
+            rpc_id (int): The number of the RPC
+            payload (bytes): A byte string of payload parameters up to 20 bytes
+
+        Returns:
+            bytes: The response payload from the RPC
+        """
+
+        done = threading.Event()
+        data = [None, None]
+
+        def _callback(status_error, resp_payload):
+            data[0] = status_error
+            data[1] = resp_payload
+            done.set()
+
+        self._rpc_queue.put((address, rpc_id, payload, _callback))
+
+        done.wait(timeout=10)
+        status_error, resp_payload = data
+        if status_error is not None:
+            raise status_error[0], status_error[1], status_error[2]  #pylint:disable=unsubscriptable-object;The call to done.wait() ensures this is okay.
+
+        return resp_payload
+
     def deferred_rpc(self, address, rpc_id, *args, **kwargs):
         """Queue an RPC to send later.
 
-        These RPCs will be sent deterministically whenever send_deferred_rpcs()
-        is called.
-
-        **Background workers may not call this method since it is unsynchronized.**
+        When this RPC is called, the result of calling it will be available to
+        the provided callback function if passed as keyword.  If no 'callback'
+        keyword is provided then the rpc will be called and its result will be
+        discarded.
 
         Args:
             address (int): The address of the tile that has the RPC.
@@ -114,23 +226,40 @@ class EmulatedDevice(EmulationMixin, VirtualIOTileDevice):
                   finishes.
         """
 
+        if isinstance(rpc_id, RPCDeclaration):
+            arg_format = rpc_id.arg_format
+            resp_format = rpc_id.resp_format
+            rpc_id = rpc_id.rpc_id
+        else:
+            arg_format = kwargs.get('arg_format', None)
+            resp_format = kwargs.get('resp_format', None)
+
+        arg_payload = b''
+
+        if arg_format is not None:
+            arg_payload = pack_rpc_payload(arg_format, args)
+
         callback = kwargs.get('callback')
         if 'callback' in kwargs:
             del kwargs['callback']
 
-        rpc_args = (address, rpc_id, args, kwargs, callback)
-        self._deferred_rpcs.append(rpc_args)
-
-    def send_deferred_rpcs(self):
-        """Send all deferred rpcs currently in the queue."""
-
-        for address, rpc_id, args, kwargs, callback in self._deferred_rpcs:
-            resp = self.rpc(address, rpc_id, *args, **kwargs)
-
+        def _callback(_exc_info, resp_payload):
             if callback is not None:
+                resp = unpack_rpc_payload(resp_format, resp_payload)
                 callback(resp)
 
-        self._deferred_rpcs = []
+        rpc_args = (address, rpc_id, arg_payload, callback)
+        self._rpc_queue.put(rpc_args)
+
+    def wait_deferred_rpcs(self):
+        """Wait until all RPCs queued to this point have been sent."""
+
+        done = threading.Event()
+        def _callback():
+            done.set()
+
+        self._rpc_queue.put(_WAIT_FOR_RPCS(_callback))
+        done.wait(timeout=10)
 
     def restore_state(self, state):
         """Restore the current state of this emulated device.

--- a/iotileemulate/iotile/emulate/virtual/emulated_device.py
+++ b/iotileemulate/iotile/emulate/virtual/emulated_device.py
@@ -6,7 +6,7 @@ import threading
 import sys
 from collections import namedtuple
 from queue import Queue
-from future.utils import viewitems
+from future.utils import viewitems, raise_
 from iotile.core.exceptions import DataError
 from iotile.core.hw.virtual import VirtualIOTileDevice
 from iotile.core.hw.virtual.common_types import pack_rpc_payload, unpack_rpc_payload
@@ -202,7 +202,7 @@ class EmulatedDevice(EmulationMixin, VirtualIOTileDevice):
         done.wait(timeout=10)
         status_error, resp_payload = data
         if status_error is not None:
-            raise status_error[0], status_error[1], status_error[2]  #pylint:disable=unsubscriptable-object;The call to done.wait() ensures this is okay.
+            raise_(status_error[0], status_error[1], status_error[2])  #pylint:disable=unsubscriptable-object;The call to done.wait() ensures this is okay.
 
         return resp_payload
 

--- a/iotileemulate/iotile/emulate/virtual/emulation_mixin.py
+++ b/iotileemulate/iotile/emulate/virtual/emulation_mixin.py
@@ -47,15 +47,33 @@ class EmulationMixin(object):
 
         super(EmulationMixin, self).__setattr__(name, value)
 
-    def _track_change(self, name, value):
+    def _track_change(self, name, value, formatter=None):
         """Track that a change happened.
 
-        This function is only needed for manually recording changes
-        that are not captured by changes to properties of this object
-        that are tracked automatically.
+        This function is only needed for manually recording changes that are
+        not captured by changes to properties of this object that are tracked
+        automatically.  Classes that inherit from `emulation_mixin` should
+        use this function to record interesting changes in their internal
+        state or events that happen.
+
+        The `value` parameter that you pass here should be a native python
+        object best representing what the value of the property that changed
+        is.  When saved to disk, it will be converted to a string using:
+        `str(value)`.  If you do not like the string that would result from
+        such a call, you can pass a custom formatter that will be called as
+        `formatter(value)` and must return a string.
+
+        Args:
+            name (str): The name of the property that changed.
+            value (object): The new value of the property.
+            formatter (callable): Optional function to convert value to a
+                string.  This function will only be called if track_changes()
+                is enabled and `name` is on the whitelist for properties that
+                should be tracked.  If `formatter` is not passed or is None,
+                it will default to `str`
         """
 
-        self._emulation_log.track_change(self._emulation_address, name, value)
+        self._emulation_log.track_change(self._emulation_address, name, value, formatter)
 
     def dump_state(self):
         """Dump the current state of this emulated object as a dictionary.

--- a/iotileemulate/iotile/emulate/virtual/peripheral_tile.py
+++ b/iotileemulate/iotile/emulate/virtual/peripheral_tile.py
@@ -62,7 +62,6 @@ class EmulatedPeripheralTile(EmulatedTile):
 
         # Register ourselves with the controller
         resp = self._device.rpc(8, rpcs.REGISTER_TILE, *self._registration_tuple())
-
         self._process_registration(resp)
 
     def _process_registration(self, resp):
@@ -87,6 +86,7 @@ class EmulatedPeripheralTile(EmulatedTile):
         """
 
         super(EmulatedPeripheralTile, self)._handle_reset()
+
         #TODO: If we have background tasks running, we need to cleanly stop them here and wait until they have stopped
         self._app_started.clear()
         self._device.deferred_rpc(8, rpcs.REGISTER_TILE, *self._registration_tuple(), callback=self._process_registration)

--- a/iotileemulate/iotile/emulate/virtual/state_log.py
+++ b/iotileemulate/iotile/emulate/virtual/state_log.py
@@ -20,7 +20,7 @@ class EmulationStateLog(object):
         self._lock = threading.Lock()
         self._whitelist = set()
 
-    def track_change(self, tile, property_name, value):
+    def track_change(self, tile, property_name, value, formatter=None):
         """Record that a change happened on a given tile's property.
 
         This will as a StateChange object to our list of changes if we
@@ -30,6 +30,11 @@ class EmulationStateLog(object):
             tile (int): The address of the tile that the change happened on.
             property_name (str): The name of the property that changed.
             value (object): The new value assigned to the property.
+            formatter (callable): Optional function to convert value to a
+                string.  This function will only be called if track_changes()
+                is enabled and `name` is on the whitelist for properties that
+                should be tracked.  If `formatter` is not passed or is None,
+                it will default to `str`.
         """
 
         if not self.tracking:
@@ -38,7 +43,10 @@ class EmulationStateLog(object):
         if len(self._whitelist) > 0 and (tile, property_name) not in self._whitelist:
             return
 
-        change = StateChange(monotonic.monotonic(), tile, property_name, value, str(value))
+        if formatter is None:
+            formatter = str
+
+        change = StateChange(monotonic.monotonic(), tile, property_name, value, formatter(value))
 
         with self._lock:
             self.changes.append(change)


### PR DESCRIPTION
In preparation for supporting EmulatedTiles that have their own background work going on, we need a general way of synchronizing RPCs to execute one at a time without requiring the RPC function to be called from a single thread.

This PR refactors the RPC dispatch logic to use a single background work-queue as the sole RPC executor.  All calls to `rpc`, `deferred_rpc` and `call_rpc` are not synchronized through this queue.  

Additional Fixes:
- Adds a lot more docstring descriptions of what is going on and why
- adds a `format_rpc` function that can print a nice string describing an RPC call-and-response including looking up a good name for the RPC (so `SET_CONFIG_VARIABLE` rather than just `RPC 0x2001`).  This is used for state tracking so that the produced changelog is easier to understand.
- Adds the background work queue thread to `iotile-core` for generic use along side the existing `StoppableWorkerThread`.  
- Adds the ability to directly set the return status from a virtual RPC.  This previously wasn't needed because normal Virtual devices don't use this mechanism to return errors but legacy RPCs do so it's needed for proper emulation.

Closes #554.