### PR TITLE
Finish sensor_log subsystem in emulated controller

### DIFF
--- a/iotileemulate/iotile/emulate/reference/controller_features/sensor_log.py
+++ b/iotileemulate/iotile/emulate/reference/controller_features/sensor_log.py
@@ -54,7 +54,7 @@ class SensorLogSubsystem(object):
         return state
 
     def prepare_for_restore(self):
-        """Preare the SensorLog subsystem for a restore.
+        """Prepare the SensorLog subsystem for a restore.
 
         This must be called at the start of the restore to clear all of the
         stream walkers in the SensorLog storage engine, which are then added

--- a/iotileemulate/iotile/emulate/reference/controller_features/sensor_log.py
+++ b/iotileemulate/iotile/emulate/reference/controller_features/sensor_log.py
@@ -3,6 +3,13 @@
 The raw sensor log is the subsystem that stores sensor readings
 on behalf of sensor graph and allows you to query them later.
 
+The main purpose of this subsystem is to serve as a persistent
+data store.  Since it allocates `StreamWalker` objects that
+are used by the SensorGraph and Streaming subsystems, it needs
+to have a very clear dump()/restore() process to ensure that
+those subsystems properly get their stream walkers restored
+to the correct state.
+
 Current State of Necessary TODOS:
 - [ ] Support dumping and restoring state
 """
@@ -26,6 +33,56 @@ class SensorLogSubsystem(object):
         self.dump_walker = None
         self.next_id = 1
         self.mutex = threading.Lock()
+
+    def dump(self):
+        """Serialize the state of this subsystem into a dict.
+
+        Returns:
+            dict: The serialized state
+        """
+
+        walker = self.dump_walker
+        if walker is not None:
+            walker = walker.dump()
+
+        state = {
+            'storage': self.storage.dump(),
+            'dump_walker': walker,
+            'next_id': self.next_id
+        }
+
+        return state
+
+    def prepare_for_restore(self):
+        """Preare the SensorLog subsystem for a restore.
+
+        This must be called at the start of the restore to clear all of the
+        stream walkers in the SensorLog storage engine, which are then added
+        back by the SensorGraph and Streaming subsystems and then restored
+        to their previous positions when restore() is called on this subsystem.
+        """
+
+        self.storage.destroy_all_walkers()
+
+    def restore(self, state):
+        """Restore the state of this subsystem from a prior call to dump().
+
+        Calling restore must be properly sequenced with calls to other
+        subsystems that include stream walkers so that their walkers are
+        properly restored.
+
+        Args:
+            state (dict): The results of a prior call to dump().
+        """
+
+        self.storage.restore(state.get('storage'))
+
+        dump_walker = state.get('dump_walker')
+        if dump_walker is not None:
+            dump_walker = self.storage.restore_walker(dump_walker)
+
+        self.dump_walker = dump_walker
+        self.next_id = state.get('next_id', 1)
 
     def clear(self, timestamp):
         """Clear all data from the RSL.

--- a/iotileemulate/iotile/emulate/reference/controller_features/sensor_log.py
+++ b/iotileemulate/iotile/emulate/reference/controller_features/sensor_log.py
@@ -9,9 +9,6 @@ are used by the SensorGraph and Streaming subsystems, it needs
 to have a very clear dump()/restore() process to ensure that
 those subsystems properly get their stream walkers restored
 to the correct state.
-
-Current State of Necessary TODOS:
-- [ ] Support dumping and restoring state
 """
 
 import threading

--- a/iotileemulate/iotile/emulate/reference/reference_controller.py
+++ b/iotileemulate/iotile/emulate/reference/reference_controller.py
@@ -141,7 +141,8 @@ class ReferenceController(RawSensorLogMixin, RemoteBridgeMixin,
             # Dump all of the subsystems
             'remote_bridge': self.remote_bridge.dump(),
             'tile_manager': self.tile_manager.dump(),
-            'config_database': self.config_database.dump()
+            'config_database': self.config_database.dump(),
+            'sensor_log': self.sensor_log.dump()
         })
 
         return superstate
@@ -165,10 +166,14 @@ class ReferenceController(RawSensorLogMixin, RemoteBridgeMixin,
         self.app_info = state.get('app_info', (0, "0.0"))
         self.os_info = state.get('os_info', (0, "0.0"))
 
+        # Notify all subsystems of our intent to restore in case they need to prepare
+        self.sensor_log.prepare_for_restore()
+
         # Restore all of the subsystems
         self.remote_bridge.restore(state.get('remote_bridge', {}))
         self.tile_manager.restore(state.get('tile_manager', {}))
         self.config_database.restore(state.get('config_database', {}))
+        self.sensor_log.restore(state.get('sensor_log', {}))
 
     @tile_rpc(*rpcs.RESET)
     def reset(self):

--- a/iotileemulate/iotile/emulate/utilities/format_rpc.py
+++ b/iotileemulate/iotile/emulate/utilities/format_rpc.py
@@ -7,8 +7,8 @@ def format_rpc(data):
     """Format an RPC call and response.
 
     Args:
-        data (tuple): A tuple containing the address, rpc_id, argument and response
-            payloads and any error code.
+        data (tuple): A tuple containing the address, rpc_id, argument and
+            response payloads and any error code.
 
     Returns:
         str: The formated RPC string.

--- a/iotileemulate/test/test_reference.py
+++ b/iotileemulate/test/test_reference.py
@@ -327,3 +327,36 @@ def test_rsl_reset_config(reference_hw):
         'streaming': 48896,
         'storage': 16128
     }
+
+
+def test_rsl_dump_restore(reference_hw):
+    """Make sure the rsl state is properly saved and restored."""
+
+    hw, device, _peripheral = reference_hw
+    refcon = device.controller
+
+    con = hw.get(8, basic=True)
+    sensor_graph = find_proxy_plugin('iotile_standard_library/lib_controller', 'SensorGraphPlugin')(con)
+
+    # Verify that we properly restore data and our download walker
+    for i in range(0, 10):
+        sensor_graph.push_reading('output 1', i)
+
+    con.rpc(0x20, 0x08, 0x5001, result_format="LLLL")
+    err, _timestamp, reading, unique_id, _act_stream = con.rpc(0x20, 0x09, 1, arg_format='B', result_format="LLLLH2x")
+    assert err == 0
+    assert reading == 0
+    assert unique_id == 1
+
+    state = device.dump_state()
+    device.restore_state(state)
+
+    # Make sure we keep our same place in the dump stream line
+    err, _timestamp, reading, unique_id, _act_stream = con.rpc(0x20, 0x09, 1, arg_format='B', result_format="LLLLH2x")
+
+    assert err == 0
+    assert reading == 1
+    assert unique_id == 2
+
+    # Make sure we have all of our data
+    assert refcon.sensor_log.engine.count() == (0, 10)

--- a/iotileemulate/test/test_reference.py
+++ b/iotileemulate/test/test_reference.py
@@ -360,3 +360,9 @@ def test_rsl_dump_restore(reference_hw):
 
     # Make sure we have all of our data
     assert refcon.sensor_log.engine.count() == (0, 10)
+
+    readings = sensor_graph.download_stream('output 1')
+    assert len(readings) == 10
+    for i, reading in enumerate(readings):
+        assert reading.value == i
+        assert reading.reading_id == i + 1

--- a/iotilesensorgraph/test/test_sensorlog.py
+++ b/iotilesensorgraph/test/test_sensorlog.py
@@ -412,3 +412,17 @@ def test_dump_restore():
     assert count1.count() == 2
     assert const1.count() == 0xFFFFFFFF
     assert unbuf1.count() == 1
+
+    # Test restoring a stream walker
+    log.clear()
+    log.destroy_all_walkers()
+    walk = log.create_walker(DataStreamSelector.FromString(str(storage)))
+
+    for _i in range(0, 25):
+        log.push(storage, reading)
+
+    assert walk.count() == 25
+    dump = walk.dump()
+    log.destroy_all_walkers()
+    walk2 = log.restore_walker(dump)
+    assert walk2.count() == 25


### PR DESCRIPTION
This PR finishes RawSensorLog support for ReferenceController including the remaining support for state snapshoting.

Closes #560 