### PR TITLE
Add streamer support into sensorgraph subsystem in iotile-emulate

### DIFF
--- a/iotileemulate/RELEASE.md
+++ b/iotileemulate/RELEASE.md
@@ -42,3 +42,5 @@ All major changes in each released version of iotile-emulate are listed here.
 - Add initial support for the sensor_graph subsystem except for dump/restore
   and streamer support.  Initial RPCs are added as well except those dealing
   with streamers.
+
+- Finish basic streamer support except for seeking and querying

--- a/iotileemulate/iotile/emulate/constants/rpc_sensorgraph.py
+++ b/iotileemulate/iotile/emulate/constants/rpc_sensorgraph.py
@@ -154,7 +154,7 @@ Returns:
     returned.
 """
 
-SG_ADD_STREAMER = RPCDeclaration(0x2007, "14s", "L")
+SG_ADD_STREAMER = RPCDeclaration(0x2007, "V", "L")
 """Add a streamer to the sensor-graph.
 
 A streamer is a resource inside the sensor-graph subsystem that packages up
@@ -174,7 +174,8 @@ the first time you call this RPC, the streamer will get index 0, the next
 call will be index 1, etc.
 
 Args:
-  - char[14]: A binary streamer descriptor.
+  - char[14]: A binary streamer descriptor.  The final byte is padding though
+    so you can pass either 13 or 14 bytes of data.
 
 Returns:
   - uint32_t: an error code.
@@ -362,7 +363,7 @@ Returns:
   - char[20]: A binary node descriptor for the node in question.
 """
 
-SG_INSPECT_STREAMER = RPCDeclaration(0x2017, "H", "L14s")
+SG_INSPECT_STREAMER = RPCDeclaration(0x2017, "H", "L14s2x")
 """Get a binary streamer descriptor describing a streamer by its index.
 
 This allows you to verify the action of the SG_ADD_STREAMER RPC by inspecting

--- a/iotileemulate/iotile/emulate/constants/rpc_sensorlog.py
+++ b/iotileemulate/iotile/emulate/constants/rpc_sensorlog.py
@@ -265,7 +265,7 @@ Possible Errors:
   - NO_MORE_READINGS: If the reading id was not found at all in the RSL.
 """
 
-RSL_DUMP_STREAM_NEXT = RPCDeclaration(0x2009, "B", "4L2H")
+RSL_DUMP_STREAM_NEXT = RPCDeclaration(0x2009, "B", "V")
 """Dump the next reading in the previously selected stream.
 
 See RSL_DUMP_STREAM_BEGIN for more details on the stream dumping process.
@@ -290,7 +290,12 @@ Args:
     used otherwise, if 1 is passed, the new format will be used.  No value
     other than 0 or 1 should be passed.
 
-Returns:
+Returns (format 0):
+  - uint32_t: An error code.
+  - uint32_t: The reading timestamp.
+  - uint32_t: The reading value.
+
+Returns (format 1):
   - uint32_t: An error code.
   - uint32_t: The reading timestamp.
   - uint32_t: The reading value.

--- a/iotileemulate/iotile/emulate/reference/controller_features/sensor_graph.py
+++ b/iotileemulate/iotile/emulate/reference/controller_features/sensor_graph.py
@@ -55,15 +55,14 @@ TODO:
   - [ ] Add SG_INSPECT_STREAMER
   - [ ] Add SG_SEEK_STREAMER
   - [ ] Add dump/restore support
-  - [ ] Properly initialize all constant streams to 0
 """
 
 import logging
-from builtins import range
 from iotile.core.hw.virtual import tile_rpc, RPCErrorCode
 from iotile.core.hw.reports import IOTileReading
 from iotile.sg import DataStream, DataStreamSelector, SensorGraph
 from iotile.sg.node_descriptor import parse_binary_descriptor, create_binary_descriptor
+from iotile.sg import streamer_descriptor
 from iotile.sg.exceptions import NodeConnectionError, ProcessingFunctionError, ResourceUsageError
 from ...constants import rpcs, pack_error, Error, ControllerSubsystem, streams, SensorGraphError
 
@@ -195,6 +194,33 @@ class SensorGraphSubsystem(object):
 
         return Error.NO_ERROR
 
+    def add_streamer(self, binary_descriptor):
+        """Add a streamer to the sensor_graph using a binary streamer descriptor.
+
+        Args:
+            binary_descriptor (bytes): An encoded binary streamer descriptor.
+
+        Returns:
+            int: A packed error code
+        """
+
+        streamer = streamer_descriptor.parse_binary_descriptor(binary_descriptor, self._sensor_log)
+
+        try:
+            with self._mutex:
+                self.graph.add_streamer(streamer)
+        except ResourceUsageError:
+            return _pack_sgerror(SensorGraphError.NO_MORE_STREAMER_RESOURCES)
+
+    def inspect_streamer(self, index):
+        """Inspect the streamer at the given index."""
+
+        with self._mutex:
+            if index >= len(self.graph.streamers):
+                return [_pack_sgerror(SensorGraphError.STREAMER_NOT_ALLOCATED), b'\0'*14]
+
+            return [Error.NO_ERROR, streamer_descriptor.create_binary_descriptor(self.graph.streamers[index])]
+
     def inspect_node(self, index):
         """Inspect the graph node at the given index."""
 
@@ -267,3 +293,16 @@ class SensorGraphMixin(object):
 
         desc = self.sensor_graph.inspect_node(index)
         return [desc]
+
+    @tile_rpc(*rpcs.SG_ADD_STREAMER)
+    def sg_add_streamer(self, desc):
+        """Add a graph streamer using a binary descriptor."""
+
+        err = self.sensor_graph.add_streamer(desc)
+        return [err]
+
+    @tile_rpc(*rpcs.SG_INSPECT_STREAMER)
+    def sg_inspect_streamer(self, index):
+        """Inspect a sensorgraph streamer by index."""
+
+        return self.sensor_graph.inspect_streamer(index)

--- a/iotileemulate/iotile/emulate/reference/controller_features/sensor_log.py
+++ b/iotileemulate/iotile/emulate/reference/controller_features/sensor_log.py
@@ -12,6 +12,7 @@ to the correct state.
 """
 
 import threading
+import struct
 from builtins import range
 from iotile.core.hw.virtual import tile_rpc
 from iotile.core.hw.reports import IOTileReading
@@ -367,11 +368,11 @@ class RawSensorLogMixin(object):
             error = pack_error(ControllerSubsystem.SENSOR_LOG, SensorLogError.NO_MORE_READINGS)
 
         if output_format == 0:
-            raise ValueError("Old output format for dump_stream not yet supported")
+            return [struct.pack("<LLL", error, timestamp, value)]
         elif output_format != 1:
             raise ValueError("Output format other than 1 not yet supported")
 
-        return [error, timestamp, value, reading_id, stream_id, 0]
+        return [struct.pack("<LLLLH2x", error, timestamp, value, reading_id, stream_id)]
 
     @tile_rpc(*rpcs.RSL_HIGHEST_READING_ID)
     def rsl_get_highest_saved_id(self):

--- a/iotileemulate/test/test_reference_sensorgraph.py
+++ b/iotileemulate/test/test_reference_sensorgraph.py
@@ -61,6 +61,8 @@ def basic_sg():
         for node in nodes:
             sensor_graph.add_node(node)
 
+        sensor_graph.add_streamer('output 10', 'controller', True, 'individual', 'telegram')
+
         yield sensor_graph, hw, device
 
 
@@ -84,6 +86,13 @@ def test_inspect_nodes(sg_device):
     assert node2 == nodes[1]
 
 
+def test_inspect_streamers(basic_sg):
+    """Ensure that we can add and inspect streamers."""
+
+    sg, _hw, _device = basic_sg
+    assert str(sg.inspect_streamer(0)) == 'realtime streamer on output 10'
+
+
 def test_persist(basic_sg):
     """Ensure that sensor_graph persists after reset."""
 
@@ -91,10 +100,13 @@ def test_persist(basic_sg):
 
     sg.persist()
     assert sg.count_nodes() == 3
+    assert str(sg.inspect_streamer(0)) == 'realtime streamer on output 10'
 
     hw.get(8, basic=True).reset(wait=0)
 
+    # Make sure we recover both streamers and nodes
     assert sg.count_nodes() == 3
+    assert str(sg.inspect_streamer(0)) == 'realtime streamer on output 10'
 
 
 def test_graph_input(basic_sg):

--- a/iotilesensorgraph/RELEASE.md
+++ b/iotilesensorgraph/RELEASE.md
@@ -20,6 +20,12 @@ here.
 - Adjust constant stream walker allocation to align with how physical devices
   behave in order to better integrate into iotile-emulate.
 
+- Add better support for linking DataStreamer objects to a SensorLog and 
+  generating reports.
+
+- Enhances sensor-graph simulation to properly handle important system inputs
+  by inserting an autocopy rule.
+
 ## 0.7.2
 
 - Add support for broadcast streamers that indicate to the receiving tile that

--- a/iotilesensorgraph/iotile/sg/graph.py
+++ b/iotilesensorgraph/iotile/sg/graph.py
@@ -150,6 +150,7 @@ class SensorGraph(object):
         if self._max_streamers is not None and len(self.streamers) >= self._max_streamers:
             raise ResourceUsageError("Maximum number of streamers exceeded", max_streamers=self._max_streamers)
 
+        streamer.link_to_storage(self.sensor_log)
         self.streamers.append(streamer)
 
     def add_constant(self, stream, value):

--- a/iotilesensorgraph/iotile/sg/graph.py
+++ b/iotilesensorgraph/iotile/sg/graph.py
@@ -325,6 +325,11 @@ class SensorGraph(object):
 
         self.sensor_log.push(stream, value)
 
+        # FIXME: This should be specified in our device model
+        if stream.important:
+            associated_output = stream.associated_stream()
+            self.sensor_log.push(associated_output, value)
+
         to_check = deque([x for x in self.roots])
 
         while len(to_check) > 0:
@@ -425,4 +430,4 @@ class SensorGraph(object):
     def dump_streamers(self):
         """Dump all of the streamers in this sensor graph as a list of strings."""
 
-        return [str(x) for x in self.streamers]
+        return [str(streamer) for streamer in self.streamers]

--- a/iotilesensorgraph/iotile/sg/parser/language.py
+++ b/iotilesensorgraph/iotile/sg/parser/language.py
@@ -165,3 +165,13 @@ def get_statement():
     get_language()
 
     return simple_statement
+
+
+def get_streamer_parser():
+    """Get the parse tree for a streamer statement."""
+
+    global streamer_stmt
+
+    get_language()
+
+    return streamer_stmt

--- a/iotilesensorgraph/iotile/sg/parser/statements/streamer_statement.py
+++ b/iotilesensorgraph/iotile/sg/parser/statements/streamer_statement.py
@@ -64,7 +64,7 @@ class StreamerStatement(SensorGraphStatement):
     def execute(self, sensor_graph, scope_stack):
         """Execute this statement on the sensor_graph given the current scope tree.
 
-        This adds a single DataStraemer to the current sensor graph
+        This adds a single DataStreamer to the current sensor graph
 
         Args:
             sensor_graph (SensorGraph): The sensor graph that we are building or

--- a/iotilesensorgraph/iotile/sg/stream.py
+++ b/iotilesensorgraph/iotile/sg/stream.py
@@ -12,7 +12,7 @@ DataStreamSelector: An object that selects a specific stream or a
 # For python 2/3 compatibility using future module
 from builtins import str
 from future.utils import python_2_unicode_compatible, iteritems
-from iotile.core.exceptions import ArgumentError
+from iotile.core.exceptions import ArgumentError, InternalError
 
 
 @python_2_unicode_compatible
@@ -25,6 +25,9 @@ class DataStream(object):
         system (bool): Whether this stream is user defined or
             has global, system-wide meaning.
     """
+
+    ImportantSystemOutputStart = 1024
+    ImportantSystemStorageStart = 1024 + 512
 
     BufferedType = 0
     UnbufferedType = 1
@@ -73,6 +76,37 @@ class DataStream(object):
     @property
     def output(self):
         return self.stream_type == DataStream.OutputType
+
+    @property
+    def important(self):
+        return self.stream_type == DataStream.InputType and self.system and self.stream_id >= DataStream.ImportantSystemOutputStart
+
+    def associated_stream(self):
+        """Return the corresponding output or storage stream for an important system input.
+
+        Certain system inputs are designed as important and automatically
+        copied to output streams without requiring any manual interaction.
+
+        This method returns the corresponding stream for an important system
+        input.  It will raise an InternalError unlesss the self.important
+        property is True.
+
+        Returns:
+            DataStream: The corresponding output or storage stream.
+
+        Raises:
+            InternalError: If this stream is not marked as an important system input.
+        """
+
+        if not self.important:
+            raise InternalError("You may only call autocopied_stream on when DataStream.important is True", stream=self)
+
+        if self.stream_id >= DataStream.ImportantSystemStorageStart:
+            stream_type = DataStream.BufferedType
+        else:
+            stream_type = DataStream.OutputType
+
+        return DataStream(stream_type, self.stream_id, True)
 
     @classmethod
     def FromString(cls, string_rep):

--- a/iotilesensorgraph/iotile/sg/streamer.py
+++ b/iotilesensorgraph/iotile/sg/streamer.py
@@ -2,7 +2,8 @@
 
 from __future__ import unicode_literals, absolute_import, print_function
 from future.utils import viewitems, python_2_unicode_compatible
-from iotile.core.exceptions import ArgumentError
+from iotile.core.hw.reports import IndividualReadingReport, BroadcastReport
+from iotile.core.exceptions import ArgumentError, InternalError
 
 
 @python_2_unicode_compatible
@@ -26,6 +27,8 @@ class DataStreamer(object):
             use to know when to trigger.  Defaults to None in which case the streamer
             triggers on its own.  The combination of automatic and with_other cannot
             be specified.
+        sensor_log (SensorLog): Actually create a StreamWalker to go along with this
+            streamer so that we can check if it's triggered.
     """
 
     KnownTypes = {u'broadcast': 1, u'telegram': 1 << 1, u'synchronous': 1 << 2}
@@ -33,7 +36,7 @@ class DataStreamer(object):
     KnownFormats = {u'individual': 0, u'hashedlist': 1, u'signedlist_userkey': 2, u'signedlist_devicekey': 3}
     KnownFormatCodes = {y: x for x, y in viewitems(KnownFormats)}
 
-    def __init__(self, selector, dest_tile, report_format, automatic, report_type=u'telegram', with_other=None):
+    def __init__(self, selector, dest_tile, report_format, automatic, report_type=u'telegram', with_other=None, sensor_log=None):
         report_format = str(report_format)
         report_type = str(report_type)
 
@@ -49,6 +52,97 @@ class DataStreamer(object):
         self.automatic = automatic
         self.report_type = report_type
         self.with_other = with_other
+        self.walker = None
+
+        if sensor_log is not None:
+            self.walker = sensor_log.create_walker(self.selector)
+
+    def triggered(self, manual=False):
+        """Check if this streamer should generate a report.
+
+        Streamers can be triggered automatically whenever they have data
+        or they can be triggered manually. This method returns True if the
+        streamer is currented triggered.
+
+        A streamer is triggered if it:
+          - (has data AND is automatic) OR
+          - (has data AND is manually triggered)
+
+        Args:
+            manual (bool): Indicate that the streamer has been manually triggered.
+
+        Returns:
+            bool: Whether the streamer can generate a report right now.
+        """
+
+        if self.walker is None:
+            raise InternalError("You can only check if a streamer is triggered if you create it with a SensorLog")
+
+        if not self.automatic and not manual:
+            return False
+
+        return self.walker.count() > 0
+
+    def requires_id(self):
+        """Whether this streamer produces reports that require a report id.
+
+        Returns:
+            bool
+        """
+
+        return self.report_type != u'individual'
+
+    def requires_signing(self):
+        """Whether this streamer produces reports that require a valid auth_chain for signing.
+
+        Returns:
+            bool
+        """
+
+        return self.report_type in (u'signedlist_userkey', u'signedlist_devicekey')
+
+    def build_report(self, device_id, max_size=None, device_uptime=0, report_id=None, auth_chain=None):
+        """Build a report with all of the readings in this streamer.
+
+        This method will produce an IOTileReport subclass and, if necessary,
+        sign it using the passed authentication chain.
+
+        Args:
+            device_id (int): The UUID of the device to generate a report for.
+            max_size (int): Optional maximum number of bytes that the report can be
+            device_uptime (int): The device's uptime to use as the sent timestamp of the report
+            report_id (int): The report id to use if the report type require serialization.
+            auth_chain (AuthChain): An auth chain class to use to sign the report if the report
+                type requires signing.
+
+        Returns:
+            IOTileReport: The report produced with as many readings as possible under max_size.
+
+        Raises:
+            InternalError: If there was no SensorLog passed when this streamer was created.
+            StreamEmptyError: If there is no data to generate a report from.  This can only happen
+                if a call to triggered() returned False.
+            ArgumentError: If the report requires additional metadata that was not passed like a
+                signing key or report_id.
+        """
+
+        if self.walker is None:
+            raise InternalError("You can only check if a streamer is triggered if you create it with a SensorLog")
+
+        if self.requires_signing() and auth_chain is None:
+            raise ArgumentError("You must pass an auth chain to sign this report.")
+
+        if self.requires_id() and report_id is None:
+            raise ArgumentError("You must pass a report_id to serialize this report")
+
+        if self.report_type == 'individual':
+            reading = self.walker.pop()
+            return IndividualReadingReport.FromReadings(device_id, [reading])
+        elif self.report_type == 'broadcast':
+            reading = self.walker.pop()
+            return BroadcastReport.FromReadings(device_id, [reading], device_uptime)
+
+        raise InternalError("Streamer report type is not supported currently", report_type=self.report_type)
 
     def __str__(self):
         manual = "manual " if not self.automatic else ""

--- a/iotilesensorgraph/iotile/sg/streamer_descriptor.py
+++ b/iotilesensorgraph/iotile/sg/streamer_descriptor.py
@@ -12,7 +12,7 @@ from .stream import DataStreamSelector
 from .streamer import DataStreamer
 
 
-def parse_binary_descriptor(bindata):
+def parse_binary_descriptor(bindata, sensor_log=None):
     """Convert a binary streamer descriptor into a string descriptor.
 
     Binary streamer descriptors are 20-byte binary structures that encode all
@@ -24,11 +24,14 @@ def parse_binary_descriptor(bindata):
     Args:
         bindata (bytes): The binary streamer descriptor that we want to
             understand.
+        sensor_log (SensorLog): Optional sensor_log to add this streamer to
+            a an underlying data store.
 
     Returns:
-        DataStreamer: A DataStreamer object representing the streamer.  You
-            can get a useful human readable string by calling str() on the
-            return value.
+        DataStreamer: A DataStreamer object representing the streamer.
+
+        You can get a useful human readable string by calling str() on the
+        return value.
     """
 
     if len(bindata) != 14:
@@ -58,7 +61,7 @@ def parse_binary_descriptor(bindata):
     else:
         raise ArgumentError("Unknown trigger type for streamer", trigger_code=trigger)
 
-    return DataStreamer(selector, dest_id, format_name, auto, type_name, with_other=with_other)
+    return DataStreamer(selector, dest_id, format_name, auto, type_name, with_other=with_other, sensor_log=sensor_log)
 
 
 def create_binary_descriptor(streamer):

--- a/iotilesensorgraph/test/test_datastream.py
+++ b/iotilesensorgraph/test/test_datastream.py
@@ -1,6 +1,8 @@
 """Tests for DataStream objects."""
 
 from builtins import str
+import pytest
+from iotile.core.exceptions import InternalError
 from iotile.sg import DataStream, DataStreamSelector
 
 
@@ -211,3 +213,22 @@ def test_buffered_pluralization():
 
     sel = DataStreamSelector.FromString('all buffered')
     assert str(sel) == 'all buffered'
+
+
+def test_important_inputs():
+    """Make sure we support matching important inputs and outputs."""
+
+    imp_stream = DataStream.FromString('system input 1024')
+    imp_store_stream = DataStream.FromString('system input 1536')
+
+    assert imp_stream.important is True
+    assert imp_store_stream.important is True
+
+    assert imp_stream.associated_stream() == DataStream.FromString('system output 1024')
+    assert imp_store_stream.associated_stream() == DataStream.FromString('system buffered 1536')
+
+    random_stream = DataStream.FromString('unbuffered 1024')
+    assert random_stream.important is False
+
+    with pytest.raises(InternalError):
+        random_stream.associated_stream()

--- a/iotilesensorgraph/test/test_integration/test_complex_gate.py
+++ b/iotilesensorgraph/test/test_integration/test_complex_gate.py
@@ -56,8 +56,8 @@ def test_complex_gate_optimization(complex_gate, complex_gate_opt):
     for x in sim2.trace:
         print("%08d %s: %d" % (x.raw_time, DataStream.FromEncoded(x.stream), x.value))
 
-    assert len(sim1.trace) == 3
-    assert len(sim2.trace) == 3
+    assert len(sim1.trace) == 4
+    assert len(sim2.trace) == 4
     assert sim1.trace == sim2.trace
 
     #Check that number of trigger streamer commands is same for optimized and unoptimized
@@ -105,6 +105,6 @@ def test_user_tick_optimization(usertick_gate, usertick_gate_opt):
     for x in sim2.trace:
         print("%08d %s: %d" % (x.raw_time, DataStream.FromEncoded(x.stream), x.value))
 
-    assert len(sim1.trace) == 3
-    assert len(sim2.trace) == 3
+    assert len(sim1.trace) == 4
+    assert len(sim2.trace) == 4
     assert sim1.trace == sim2.trace

--- a/iotilesensorgraph/test/test_streamer.py
+++ b/iotilesensorgraph/test/test_streamer.py
@@ -1,0 +1,26 @@
+"""Tests of DataStreamer functionality."""
+
+from __future__ import unicode_literals
+from iotile.sg.streamer_descriptor import parse_binary_descriptor, parse_string_descriptor, create_binary_descriptor
+
+
+def test_descriptors():
+    """Make sure we can parse string and binary descriptors."""
+    streamer = parse_string_descriptor('manual realtime streamer on unbuffered 1 to controller')
+    assert str(streamer) == 'manual realtime streamer on unbuffered 1'
+
+    bin_desc = create_binary_descriptor(streamer)
+    streamer2 = parse_binary_descriptor(bin_desc)
+
+    assert streamer2 == streamer
+
+    streamer = parse_string_descriptor('realtime streamer on unbuffered 1 to slot 5 with streamer 0')
+    assert str(streamer) == 'manual realtime streamer on unbuffered 1 to slot 5 with streamer 0'
+
+    streamer = parse_string_descriptor(b'realtime streamer on unbuffered 1 to slot 5 with streamer 0')
+    assert str(streamer) == 'manual realtime streamer on unbuffered 1 to slot 5 with streamer 0'
+
+    bin_desc = create_binary_descriptor(streamer)
+    streamer2 = parse_binary_descriptor(bin_desc)
+
+    assert streamer2 == streamer

--- a/iotilesensorgraph/test/test_streamer.py
+++ b/iotilesensorgraph/test/test_streamer.py
@@ -1,6 +1,5 @@
 """Tests of DataStreamer functionality."""
 
-from __future__ import unicode_literals
 from iotile.sg.streamer_descriptor import parse_binary_descriptor, parse_string_descriptor, create_binary_descriptor
 
 
@@ -17,7 +16,7 @@ def test_descriptors():
     streamer = parse_string_descriptor('realtime streamer on unbuffered 1 to slot 5 with streamer 0')
     assert str(streamer) == 'manual realtime streamer on unbuffered 1 to slot 5 with streamer 0'
 
-    streamer = parse_string_descriptor(b'realtime streamer on unbuffered 1 to slot 5 with streamer 0')
+    streamer = parse_string_descriptor(u'realtime streamer on unbuffered 1 to slot 5 with streamer 0')
     assert str(streamer) == 'manual realtime streamer on unbuffered 1 to slot 5 with streamer 0'
 
     bin_desc = create_binary_descriptor(streamer)


### PR DESCRIPTION
This PR finishes adding basic support for streamers into the sensor-graph subsystem of `ReferenceController` in iotile-emulate.  It finishes support for `add_streamer` and `inspect_streamer` and adds some infrastructure to be able to generate reports from streamers.  Previously they were just plain data models designed to hold a description of the streamer but had no actual ability to use the streamer in any way.

**Remaining Work:**
  - add basic stream manager subsystem that can take reports generated by sensor_graph and stream them out of the device.
  - add support for state dump/restore

Tracked in #550 