### PR TITLE
Improve iotile-gateway performance and prepare awsiot for py3

### DIFF
--- a/iotilecore/iotile/core/hw/reports/parser.py
+++ b/iotilecore/iotile/core/hw/reports/parser.py
@@ -143,6 +143,23 @@ class IOTileReportParser (object):
         fmt = self.known_formats[current_type]
         return fmt(report_data)
 
+    def deserialize_report(self, serialized):
+        """Deserialize a report that has been serialized by calling report.serialize()
+
+        Args:
+            serialized (dict): A serialized report object
+        """
+
+        type_map = self.known_formats
+
+        if serialized['report_format'] not in type_map:
+            raise ArgumentError("Unknown report format in DeserializeReport", format=serialized['report_format'])
+
+        report = type_map[serialized['report_format']](serialized['encoded_report'])
+        report.received_time = serialized['received_time']
+
+        return report
+
     def _handle_report(self, report):
         """Try to emit a report and possibly keep a copy of it
         """
@@ -167,21 +184,3 @@ class IOTileReportParser (object):
             formats[report_format.ReportType] = report_format
 
         return formats
-
-    @classmethod
-    def DeserializeReport(cls, serialized):
-        """Deserialize a report that has been serialized by calling report.serialize()
-
-        Args:
-            serialized (dict): A serialized report object
-        """
-
-        type_map = cls._build_type_map()
-
-        if serialized['report_format'] not in type_map:
-            raise ArgumentError("Unknown report format in DeserializeReport", format=serialized['report_format'])
-
-        report = type_map[serialized['report_format']](serialized['encoded_report'])
-        report.received_time = serialized['received_time']
-
-        return report

--- a/iotilecore/iotile/core/hw/reports/parser.py
+++ b/iotilecore/iotile/core/hw/reports/parser.py
@@ -4,6 +4,7 @@
 import pkg_resources
 from iotile.core.exceptions import ArgumentError
 
+
 class IOTileReportParser (object):
     """Accumulates data from a stream and emits IOTileReports
 

--- a/iotilecore/iotile/core/hw/transport/websocketstream.py
+++ b/iotilecore/iotile/core/hw/transport/websocketstream.py
@@ -11,7 +11,7 @@ from ws4py.client.threadedclient import WebSocketClient
 from iotile.core.hw.exceptions import *
 from iotile.core.exceptions import *
 from iotile.core.hw.commands import RPCCommand
-from iotile.core.hw.reports import IOTileReportParser, BroadcastReport
+from iotile.core.hw.reports import IOTileReportParser, BroadcastReport, IOTileReading
 from .cmdstream import CMDStream
 
 
@@ -23,6 +23,7 @@ class WSIOTileClient(WebSocketClient):
         self.messages = Queue()
         self.binary = True
         self.report_callback = report_callback
+        self.report_parser = IOTileReportParser()
 
     def start(self):
         try:
@@ -69,7 +70,7 @@ class WSIOTileClient(WebSocketClient):
         unpacked_message = self.unpack(message.data)
 
         if 'type' in unpacked_message and unpacked_message['type'] == 'report':
-            report = IOTileReportParser.DeserializeReport(unpacked_message['value'])
+            report = self.report_parser.deserialize_report(unpacked_message['value'])
             self.report_callback(report)
         else:
             self.messages.put(unpacked_message)

--- a/iotilecore/test/test_reports/test_report_parser.py
+++ b/iotilecore/test/test_reports/test_report_parser.py
@@ -101,7 +101,9 @@ class TestReportParser(unittest.TestCase):
         report = IndividualReadingReport(report_data1)
         ser = report.serialize()
 
-        report2 = IOTileReportParser.DeserializeReport(ser)
+        report_parser = IOTileReportParser()
+
+        report2 = report_parser.deserialize_report(ser)
         assert report2.origin == report.origin
         assert report2.received_time == report.received_time
 

--- a/iotilegateway/iotilegateway/main.py
+++ b/iotilegateway/iotilegateway/main.py
@@ -52,3 +52,7 @@ def main():
 
     except Exception:  # pylint: disable=W0703
         log.exception("Fatal error starting gateway")
+
+
+if __name__ == '__main__':
+    main()

--- a/iotilegateway/setup.py
+++ b/iotilegateway/setup.py
@@ -21,7 +21,7 @@ setup(
     version=version.version,
     license="LGPLv3",
     install_requires=[
-        "tornado>=4.4.0,<5.0.0",
+        "tornado>=4.5.0,<5.0.0",
         "iotile-core>=3.0.1",
         "monotonic",
         "msgpack>=0.5.6",

--- a/iotilegateway/tox.ini
+++ b/iotilegateway/tox.ini
@@ -8,7 +8,7 @@ deps=
     pytest-logging
     ../iotilecore
     ../iotiletest
-    tornado>=4.4.0,<5.0.0
+    tornado>=4.5.0,<5.0.0
     futures
 commands=
 	py.test {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ deps =
     linux_only: ./transport_plugins/native_ble
     ./iotile_ext_cloud
     requests-mock
-    tornado>=4.4.0,<5.0.0
+    tornado>=4.5.0,<5.0.0
     py27: futures
     pycryptodome
 commands =

--- a/transport_plugins/awsiot/iotile_transport_awsiot/connection_manager.py
+++ b/transport_plugins/awsiot/iotile_transport_awsiot/connection_manager.py
@@ -1,8 +1,10 @@
 import threading
-import Queue
+import queue
 import logging
-from timeout import TimeoutInterval
+from .timeout import TimeoutInterval
 from iotile.core.exceptions import ArgumentError
+from future.utils import viewitems
+from past.builtins import basestring
 
 class ConnectionAction(object):
     """A generic action handled internally by ConnectionManager
@@ -80,7 +82,7 @@ class ConnectionManager(threading.Thread):
 
         self.id = adapter_id
         self._stop_event = threading.Event()
-        self._actions = Queue.Queue()
+        self._actions = queue.Queue()
         self._connections = {}
         self._int_connections = {}
         self._data_lock = threading.Lock()
@@ -103,7 +105,7 @@ class ConnectionManager(threading.Thread):
 
                 try:
                     action = self._actions.get(timeout=0.1)
-                except Queue.Empty:
+                except queue.Empty:
                     continue
 
                 handler_name = '_{}_action'.format(action.action)
@@ -158,7 +160,7 @@ class ConnectionManager(threading.Thread):
         key = conn_or_int_id
         if isinstance(key, basestring):
             table = self._int_connections
-        elif isinstance(key, (int, long)):
+        elif isinstance(key, int):
             table = self._connections
         else:
             raise ArgumentError("You must supply either an int connection id or a string internal id to _get_connection_state", id=key)
@@ -189,7 +191,7 @@ class ConnectionManager(threading.Thread):
         key = conn_or_int_id
         if isinstance(key, basestring):
             table = self._int_connections
-        elif isinstance(key, (int, long)):
+        elif isinstance(key, int):
             table = self._connections
         else:
             raise ArgumentError("You must supply either an int connection id or a string internal id to _get_connection_state", id=key)
@@ -220,7 +222,7 @@ class ConnectionManager(threading.Thread):
         key = conn_or_int_id
         if isinstance(key, basestring):
             table = self._int_connections
-        elif isinstance(key, (int, long)):
+        elif isinstance(key, int):
             table = self._connections
         else:
             return None
@@ -245,7 +247,7 @@ class ConnectionManager(threading.Thread):
         key = conn_or_int_id
         if isinstance(key, basestring):
             table = self._int_connections
-        elif isinstance(key, (int, long)):
+        elif isinstance(key, int):
             table = self._connections
         else:
             raise ArgumentError("You must supply either an int connection id or a string internal id to _get_connection_state", id=key)
@@ -263,7 +265,7 @@ class ConnectionManager(threading.Thread):
         timeout.
         """
 
-        for conn_id, data in self._connections.iteritems():
+        for conn_id, data in viewitems(self._connections):
             if 'timeout' in data and data['timeout'].expired:
                 if data['state'] == self.Connecting:
                     self.finish_connection(conn_id, False, 'Connection attempt timed out')
@@ -332,7 +334,7 @@ class ConnectionManager(threading.Thread):
 
         # Make sure we are not reusing an id that is currently connected to something
         if self._get_connection_state(conn_id) != self.Disconnected:
-            print self._connections[conn_id]
+            print(self._connections[conn_id])
             callback(conn_id, self.id, False, 'Connection ID is already in use for another connection')
             return
 

--- a/transport_plugins/awsiot/iotile_transport_awsiot/packet_queue.py
+++ b/transport_plugins/awsiot/iotile_transport_awsiot/packet_queue.py
@@ -52,7 +52,7 @@ class PacketQueue(object):
 
         # If this packet is in the past, drop it
         if self._next_expected is not None and sequence < self._next_expected:
-            print "Dropping out of order packet, seq=%d" % sequence
+            print("Dropping out of order packet, seq=%d" % sequence)
             return
 
         self._out_of_order.append((sequence, args))

--- a/transport_plugins/awsiot/test/conftest.py
+++ b/transport_plugins/awsiot/test/conftest.py
@@ -9,7 +9,8 @@ import AWSIoTPythonSDK.MQTTLib
 from iotile.core.hw.hwmanager import HardwareManager
 from iotile.core.dev.registry import ComponentRegistry
 from iotilegateway.gateway import IOTileGateway
-
+from builtins import range
+from future.utils import viewitems
 
 Message = namedtuple('Message', ['topic', 'payload'])
 
@@ -87,7 +88,7 @@ class LocalBroker(object):
                 continue
 
             matched = True
-            for i in xrange(0, len(parts)):
+            for i in range(0, len(parts)):
                 if (parts[i] != list_parts[i]) and list_parts[i] != '+':
                     matched = False
                     break
@@ -111,7 +112,7 @@ class LocalBroker(object):
         if matched_topic in self.listeners:
             msg_obj = Message(topic, message)
 
-            for _, callback in self.listeners[matched_topic].iteritems():
+            for _, callback in viewitems(self.listeners[matched_topic]):
                 callback(self.client, None, msg_obj)
 
         if LocalBroker.expected is not None and LocalBroker.sequence >= self.expected:

--- a/transport_plugins/awsiot/test/test_agent.py
+++ b/transport_plugins/awsiot/test/test_agent.py
@@ -1,4 +1,5 @@
-import Queue
+import queue
+
 from iotile_transport_awsiot.mqtt_client import OrderedAWSIOTClient
 import time
 
@@ -62,7 +63,7 @@ def test_tracing(gateway, hw_man, local_broker):
 
     time.sleep(0.1)
     data = hw_man.dump_trace('raw')
-    assert data == 'Hello world, this is tracing data!'
+    assert data == b'Hello world, this is tracing data!'
 
 
 def test_rpcs(gateway, hw_man, local_broker):
@@ -74,8 +75,8 @@ def test_rpcs(gateway, hw_man, local_broker):
 def test_script(gateway, hw_man, local_broker):
     """Make sure we can send scripts."""
 
-    script = bytes('ab')*10000
-    progs = Queue.Queue()
+    script = bytearray(('ab'*10000).encode('utf-8'))
+    progs = queue.Queue()
     hw_man.connect(3, wait=0.1)
 
     gateway.agents[0].throttle_progress = 0.0
@@ -104,8 +105,8 @@ def test_script(gateway, hw_man, local_broker):
 def test_script_chunking(gateway, hw_man, local_broker):
     """Make sure we can send scripts."""
 
-    script = bytes('a')*1024*80
-    progs = Queue.Queue()
+    script = bytearray(('a'*1024*80).encode('utf-8'))
+    progs = queue.Queue()
     hw_man.connect(3, wait=0.1)
 
     gateway.agents[0].throttle_progress = 0.0
@@ -135,7 +136,7 @@ def test_script_chunking(gateway, hw_man, local_broker):
 def test_script_progress_throttling(gateway, hw_man, local_broker):
     """Make sure progress updates are properly throttled."""
 
-    script = bytes('a')*1024*80
+    script = bytearray(('a'*1024*80).encode('utf-8'))
     progs = []
     hw_man.connect(3, wait=0.1)
 

--- a/transport_plugins/awsiot/tox.ini
+++ b/transport_plugins/awsiot/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27
+envlist = py27, py36
 
 [testenv]
 passenv=APPDATA

--- a/transport_plugins/jlink/iotile_transport_jlink/jlink_background.py
+++ b/transport_plugins/jlink/iotile_transport_jlink/jlink_background.py
@@ -6,12 +6,12 @@ import logging
 import struct
 import time
 from collections import namedtuple
-from Queue import Queue
 from monotonic import monotonic
 from iotile.core.exceptions import ArgumentError, HardwareError
 import iotile_transport_jlink.devices as devices
 from .structures import ControlStructure
 
+from queue import Queue
 
 #pylint:disable=invalid-name;This is not a constant so its name is okay
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Changes are separated in to two commits. The change for performance mostly just moves the repeated call to pkg_resources.load(). Since the report types aren't expected to change on runtime, we can just instantiate the types on import.

For awsiot changes, I fixed all of the py3 test failures and ran them against py2 again to ensure they are still working. There still may be changed behavior that I missed but it should be mostly localized to the awsiot transport plugin, which may be changing significantly anyways.