### PR TITLE
Update RPC and TileBusProxy

### DIFF
--- a/iotilecore/iotile/core/hw/hwmanager.py
+++ b/iotilecore/iotile/core/hw/hwmanager.py
@@ -115,7 +115,8 @@ class HardwareManager:
 
     @classmethod
     def RegisterDevelopmentProxy(cls, proxy_obj):  # pylint: disable=C0103; class methods are capitalized when expected to be invoked on types
-        """Register a proxy object that should be available for local development.
+        """
+        Register a proxy object that should be available for local development.
 
         Often during development, you need to create a virtual iotile device with
         its own proxy object.  It's easy to point CoreTools at the virtual device
@@ -166,6 +167,28 @@ class HardwareManager:
             HardwareManager.DevelopmentApps[app_tag].append((ver_range, quality, app))
 
         HardwareManager.DevelopmentAppNames[app.AppName()] = app
+
+    def load_development_proxy(self, filename):
+        """
+        Load a proxy object instead of having it pre-registered.
+        This loads the proxy for a python file that we want to use in test fixtures
+
+        This is useful for pulling in the TileBusProxyObject-related classes for a test
+        so that they don't need to be tethered to the HardwareManager (i.e. VirtualTile)
+
+
+        Args:
+            filename (str): The proxy module class that should be
+                loaded.
+        """
+
+        proxy_class = self._load_module_classes(filename, TileBusProxyObject)[0]
+
+        name = proxy_class.ModuleName()
+        if name not in HardwareManager.DevelopmentProxies:
+            HardwareManager.DevelopmentProxies[name] = []
+
+        HardwareManager.DevelopmentProxies[name].append(proxy_class)
 
     def _setup_proxies(self):
         """Load in proxy module objects for all of the registered components on this system."""

--- a/iotilecore/iotile/core/hw/proxy/proxy.py
+++ b/iotilecore/iotile/core/hw/proxy/proxy.py
@@ -16,6 +16,7 @@ from time import sleep
 from iotile.core.utilities.packed import unpack
 import struct
 from iotile.core.exceptions import *
+from ..virtual import unpack_rpc_payload
 
 
 class TileBusProxyObject(object):
@@ -59,7 +60,7 @@ class TileBusProxyObject(object):
         try:
             res = self._parse_rpc_result(status, payload, *res_type, command=(feature << 8) | cmd)
             if unpack_flag:
-                return unpack("<%s" % kw["result_format"], res['buffer'])
+                return unpack_rpc_payload("%s" % kw["result_format"], res['buffer'])
 
             return res
         except ModuleBusyError:

--- a/iotilecore/iotile/core/hw/virtual/__init__.py
+++ b/iotilecore/iotile/core/hw/virtual/__init__.py
@@ -6,10 +6,10 @@ from .virtualdevice import VirtualIOTileDevice
 from .common_types import (tile_rpc, RPCDispatcher, RPCInvalidIDError,
                            RPCNotFoundError, RPCInvalidArgumentsError,
                            RPCInvalidReturnValueError, TileNotFoundError,
-                           RPCErrorCode)
+                           RPCErrorCode, unpack_rpc_payload)
 from .virtualinterface import VirtualIOTileInterface
 
 __all__ = ['VirtualTile', 'VirtualIOTileDevice', 'tile_rpc',
            'RPCDispatcher', 'RPCInvalidIDError', 'TileNotFoundError',
            'RPCNotFoundError', 'RPCInvalidArgumentsError',
-           'RPCInvalidReturnValueError', 'RPCErrorCode', 'VirtualIOTileInterface']
+           'RPCInvalidReturnValueError', 'RPCErrorCode', 'VirtualIOTileInterface', 'unpack_rpc_payload']

--- a/iotilecore/iotile/core/hw/virtual/virtualtile.py
+++ b/iotilecore/iotile/core/hw/virtual/virtualtile.py
@@ -5,8 +5,6 @@ import os
 import imp
 import inspect
 import pkg_resources
-from iotile.core.hw.proxy.proxy import TileBusProxyObject
-from iotile.core.hw.hwmanager import HardwareManager
 from iotile.core.exceptions import ExternalError, ArgumentError
 from .base_runnable import BaseRunnable
 from .common_types import tile_rpc, RPCDispatcher
@@ -135,12 +133,6 @@ class VirtualTile(BaseRunnable, RPCDispatcher):
             raise ArgumentError("No VirtualTiles subclasses were defined in script", path=script_path)
         elif len(devs) > 1:
             raise ArgumentError("More than one VirtualTiles subclass was defined in script", path=script_path, tiles=devs)
-
-        # Allow automatically injecting associated proxy objects so that we can use this tile with a proxy without
-        # installing it.
-        proxies = [x for x in itervalues(mod.__dict__) if inspect.isclass(x) and issubclass(x, TileBusProxyObject) and x != TileBusProxyObject]
-        for proxy in proxies:
-            HardwareManager.RegisterDevelopmentProxy(proxy)
 
         return devs[0]
 

--- a/iotilecore/test/test_hw/test_virtualadapter.py
+++ b/iotilecore/test/test_hw/test_virtualadapter.py
@@ -78,6 +78,8 @@ def tile_based():
         pytest.skip('Cannot pass device config because path has [@,;] in it')
 
     hw = HardwareManager('virtual:tile_based@%s' % conf_file)
+
+    hw.load_development_proxy('test/test_hw/virtual_tile.py')
     yield hw
 
     hw.disconnect()


### PR DESCRIPTION
- RPC calls the new `unpack_rpc_payload` method now

- TileBusProxy dependency removed from VirtualTile. Only functional change for tests is that you need to use the new `load_development_proxy` when using `virtual:` with TileBusProxy objects. 

Tests executed on py2/py3 locally and passing.