### PR TITLE
Fix RPC CommandNotFound exception working around controller bug.

### DIFF
--- a/iotilecore/RELEASE.md
+++ b/iotilecore/RELEASE.md
@@ -2,6 +2,15 @@
 
 All major changes in each released version of `iotile-core` are listed here.
 
+## 3.24.2
+
+- Add a better exception when the return value received from an RPC does not
+  match the format that we expect.  
+
+- Add a workaround for a controller firmware bug so that CommandNotFound 
+  exceptions are properly raised when an RPC does not exist on the controller
+  tile.
+
 ## 3.24.1
 
 - Add 'show_rpcs' command line option to the iotile-updateinfo script to allow

--- a/iotilecore/iotile/core/hw/exceptions.py
+++ b/iotilecore/iotile/core/hw/exceptions.py
@@ -34,5 +34,17 @@ class StreamOperationNotSupportedError(RPCError):
     def __init__(self, **kwargs):
         super(StreamOperationNotSupportedError, self).__init__("Underlying command stream does not support the required operation", **kwargs)
 
+class InvalidReturnValueError(RPCError):
+    """Exception thrown when the return value of an RPC does not conform to its known format."""
+
+    def __init__(self, address, rpc_id, format_code, response, **kwargs):
+        super(InvalidReturnValueError, self).__init__("Invalid return value from Tile %d, RPC 0x%04x, expected format %s, got %d bytes"
+                                                      % (address, rpc_id, format_code, len(response)), **kwargs)
+
+        self.address = address
+        self.rpc_id = rpc_id
+        self.format_code = format_code
+        self.response = response
+
 class UnknownModuleTypeError(iotile.core.exceptions.TypeSystemError):
     pass

--- a/iotilecore/iotile/core/hw/proxy/proxy.py
+++ b/iotilecore/iotile/core/hw/proxy/proxy.py
@@ -64,7 +64,10 @@ class TileBusProxyObject(object):
         try:
             res = self._parse_rpc_result(status, payload, *res_type, command=rpc_id)
             if unpack_flag:
-                return unpack_rpc_payload("%s" % kw["result_format"], res['buffer'])
+                try:
+                    return unpack_rpc_payload("%s" % kw["result_format"], res['buffer'])
+                except struct.error as err:
+                    raise InvalidReturnValueError(self.addr, rpc_id, kw['result_format'], res['buffer'], status=status)
 
             return res
         except ModuleBusyError:
@@ -287,20 +290,25 @@ class TileBusProxyObject(object):
         parsed['status'] = status
         parsed['return_value'] = status & 0b00111111
 
-        #Check for protocol defined errors
+        # Check for protocol defined errors
         if not status & (1<<6):
             if status == 2:
                 raise UnsupportedCommandError(address=self.addr, command=command)
 
             raise RPCError("Unknown status code received from RPC call", address=self.addr, status_code=status)
 
+        # This second check below is a workaround for a lib_controller bug introduced
+        # 9/27/2017 that causes the app_defined status bit to be set for all status
+        # codes that come from a controller.
+        if self.addr == 8 and status == ((1 << 6) | 2):
+            raise UnsupportedCommandError(address=self.addr, command=command)
 
         #Otherwise, parse the results according to the type information given
         size = len(payload)
 
         if size < 2*num_ints:
             raise RPCError('Return value too short to unpack', expected_minimum_size=2*num_ints, actual_size=size, status_code=status, payload=payload)
-        elif buff == False and size != 2*num_ints:
+        elif buff is False and size != 2*num_ints:
             raise RPCError('Return value was not the correct size', expected_size=2*num_ints, actual_size=size, status_code=status, payload=payload)
 
         for i in range(0, num_ints):


### PR DESCRIPTION
Adds a workaround into `iotile-core` for https://github.com/iotile/lib_controller/issues/166.  This will allow us to reliably detect programmatically if an RPC failed because it was not implemented or for another reason.  

This is useful for `synchronize_rtc` in POD-1M v2 since older firmwares won't support that RPC and we want to distinguish that expected failure from an unexpected issue running the RPC itself.