### PR TITLE
Slightly cleanup iotile-emulate code and add support for asynchronous RPCs

### DIFF
--- a/iotilecore/RELEASE.md
+++ b/iotilecore/RELEASE.md
@@ -2,6 +2,11 @@
 
 All major changes in each released version of `iotile-core` are listed here.
 
+## HEAD
+
+- Fix support for STILL_PENDING flag in WorkQueueThread
+- Update AsynchronousRPCResponse exception to not need an `__init__` argument.
+
 ## 3.24.3
 
 - Fix UTCAssigner to properly handle anchor streams and add support for decoding

--- a/iotilecore/iotile/core/hw/reports/utc_assigner.py
+++ b/iotilecore/iotile/core/hw/reports/utc_assigner.py
@@ -120,6 +120,7 @@ class UTCAssigner(object):
         if uptime is None and utc is None:
             return
 
+        ##FIXME: if uptime is None, this will break
         if uptime & (1 << 31):
             if utc is not None:
                 return

--- a/iotilecore/iotile/core/hw/reports/utc_assigner.py
+++ b/iotilecore/iotile/core/hw/reports/utc_assigner.py
@@ -120,8 +120,7 @@ class UTCAssigner(object):
         if uptime is None and utc is None:
             return
 
-        ##FIXME: if uptime is None, this will break
-        if uptime & (1 << 31):
+        if uptime is not None and uptime & (1 << 31):
             if utc is not None:
                 return
 

--- a/iotilecore/iotile/core/hw/transport/adapterstream.py
+++ b/iotilecore/iotile/core/hw/transport/adapterstream.py
@@ -198,10 +198,10 @@ class AdapterCMDStream(CMDStream):
         if self.connection_interrupted:
             self._try_reconnect()
 
+        self.adapter.periodic_callback()
+
         if not success:
             raise HardwareError("Could not send RPC", reason=result['failure_reason'])
-
-        self.adapter.periodic_callback()
 
         return status, payload
 

--- a/iotilecore/iotile/core/hw/virtual/common_types.py
+++ b/iotilecore/iotile/core/hw/virtual/common_types.py
@@ -41,7 +41,8 @@ class RPCErrorCode(IOTileException):
 class AsynchronousRPCResponse(IOTileException):
     """Exception thrown from an RPC implementation when it will return asynchronously."""
 
-    pass
+    def __init__(self):
+        super(AsynchronousRPCResponse, self).__init__("RPC handler elected to return asynchronously")
 
 
 def _create_argcode(code, arg_bytes):

--- a/iotilecore/iotile/core/hw/virtual/common_types.py
+++ b/iotilecore/iotile/core/hw/virtual/common_types.py
@@ -30,11 +30,18 @@ class TileNotFoundError(IOTileException):
     """Exception thrown when an RPC is sent to a tile that does not exist."""
     pass
 
+
 class RPCErrorCode(IOTileException):
     """Exception thrown from an RPC implementation to set the status code."""
 
     def __init__(self, status_code):
         super(RPCErrorCode, self).__init__("RPC returned application defined status code %d" % status_code, code=status_code)
+
+
+class AsynchronousRPCResponse(IOTileException):
+    """Exception thrown from an RPC implementation when it will return asynchronously."""
+
+    pass
 
 
 def _create_argcode(code, arg_bytes):

--- a/iotilecore/iotile/core/utilities/workqueue_thread.py
+++ b/iotilecore/iotile/core/utilities/workqueue_thread.py
@@ -6,7 +6,7 @@ import sys
 from collections import namedtuple
 from queue import Queue
 from future.utils import raise_
-from iotile.core.exceptions import TimeoutExpiredError
+from iotile.core.exceptions import TimeoutExpiredError, DataError
 
 STOP_WORKER_ITEM = object()
 MarkLocationItem = namedtuple('MarkLocationItem', ['callback'])
@@ -39,11 +39,21 @@ class WorkQueueThread(threading.Thread):
       was called have been processed.
 
     Args:
-        handler (callable): The handler function that will be pasesd all of the
+        handler (callable): The handler function that will be passed all of the
             work items queued in dispatch() and should return a result that will
             be the return value of dispatch().  If this function throws an exception,
             it will be rethrown from dispatch.
     """
+
+    STILL_PENDING = object()
+    """Special return value from handler to indicate callback should be deferred.
+
+    This allows the background handler function to store away a callback
+    and call it in the future if it needs to.  The handler can inspect
+    the callback by calling current_callback(), which will raise an
+    exception if not called while an item is being dispatched.
+    """
+
 
     def __init__(self, handler):
         super(WorkQueueThread, self).__init__()
@@ -51,7 +61,28 @@ class WorkQueueThread(threading.Thread):
 
         self._routine = handler
         self._work_queue = Queue()
+        self._current_item = None
         self._logger = logging.getLogger(__name__)
+
+    def current_callback(self):
+        """Get the current callback from a handler function.
+
+        This method allows a handler to get the callback that would
+        be called when it returns.  It is only useful to use in
+        conjunction with the STILL_PENDING return value so that the
+        handler can store the callback away and call it later when
+        a long-running operation has finished.
+
+        Returns:
+            callable: The callback function associated with the current work item.
+
+            This will be None if there was no callback passed.
+        """
+
+        if self._current_item is None:
+            raise DataError("WorkQueueThread.current_callback() called while a work item was not executing")
+
+        return self._current_item.callback
 
     def dispatch(self, value, callback=None):
         """Dispatch an item to the workqueue and optionally wait.
@@ -225,14 +256,18 @@ class WorkQueueThread(threading.Thread):
                     continue
 
                 try:
+                    self._current_item = item
+
                     exc_info = None
                     retval = None
 
                     retval = self._routine(item.arg)
                 except:  #pylint:disable=bare-except;We need to capture the exception and feed it back to the caller
                     exc_info = sys.exc_info()
+                finally:
+                    self._current_item = None
 
-                if item.callback is not None:
+                if item.callback is not None and retval is not STILL_PENDING:
                     item.callback(exc_info, retval)
             except:  #pylint:disable=bare-except;We cannot let this background thread die until we are told to stop()
                 self._logger.exception("Error inside background workqueue thread")

--- a/iotilecore/iotile/core/utilities/workqueue_thread.py
+++ b/iotilecore/iotile/core/utilities/workqueue_thread.py
@@ -267,7 +267,7 @@ class WorkQueueThread(threading.Thread):
                 finally:
                     self._current_item = None
 
-                if item.callback is not None and retval is not STILL_PENDING:
+                if item.callback is not None and retval is not self.STILL_PENDING:
                     item.callback(exc_info, retval)
             except:  #pylint:disable=bare-except;We cannot let this background thread die until we are told to stop()
                 self._logger.exception("Error inside background workqueue thread")

--- a/iotileemulate/RELEASE.md
+++ b/iotileemulate/RELEASE.md
@@ -4,6 +4,9 @@ All major changes in each released version of iotile-emulate are listed here.
 
 ## HEAD
 
+- Cleanup and slightly refactor reset code.  Improve reset behavior to be more
+  synchronous.
+
 - Add support for EmulatedDevice and EmulatedTile classes.  These classes allow
   for the creation of virtual devices that emulate physical devices with support
   for state snapshotting to save/load device state and test scenarios to allow

--- a/iotileemulate/RELEASE.md
+++ b/iotileemulate/RELEASE.md
@@ -7,6 +7,13 @@ All major changes in each released version of iotile-emulate are listed here.
 - Cleanup and slightly refactor reset code.  Improve reset behavior to be more
   synchronous.
 
+- Add support for asynchronous RPCs.
+
+- Update the DemoDevice to have an async rpc implementation on the peripheral
+  tile to test the async rpc implementation.
+
+## 0.0.1
+
 - Add support for EmulatedDevice and EmulatedTile classes.  These classes allow
   for the creation of virtual devices that emulate physical devices with support
   for state snapshotting to save/load device state and test scenarios to allow

--- a/iotileemulate/iotile/emulate/constants/rpc_clockmanager.py
+++ b/iotileemulate/iotile/emulate/constants/rpc_clockmanager.py
@@ -107,7 +107,7 @@ Returns:
   - uint32_t: The current UTC or uptime.
 """
 
-GET_CURRENT_UPTIME = RPCDeclaration(0x1001, "", "L")
+GET_CURRENT_UPTIME = RPCDeclaration(0x100f, "", "L")
 """Get the current uptime of the device.
 
 This RPC will always return  the number of seconds since the device last reset

--- a/iotileemulate/iotile/emulate/demo/demo_device.py
+++ b/iotileemulate/iotile/emulate/demo/demo_device.py
@@ -1,7 +1,26 @@
 """A simple emulated reference device that includes a blank non-controller tile."""
 
+from iotile.core.hw.virtual import tile_rpc
+from iotile.core.hw.virtual.common_types import AsynchronousRPCResponse, pack_rpc_payload
 from ..virtual import EmulatedPeripheralTile
 from ..reference import ReferenceDevice
+
+
+class DemoEmulatedTile(EmulatedPeripheralTile):
+    """A basic demo emulated tile with an async rpc."""
+
+    @tile_rpc(0x8000, "L", "L")
+    def async_echo(self, arg):
+        """Asynchronously echo the argument number."""
+
+        self._device.deferred_task(self._device.finish_async_rpc, self.address, 0x8000, pack_rpc_payload("L", (arg,)), sync=False)
+        raise AsynchronousRPCResponse()
+
+    @tile_rpc(0x8001, "L", "L")
+    def sync_echo(self, arg):
+        """Synchronously echo the argument number."""
+
+        return [arg]
 
 
 class DemoEmulatedDevice(ReferenceDevice):
@@ -26,7 +45,7 @@ class DemoEmulatedDevice(ReferenceDevice):
     def __init__(self, args):
         super(DemoEmulatedDevice, self).__init__(args)
 
-        peripheral = EmulatedPeripheralTile(11, 'abcdef', device=self)
+        peripheral = DemoEmulatedTile(11, 'abcdef', device=self)
         peripheral.declare_config_variable('test 1', 0x8000, 'uint32_t')
         peripheral.declare_config_variable('test 2', 0x8001, 'uint8_t[16]')
 

--- a/iotileemulate/iotile/emulate/reference/controller_features/clock_manager.py
+++ b/iotileemulate/iotile/emulate/reference/controller_features/clock_manager.py
@@ -259,7 +259,7 @@ class ClockManagerMixin(object):
 
         return [time]
 
-    @tile_rpc(*rpcs.GET_CURRENT_TIME)
+    @tile_rpc(*rpcs.GET_CURRENT_UPTIME)
     def get_current_uptime(self):
         """Get the device's current time."""
 

--- a/iotileemulate/iotile/emulate/reference/controller_features/config_database.py
+++ b/iotileemulate/iotile/emulate/reference/controller_features/config_database.py
@@ -78,7 +78,6 @@ class ConfigEntry(object):
         return ConfigEntry(target, var_id, data, valid)
 
 
-
 class ConfigDatabase(SerializableState):
     """Emulated state of the config database.
 

--- a/iotileemulate/iotile/emulate/reference/controller_features/sensor_graph.py
+++ b/iotileemulate/iotile/emulate/reference/controller_features/sensor_graph.py
@@ -49,12 +49,9 @@ it to emulate how you interact with sensor-graph in a physical IOTile based
 device.
 
 TODO:
-  - [X] Add SG_QUERY_STREAMER
-  - [X] Add SG_TRIGGER_STREAMER
-  - [X] Add SG_SEEK_STREAMER
   - [ ] Add dump/restore support
   - [ ] Add clock manager integration
-  - [X] Add stream manager integration
+  - [ ] Add support for logging information on reset
 """
 
 import logging
@@ -62,11 +59,11 @@ import struct
 from future.utils import viewitems
 from iotile.core.hw.virtual import tile_rpc, RPCErrorCode
 from iotile.core.hw.reports import IOTileReading
-from iotile.sg import DataStream, DataStreamSelector, SensorGraph
+from iotile.sg import DataStream, SensorGraph
 from iotile.sg.node_descriptor import parse_binary_descriptor, create_binary_descriptor
 from iotile.sg import streamer_descriptor
 from iotile.sg.exceptions import NodeConnectionError, ProcessingFunctionError, ResourceUsageError, UnresolvedIdentifierError, StreamEmptyError
-from ...constants import rpcs, pack_error, Error, ControllerSubsystem, streams, SensorGraphError, SensorLogError
+from ...constants import rpcs, pack_error, Error, ControllerSubsystem, SensorGraphError, SensorLogError
 
 def _pack_sgerror(short_code):
     """Pack a short error code with the sensorgraph subsystem."""
@@ -385,8 +382,6 @@ class SensorGraphMixin(object):
         stream_man (StreamManager): The stream manager subsystem
         model (DeviceModel): A device model containing resource limits about the
             emulated device.
-        mutex (threading.Lock): A shared mutex from the sensor_log subsystem to
-            use to make sure we only access it from a single thread at a time.
     """
 
     def __init__(self, sensor_log, stream_manager, model):

--- a/iotileemulate/iotile/emulate/reference/reference_controller.py
+++ b/iotileemulate/iotile/emulate/reference/reference_controller.py
@@ -99,6 +99,8 @@ class ReferenceController(RawSensorLogMixin, RemoteBridgeMixin,
             for system in self._post_config_subsystems:
                 system.clear_to_reset(config_assignments)
 
+            self._logger.info("Finished clearing controller to reset condition")
+
         if deferred:
             self._device.deferred_task(_post_config_setup)
         else:
@@ -116,15 +118,16 @@ class ReferenceController(RawSensorLogMixin, RemoteBridgeMixin,
         peripheral tiles on reset for a clean boot.
         """
 
+        self._logger.info("Resetting controller")
+        self._device.reset_count += 1
+
         super(ReferenceController, self)._handle_reset()
 
         self._clear_to_reset_condition(deferred=True)
-
-        self._logger.info("Controller tile has finished resetting itself and will now reset each tile")
-        self._device.reset_peripheral_tiles()
+        self._device.deferred_task(self._device.reset_peripheral_tiles)
 
     def start(self, channel=None):
-        """Start this conrtoller tile.
+        """Start this controller tile.
 
         This resets the controller to its reset state.
 
@@ -192,7 +195,6 @@ class ReferenceController(RawSensorLogMixin, RemoteBridgeMixin,
     def reset(self):
         """Reset the device."""
 
-        self._device.reset_count += 1
         self._handle_reset()
 
         raise TileNotFoundError("Controller tile was reset via an RPC")

--- a/iotileemulate/iotile/emulate/reference/reference_device.py
+++ b/iotileemulate/iotile/emulate/reference/reference_device.py
@@ -133,6 +133,7 @@ class ReferenceDevice(EmulatedDevice):
         consistent atomic restoration process.
 
         This method will block while the background restore happens.
+
         Args:
             state (dict): A previously dumped state produced by dump_state.
         """

--- a/iotileemulate/iotile/emulate/reference/reference_device.py
+++ b/iotileemulate/iotile/emulate/reference/reference_device.py
@@ -6,7 +6,7 @@ from future.utils import viewitems
 from past.builtins import basestring
 from iotile.core.exceptions import ArgumentError, DataError
 from ..virtual import EmulatedDevice, EmulatedPeripheralTile
-from ..constants import rpcs
+from ..constants import rpcs, RunLevel
 from .reference_controller import ReferenceController
 
 
@@ -77,8 +77,7 @@ class ReferenceDevice(EmulatedDevice):
                 continue
 
             # Check and make sure that if the tile should start that it has started
-            # FIXME: Remove hardcoded run level constant
-            if tile.run_level != 2:
+            if tile.run_level != RunLevel.SAFE_MODE:
                 tile.wait_started(timeout=2.0)
 
         self.wait_idle()

--- a/iotileemulate/iotile/emulate/reference/reference_device.py
+++ b/iotileemulate/iotile/emulate/reference/reference_device.py
@@ -4,7 +4,7 @@ import base64
 import logging
 from future.utils import viewitems
 from past.builtins import basestring
-from iotile.core.exceptions import ArgumentError, DataError, InternalError
+from iotile.core.exceptions import ArgumentError, DataError
 from ..virtual import EmulatedDevice, EmulatedPeripheralTile
 from ..constants import rpcs
 from .reference_controller import ReferenceController
@@ -77,6 +77,7 @@ class ReferenceDevice(EmulatedDevice):
                 continue
 
             # Check and make sure that if the tile should start that it has started
+            # FIXME: Remove hardcoded run level constant
             if tile.run_level != 2:
                 tile.wait_started(timeout=2.0)
 
@@ -84,6 +85,8 @@ class ReferenceDevice(EmulatedDevice):
 
     def reset_peripheral_tiles(self):
         """Reset all peripheral tiles (asynchronously)."""
+
+        self._logger.info("Resetting all peripheral tiles")
 
         for address in sorted(self._tiles):
             if address == 8:

--- a/iotileemulate/iotile/emulate/transport/emulatedadapter.py
+++ b/iotileemulate/iotile/emulate/transport/emulatedadapter.py
@@ -110,3 +110,22 @@ class EmulatedDeviceAdapter(VirtualDeviceAdapter):
         """
 
         callback(conn_id, self.id, True, None)
+
+    def periodic_callback(self):
+        """Periodic callback task.
+
+        This task is called periodically when this device adapter is attached
+        to an iotile-gateway and called at specific points in time when it
+        is attached to an AdapterStream.
+
+        The primary task that we need to do for emulated devices is to call
+        wait_idle() to make sure that they finish any pending background work.
+
+        This is particularly useful for ensuring that reset RPCs happen
+        synchronously without needing a delay.
+        """
+
+        super(EmulatedDeviceAdapter, self).periodic_callback()
+
+        for dev in itervalues(self.devices):
+            dev.wait_idle()

--- a/iotileemulate/iotile/emulate/virtual/emulated_device.py
+++ b/iotileemulate/iotile/emulate/virtual/emulated_device.py
@@ -78,8 +78,6 @@ class EmulatedDevice(EmulationMixin, VirtualIOTileDevice):
 
         address, rpc_id, arg_payload = action
 
-        # FIXME: Check for a queued RPC and return busy
-
         try:
             # Send the RPC immediately and wait for the response
             resp = super(EmulatedDevice, self).call_rpc(address, rpc_id, arg_payload)

--- a/iotileemulate/iotile/emulate/virtual/emulated_tile.py
+++ b/iotileemulate/iotile/emulate/virtual/emulated_tile.py
@@ -9,7 +9,7 @@ from past.builtins import basestring
 from future.utils import viewitems, viewvalues
 from iotile.core.exceptions import ArgumentError, DataError
 from iotile.core.hw.virtual import VirtualTile
-from iotile.core.hw.virtual import tile_rpc
+from iotile.core.hw.virtual import tile_rpc, TileNotFoundError
 from .emulated_device import EmulatedDevice
 from .emulation_mixin import EmulationMixin
 from ..constants import rpcs, Error
@@ -289,7 +289,6 @@ class EmulatedTile(EmulationMixin, VirtualTile):
 
         return {desc.name: desc.latch() for desc in viewvalues(self._config_variables)}
 
-
     def dump_state(self):
         """Dump the current state of this emulated tile as a dictionary.
 
@@ -338,6 +337,7 @@ class EmulatedTile(EmulationMixin, VirtualTile):
         """Reset this tile."""
 
         self._handle_reset()
+        raise TileNotFoundError("tile was reset via an RPC")
 
     @tile_rpc(*rpcs.LIST_CONFIG_VARIABLES)
     def list_config_variables(self, offset):

--- a/iotileemulate/test/test_clock.py
+++ b/iotileemulate/test/test_clock.py
@@ -120,7 +120,7 @@ def test_tick_inputs(basic_device):
     assert key_parts_4 == list(zip(range(5, 11, 5), range(5, 11, 5)))
 
 
-@pytest.mark.xfail(reason="synchronize_clock is still in prerelease")
+#@pytest.mark.xfail(reason="synchronize_clock is still in prerelease")
 def test_utc_time(basic_device):
     """Make sure we can get and set utc time."""
 
@@ -131,16 +131,19 @@ def test_utc_time(basic_device):
 
     test_time = datetime.datetime(2018, 11, 11, 16, 0, 0)
     zero = datetime.datetime(1970, 1, 1)
+    y2k_zero = datetime.datetime(2000, 1, 1)
 
     device.controller.clock_manager.handle_tick()
 
     delta = (test_time - zero).total_seconds()
+    y2k_delta = (test_time - y2k_zero).total_seconds()
 
     test_interface.synchronize_clock(delta)
     device_time = test_interface.current_time()
     device_uptime = test_interface.get_uptime()
     info = test_interface.get_timeoffset()
 
-    assert device_time == 0x5
-    assert device_uptime == 0
-    assert info == {'is_utc': True, 'offset': int(delta) - 1}
+    assert device_time & (1 << 31)
+    assert (device_time & ~(1 << 31)) == int(y2k_delta)
+    assert device_uptime == 1
+    assert info == {'is_utc': True, 'offset': int(y2k_delta) - 1}

--- a/iotileemulate/test/test_clock.py
+++ b/iotileemulate/test/test_clock.py
@@ -120,7 +120,6 @@ def test_tick_inputs(basic_device):
     assert key_parts_4 == list(zip(range(5, 11, 5), range(5, 11, 5)))
 
 
-#@pytest.mark.xfail(reason="synchronize_clock is still in prerelease")
 def test_utc_time(basic_device):
     """Make sure we can get and set utc time."""
 

--- a/iotileemulate/test/test_emulatedadapter.py
+++ b/iotileemulate/test/test_emulatedadapter.py
@@ -1,5 +1,6 @@
 """Tests for the EmulatedDeviceAdapter class."""
 
+from __future__ import print_function
 import json
 from iotile.core.hw import HardwareManager
 
@@ -89,3 +90,34 @@ def test_saving_changes(tmpdir):
         debug.save_changes(str(change_file))
 
     assert change_file.exists()
+
+
+def test_async_rpc():
+    """Make sure we can send an asynchronous rpc."""
+
+    with HardwareManager(port='emulated:emulation_demo') as hw:
+        hw.connect(1)
+
+        proxy = hw.get(11, basic=True)
+
+        # This RPC is async
+        echo, = proxy.rpc_v2(0x8000, "L", "L", 5)
+        assert echo == 5
+
+        # This RPC is sync
+        echo, = proxy.rpc_v2(0x8001, "L", "L", 6)
+        assert echo == 6
+
+
+def test_racefree_reset():
+    """Make sure we can reset at will."""
+
+    with HardwareManager(port='emulated:emulation_demo') as hw:
+        hw.connect(1)
+
+        proxy = hw.get(8, basic=True)
+
+        for i in range(0, 10):
+            print("starting reset %d" % i)
+            proxy.reset(wait=0)
+            print("finished reset %d" % i)

--- a/iotileemulate/test/test_emulation.py
+++ b/iotileemulate/test/test_emulation.py
@@ -1,5 +1,6 @@
 """Tests of various utilities used in IOTileDevice emulation."""
 
+from __future__ import print_function
 import pytest
 from iotile.core.exceptions import DataError, ArgumentError
 from iotile.emulate.virtual.emulated_tile import parse_size_name, ConfigDescriptor
@@ -82,7 +83,7 @@ def test_unsupported_type():
     """Make sure we throw en error if we have an unknown python type."""
 
     with pytest.raises(ArgumentError):
-        desc = ConfigDescriptor(0x8000, 'uint8_t', default=b'\0', python_type="unsupported")
+        ConfigDescriptor(0x8000, 'uint8_t', default=b'\0', python_type="unsupported")
 
 
 @pytest.mark.parametrize("type_name, default_value, latched_value, python_type, expected_exc", [


### PR DESCRIPTION
This PR merges some slight code cleanup of `iotile-emulate` that I had on a side branch and finishes initial support for asynchronous RPCs, which are RPCs whose handler function returns without giving a response.  From the caller's point of view, all RPCs (including these) are synchronous, so the caller remains blocked, however the actual response value is provided via a callback on `EmulatedDevice.finish_async_rpc` rather than the return value of the rpc handler itself.

This is an important feature for emulating many real-world tiles that extensively use asynchronous rpcs.

**Additional changes:**

- The reset handling logic of the emulator is slightly refactored to remove some race conditions
- The `EmulatedDeviceAdapter` is updated so that a device reset happens synchronously by the time a `reset` rpc returns.  This is important because it allows for race free unit tests that involve emulated device resets.  In physical devices there is a 1 second delay to give the device time to actually reset, which would be very slow in a unit testing context.  With this change, the delay is not needed for emulated devices and resets should now be race-free.
- Fixes to `WorkQueueThread` to properly allow for deferring the response to a work item.  This is the underlying feature used by asynchronous rpcs.
- Explicit checks for programming errors that would cause deadlocks are adding using a thread-local variable to determine if code is running on the rpc execution thread, which cannot block on an rpc or sychronously attempt to execute an rpc.