### PR TITLE
Consolidate all extension importing code into a single place in iotile-core

### DIFF
--- a/iotilecore/RELEASE.md
+++ b/iotilecore/RELEASE.md
@@ -4,6 +4,9 @@ All major changes in each released version of `iotile-core` are listed here.
 
 ## HEAD
 
+- Consolidate entry point related code into ComponentRegistry with a single
+  implementation of extension finding and importing.  Remove now redundant
+  reimplementations of the same code.
 - Fix support for STILL_PENDING flag in WorkQueueThread
 - Update AsynchronousRPCResponse exception to not need an `__init__` argument.
 

--- a/iotilecore/iotile/core/dev/__init__.py
+++ b/iotilecore/iotile/core/dev/__init__.py
@@ -1,2 +1,7 @@
-# This file is copyright Arch Systems, Inc.  
+# This file is copyright Arch Systems, Inc.
 # Except as otherwise provided in the relevant LICENSE file, all rights are reserved.
+
+from .iotileobj import IOTile
+from .registry import ComponentRegistry
+
+__all__ = ['IOTile', 'ComponentRegistry']

--- a/iotilecore/iotile/core/dev/iotileobj.py
+++ b/iotilecore/iotile/core/dev/iotileobj.py
@@ -20,6 +20,7 @@ _ProductDeclaration = namedtuple('_ProductDeclaration', ['dev_path', 'release_pa
 _ReleaseOnlyProduct = _ProductDeclaration(r"${release}/${product}", r"${release}/${product}", None)
 _DevOnlyProduct = _ProductDeclaration(r"${module}/${product}", r"${module}/${product}", None)
 
+
 class IOTile(object):
     """
     IOTile
@@ -298,7 +299,7 @@ class IOTile(object):
 
     def _check_has_wheel(self):
         for prod in self.PYTHON_PRODUCTS:
-            if self.find_products(prod) > 0:
+            if len(self.find_products(prod)) > 0:
                 return True
 
         return False

--- a/iotilecore/iotile/core/dev/iotileobj.py
+++ b/iotilecore/iotile/core/dev/iotileobj.py
@@ -22,11 +22,35 @@ _DevOnlyProduct = _ProductDeclaration(r"${module}/${product}", r"${module}/${pro
 
 
 class IOTile(object):
-    """
-    IOTile
+    """Object representing an IOTile component that implements or extends CoreTools.
 
-    A python representation of an IOTile module allowing you to inspect the products
-    that its build produces and include it as a dependency in another build process.
+    IOTile components are "projects" in the sense of traditional IDEs,
+    "packages" in nodejs or "distributions" in python.  They are single
+    directories that contain related code and a metadata file that describes
+    what the project is and how to use it.
+
+    Since IOTile components describe building blocks for IOT devies, they do not
+    contain code in a single language but could describe a variety of different
+    kinds of artifacts such as:
+
+    - firmware images
+    - python extensions for CoreTools
+    - build automation steps used in hardware manufacturing
+    - emulators for specific IOTile devices
+
+    The unifying concepts that extend to all of the above finds of components are
+    that they product "artifacts" through a build process, the entire component
+    has a single version and it can have dependencies on other components.
+
+    There is a single file inside the root of the component directory,
+    `module_settings.json` that contains all of this metadata.
+
+    The `IOTile` object is constructed from a `module_settings.json` file and
+    provides helper routines to parse and search its contents.
+
+    Args:
+        folder (str): The path to a folder containing a `module_settings.json`
+            file that will be loaded into this IOTile object.
     """
 
     V1_FORMAT = "v1"
@@ -489,12 +513,11 @@ class IOTile(object):
         return []
 
     def filter_products(self, desired_prods):
-        """
-        When asked for a product that this iotile produces, filter only those on this list
-        """
+        """When asked for a product, filter only those on this list."""
 
         self.filter_prods = True
         self.desired_prods = set(desired_prods)
 
     def path(self):
+        """The path to this component."""
         return self.folder

--- a/iotilecore/iotile/core/dev/registry.py
+++ b/iotilecore/iotile/core/dev/registry.py
@@ -159,7 +159,6 @@ class ComponentRegistry(object):
 
             found_extensions.extend((name, x) for x in self._filter_subclasses(ext, class_filter))
 
-
         for (name, ext) in self._registered_extensions.get(group, []):
             if name_filter is not None and name != name_filter:
                 continue

--- a/iotilecore/iotile/core/dev/registry.py
+++ b/iotilecore/iotile/core/dev/registry.py
@@ -1,17 +1,21 @@
 # This file is copyright Arch Systems, Inc.
 # Except as otherwise provided in the relevant LICENSE file, all rights are reserved.
 
+import os.path
+import sys
+import logging
+import imp
+import inspect
+from types import ModuleType
+from future.utils import itervalues
+from past.builtins import basestring
+
 from iotile.core.utilities.kvstore_sqlite import SQLiteKVStore
 from iotile.core.utilities.kvstore_json import JSONKVStore
 from iotile.core.utilities.kvstore_mem import InMemoryKVStore
-from iotile.core.exceptions import *
+from iotile.core.exceptions import ArgumentError
 from iotile.core.utilities.paths import settings_directory
-import json
-import os.path
 from .iotileobj import IOTile
-import pkg_resources
-import imp
-import sys
 
 MISSING = object()
 
@@ -27,20 +31,34 @@ class ComponentRegistry(object):
     BackingType = SQLiteKVStore
     BackingFileName = 'component_registry.db'
 
+    _registered_extensions = {}
+
     def __init__(self):
-        self.kvstore = self.BackingType(self.BackingFileName, respect_venv=True)
+        self._kvstore = None
         self._plugins = None
+        self._logger = logging.getLogger(__name__)
+
+    @property
+    def kvstore(self):
+        """Lazily load the underlying key-value store backing this registry."""
+
+        if self._kvstore is None:
+            self._kvstore = self.BackingType(self.BackingFileName, respect_venv=True)
+
+        return self._kvstore
 
     @property
     def plugins(self):
         """Lazily load iotile plugins only on demand.
 
-        This is a slow operation on computers with a slow FS and
-        is rarely accessed information, so only compute it when it
-        is actually asked for.
+        This is a slow operation on computers with a slow FS and is rarely
+        accessed information, so only compute it when it is actually asked
+        for.
         """
 
         if self._plugins is None:
+            import pkg_resources
+
             self._plugins = {}
 
             for entry in pkg_resources.iter_entry_points('iotile.plugin'):
@@ -50,6 +68,169 @@ class ComponentRegistry(object):
                     self._plugins[name] = value
 
         return self._plugins
+
+    def load_extensions(self, group, name_filter=None, class_filter=None, product_name=None):
+        """Dynamically load and return extension objects of a given type.
+
+        This is the centralized way for all parts of CoreTools to allow plugin
+        behavior.  Whenever a plugin is needed, this method should be called
+        to load it.  Examples of plugins are proxy modules, emulated tiles,
+        iotile-build autobuilders, etc.
+
+        Each kind of plugin will typically be a subclass of a certain base class
+        and can be provided one of three ways:
+
+        1. It can be registered as an entry point in a pip installed package.
+           The entry point group must map the group passed to load_extensions.
+        2. It can be listed as a product of an IOTile component that is stored
+           in this ComponentRegistry.  The relevant python file inside the
+           component will be imported dynamically as needed.
+        3. It can be programmatically registered by calling ``register_extension()``
+           on this class with a string name and an object.  This is equivalent to
+           exposing that same object as an entry point with the given name.
+
+        There is special behavior of this function if class_filter is passed
+        and the object returned by one of the above three methods is a python
+        module. The module will be search for object definitions that match
+        the defined class.
+
+        Args:
+            group (str): The extension type that you wish to enumerate.  This
+                will be used as the entry_point group for searching pip
+                installed packages.
+            name_filter (str): Only return objects with the given name
+            class_filter (type or tuple of types): An object that will be passed to
+                instanceof() to verify that all extension objects have the correct
+                types.  If not passed, no checking will be done.
+            product_name (str): If this extension can be provided by a registered
+                local component, the name of the product that should be loaded.
+
+        Returns:
+            list of (str, object): A list of the found and loaded extension objects.
+
+            The string returned with each extension is the name of the
+            entry_point or the base name of the file in the component or the
+            value provided by the call to register_extension depending on how
+            the extension was found.
+        """
+
+        found_extensions = []
+
+        import pkg_resources
+
+        for entry in pkg_resources.iter_entry_points(group):
+            name = entry.name
+
+            if name_filter is not None and name != name_filter:
+                continue
+
+            ext = entry.load()
+
+            found_extensions.extend((name, x) for x in self._filter_subclasses(ext, class_filter))
+
+        if product_name is not None:
+            for comp in self.iter_components():
+                products = comp.find_products(product_name)
+                for product in products:
+                    try:
+                        entries = self.load_extension(product, name_filter=name_filter, class_filter=class_filter)
+
+                        if len(entries) == 0:
+                            self._logger.warn("Found no valid extensions in product %s of component %s", product, comp.path)
+                            continue
+
+                        found_extensions.extend(entries)
+                    except:  #pylint:disable=bare-except;We don't want a broken extension to take down the whole system
+                        self._logger.exception("Unable to load extension %s from local component %s at path %s", product_name, comp, product)
+
+        for (name, ext) in self._registered_extensions.get(group, []):
+
+            if name_filter is not None and name != name_filter:
+                continue
+
+            found_extensions.extend((name, x) for x in self._filter_subclasses(ext, class_filter))
+
+        return found_extensions
+
+    def register_extension(self, group, name, extension):
+        """Register an extension.
+
+        Args:
+            group (str): The type of the extension
+            name (str): A name for the extension
+            extension (str or class): If this is a string, then it will be
+                interpreted as a path to import and load.  Otherwise it
+                will be treated as the extension object itself.
+        """
+
+        if isinstance(extension, basestring):
+            name, extension = self.load_extension(extension)[0]
+
+        if group not in self._registered_extensions:
+            self._registered_extensions[group] = []
+
+        self._registered_extensions[group].append((name, extension))
+
+    def clear_extensions(self, group=None):
+        """Clear all previously registered extensions."""
+
+        if group is None:
+            self._registered_extensions = {}
+            return
+
+        if group in self._registered_extensions:
+            self._registered_extensions[group] = []
+
+    def load_extension(self, path, name_filter=None, class_filter=None, unique=False):
+        """Load a single python module extension.
+
+        This function is similar to using the imp module directly to load a
+        module and potentially inspecting the objects it declares to filter
+        them by class.
+
+        Args:
+            path (str): The path to the python file to load
+            name_filter (str): If passed, the basename of the module must match
+                name or nothing is returned.
+            class_filter (type): If passed, only instance of this class are returned.
+            unique (bool): If True (default is False), there must be exactly one object
+                found inside this extension that matches all of the other criteria.
+
+        Returns:
+            list of (name, type): A list of the objects found at the extension path.
+
+            If unique is True, then the list only contains a single entry and that
+            entry will be directly returned.
+        """
+
+        name, ext = _try_load_module(path)
+
+        if name_filter is not None and name != name_filter:
+            return []
+
+        found = [(name, x) for x in self._filter_subclasses(ext, class_filter)]
+        if not unique:
+            return found
+
+        if len(found) > 1:
+            raise ArgumentError("Extension %s should have had exactly one instance of class %s, found %d" % (path, class_filter.__name__, len(found)), classes=found)
+        elif len(found) == 0:
+            raise ArgumentError("Extension %s had no instances of class %s" % (path, class_filter.__name__))
+
+        return found[0]
+
+    def _filter_subclasses(self, obj, class_filter):
+        if class_filter is None:
+            return [obj]
+
+        if isinstance(obj, ModuleType):
+            return [x for x in itervalues(obj.__dict__) if inspect.isclass(x) and issubclass(x, class_filter) and x != class_filter]
+
+        if inspect.isclass(obj) and issubclass(obj, class_filter):
+            return [obj]
+
+        self._logger.warn("Found no valid extension objects in %s, sought subclasses of %s", obj, class_filter)
+        return []
 
     @classmethod
     def SetBackingStore(cls, backing):
@@ -138,11 +319,19 @@ class ComponentRegistry(object):
 
         return [x[0] for x in items if not x[0].startswith('config:')]
 
+    def iter_components(self):
+        """Iterate over all defined components yielding IOTile objects."""
+
+        names = self.list_components()
+
+        for name in names:
+            yield self.get_component(name)
+
     def list_config(self):
         """List all of the configuration variables
         """
         items = self.kvstore.get_all()
-        cfgitems = ["{0}={1}".format(x[0][len('config:'):],x[1]) 
+        cfgitems = ["{0}={1}".format(x[0][len('config:'):],x[1])
                 for x in items if x[0].startswith('config:')]
         return cfgitems
 
@@ -222,6 +411,58 @@ def _check_registry_type(folder=None):
             ComponentRegistry.SetBackingStore(data)
     except IOError:
         pass
+
+
+def _try_load_module(path):
+    """Try to programmatically load a python module by path.
+
+    Path should point to a python file (optionally without the .py) at the
+    end.  If it ends in a :<name> then name must point to an object defined in
+    the module, which is returned instead of the module itself.
+
+    Args:
+        path (str): The path of the module to load
+
+    Returns:
+        str, object: The basename of the module loaded and the requested object.
+    """
+
+    obj_name = None
+    if len(path) > 2 and ':' in path[2:]:  # Don't flag windows C: type paths
+        path, _, obj_name = path.rpartition(":")
+
+    folder, basename = os.path.split(path)
+    if folder == '':
+        folder = './'
+
+    if basename == '' or not os.path.exists(path):
+        raise ArgumentError("Could not find python module to load extension", path=path)
+
+    basename, ext = os.path.splitext(basename)
+    if ext not in (".py", ".pyc", ""):
+        raise ArgumentError("Attempted to load module is not a python package or module (.py or .pyc)", path=path)
+
+    try:
+        fileobj = None
+        fileobj, pathname, description = imp.find_module(basename, [folder])
+
+        #Don't load modules twice
+        if basename in sys.modules:
+            mod = sys.modules[basename]
+        else:
+            mod = imp.load_module(basename, fileobj, pathname, description)
+
+        if obj_name is not None:
+            if obj_name not in mod.__dict__:
+                raise ArgumentError("Cannot find named object '%s' inside module '%s'" % (obj_name, basename), path=path)
+
+            mod = mod.__dict__[obj_name]
+
+        return (basename, mod)
+    finally:
+        if fileobj is not None:
+            fileobj.close()
+
 
 # Update our default registry backing store appropriately
 _check_registry_type()

--- a/iotilecore/iotile/core/hw/hwmanager.py
+++ b/iotilecore/iotile/core/hw/hwmanager.py
@@ -8,17 +8,10 @@
 '''This file contains necessary functionality to manage the Hardware'''
 
 from builtins import range
-from functools import reduce
 import time
-import inspect
-import os.path
-import imp
 import binascii
-import sys
 import logging
 from queue import Empty
-import pkg_resources
-from future.utils import itervalues
 from typedargs.annotate import annotated, param, return_type, finalizer, docannotate, context
 
 from iotile.core.dev.semver import SemanticVersion
@@ -66,11 +59,6 @@ class HardwareManager(object):
 
     """
 
-    # Allow overriding proxies for development by adding them to this shared proxy map
-    DevelopmentProxies = {}
-    DevelopmentApps = {}
-    DevelopmentAppNames = {}
-
     logger = logging.getLogger(__name__)
 
     @param("port", "string", desc="transport method to use in the format transport[:port[,connection_string]]")
@@ -110,103 +98,16 @@ class HardwareManager(object):
         self._setup_proxies()
         self._setup_apps()
 
-    @classmethod
-    def RegisterDevelopmentProxy(cls, proxy_obj):  # pylint: disable=C0103; class methods are capitalized when expected to be invoked on types
-        """
-        Register a proxy object that should be available for local development.
-
-        Often during development, you need to create a virtual iotile device with
-        its own proxy object.  It's easy to point CoreTools at the virtual device
-        in order to test it, but there did not use to be a good way to load in
-        its proxy object.  This method allows the user to inject a development
-        proxy module to use with the virtual device.
-
-        Args:
-            proxy_obj (TileBusProxyObject): The proxy module class that should be
-                registered.
-        """
-
-        name = proxy_obj.ModuleName()
-
-        if name not in HardwareManager.DevelopmentProxies:
-            HardwareManager.DevelopmentProxies[name] = []
-
-        HardwareManager.DevelopmentProxies[name].append(proxy_obj)
-
-    @classmethod
-    def ClearDevelopmentApps(cls):
-        """Clear all development apps previously registered."""
-
-        cls.DevelopmentAppNames = {}
-        cls.DevelopmentApps = {}
-
-    @classmethod
-    def RegisterDevelopmentApp(cls, app):  # pylint: disable=C0103; class methods are capitalized when expected to be invoked on types
-        """Register an IOTileApp object that should be available for local development.
-
-        Often during development, you need to create a virtual iotile device with
-        its own app object.  It's easy to point CoreTools at the virtual device
-        in order to test it, but there did not use to be a good way to load in
-        its app object.  This method allows the user to inject a development
-        app module to use with the virtual device.
-
-        Args:
-            app (TileBusApp): The app module class that should be
-                registered.
-        """
-
-        matches = app.MatchInfo()
-
-        for (app_tag, ver_range, quality) in matches:
-            if app_tag not in HardwareManager.DevelopmentApps:
-                HardwareManager.DevelopmentApps[app_tag] = []
-
-            HardwareManager.DevelopmentApps[app_tag].append((ver_range, quality, app))
-
-        HardwareManager.DevelopmentAppNames[app.AppName()] = app
-
-    def load_development_proxy(self, filename):
-        """
-        Load a proxy object instead of having it pre-registered.
-        This loads the proxy for a python file that we want to use in test fixtures
-
-        This is useful for pulling in the TileBusProxyObject-related classes for a test
-        so that they don't need to be tethered to the HardwareManager (i.e. VirtualTile)
-
-
-        Args:
-            filename (str): The proxy module class that should be
-                loaded.
-        """
-
-        proxy_class = self._load_module_classes(filename, TileBusProxyObject)[0]
-
-        name = proxy_class.ModuleName()
-        if name not in HardwareManager.DevelopmentProxies:
-            HardwareManager.DevelopmentProxies[name] = []
-
-        HardwareManager.DevelopmentProxies[name].append(proxy_class)
-
     def _setup_proxies(self):
         """Load in proxy module objects for all of the registered components on this system."""
 
         # Find all of the registered IOTile components and see if we need to add any proxies for them
         reg = ComponentRegistry()
-        modules = reg.list_components()
+        proxy_classes = reg.load_extensions('iotile.proxy', class_filter=TileBusProxyObject, product_name="proxy_module")
 
-        proxies = reduce(lambda x, y: x+y, [reg.find_component(x).proxy_modules() for x in modules], [])
-        proxy_classes = []
-        for prox in proxies:
-            proxy_classes += self._load_module_classes(prox, TileBusProxyObject)
-
-        # Find all installed proxy objects through registered entry points
-        for entry in pkg_resources.iter_entry_points('iotile.proxy'):
-            mod = entry.load()
-            proxy_classes += [x for x in itervalues(mod.__dict__) if inspect.isclass(x) and issubclass(x, TileBusProxyObject) and x != TileBusProxyObject]
-
-        for obj in proxy_classes:
+        for _name, obj in proxy_classes:
             if obj.__name__ in self._proxies:
-                continue #Don't readd proxies that we already know about
+                continue
 
             self._proxies[obj.__name__] = obj
 
@@ -219,25 +120,15 @@ class HardwareManager(object):
                 else:
                     self._name_map[short_name] = [obj]
             except Exception:  #pylint: disable=broad-except;We don't want this to die if someone loads a misbehaving plugin
-                self.logger.exception("Error importing misbehaving proxy module, skipping.")
+                self.logger.exception("Error importing misbehaving proxy object %s, skipping.", obj)
 
     def _setup_apps(self):
         """Load in all iotile app objects for all registered or installed components on this system."""
 
         reg = ComponentRegistry()
-        modules = reg.list_components()
+        app_classes = reg.load_extensions('iotile.app', class_filter=IOTileApp, product_name="app_module")
 
-        apps = reduce(lambda x, y: x+y, [reg.find_component(x).app_modules() for x in modules], [])
-        app_classes = []
-        for app in apps:
-            app_classes += self._load_module_classes(app, IOTileApp)
-
-        # Find all installed proxy objects through registered entry points
-        for entry in pkg_resources.iter_entry_points('iotile.app'):
-            mod = entry.load()
-            app_classes += [x for x in itervalues(mod.__dict__) if inspect.isclass(x) and issubclass(x, IOTileApp) and x != IOTileApp]
-
-        for app in app_classes:
+        for _name, app in app_classes:
             try:
                 matches = app.MatchInfo()
                 name = app.AppName()
@@ -252,7 +143,7 @@ class HardwareManager(object):
 
                 self._named_apps[name] = app
             except Exception:  #pylint: disable=broad-except;We don't want this to die if someone loads a misbehaving plugin
-                self.logger.exception("Error importing misbehaving app module, skipping.")
+                self.logger.exception("Error importing misbehaving app module %s, skipping.", app)
 
     @param("address", "integer", "positive", desc="numerical address of module to get")
     @param("basic", "bool", desc="return a basic global proxy rather than a specialized one")
@@ -322,24 +213,14 @@ class HardwareManager(object):
 
         # If name includes a .py, assume that it points to python file and try to load that.
         if name is None and path is not None:
-            loaded_classes = self._load_module_classes(path, IOTileApp)
-            if len(loaded_classes) > 1:
-                raise ArgumentError("app called with a python file that contained more than one IOTileApp class", classes=loaded_classes)
-            elif len(loaded_classes) == 0:
-                raise ArgumentError("app called with a python file that did not contain any IOTileApp subclasses")
-
-            app_class = loaded_classes[0]
+            _name, app_class = ComponentRegistry().load_extension(path, class_filter=IOTileApp, unique=True)
         elif name is not None:
-            if name in self.DevelopmentAppNames:
-                app_class = self.DevelopmentAppNames[name]
-            else:
-                app_class = self._named_apps.get(name)
+            app_class = self._named_apps.get(name)
         else:
             best_match = None
             matching_tags = self._known_apps.get(app_tag, [])
-            dev_tags = self.DevelopmentApps.get(app_tag, [])
 
-            for (ver_range, quality, app) in matching_tags + dev_tags:
+            for (ver_range, quality, app) in matching_tags:
                 if ver_range.check(app_version):
                     if best_match is None:
                         best_match = (quality, app)
@@ -848,30 +729,6 @@ class HardwareManager(object):
         """Close the current AdapterStream"""
         self.stream.close()
 
-    @classmethod
-    def _load_module_classes(cls, path, base_class):
-        """Load a python module and return all classes that inherit from a given base."""
-
-        folder, basename = os.path.split(path)
-        basename, ext = os.path.splitext(basename)
-        if ext not in (".py", ".pyc", ""):
-            raise ArgumentError("Attempted to load module is not a python package or module (.py or .pyc)", path=path)
-
-        try:
-            fileobj, pathname, description = imp.find_module(basename, [folder])
-
-            #Don't load modules twice
-            if basename in sys.modules:
-                mod = sys.modules[basename]
-            else:
-                mod = imp.load_module(basename, fileobj, pathname, description)
-        except ImportError as exc:
-            cls.logger.exception("Error importing module: %s looking for class %s", path, base_class)
-            raise ArgumentError("Could not import module in order to load external proxy modules", module_path=path, parent_directory=folder, module_name=basename, error=str(exc))
-
-        # Find all classes in this module that inherit from the given base class
-        return [x for x in itervalues(mod.__dict__) if inspect.isclass(x) and issubclass(x, base_class) and x != base_class]
-
     @return_type("list(basic_dict)")
     @param("wait", "float", desc="Time to wait for devices to show up before returning")
     @param("sort", "string", desc="Sort scan results by a key named key")
@@ -911,9 +768,6 @@ class HardwareManager(object):
         If no proxy type is found, return None.
         """
 
-        if short_name in HardwareManager.DevelopmentProxies:
-            return HardwareManager.DevelopmentProxies[short_name][0]
-
         if short_name not in self._name_map:
             return None
 
@@ -951,19 +805,12 @@ class HardwareManager(object):
             return CMDStream(port, conn_string, record=self._record)
 
         #Next attempt to find a CMDStream that is registered for this transport type
-        for stream_entry in pkg_resources.iter_entry_points('iotile.cmdstream'):
-            if stream_entry.name != self.transport:
-                continue
-
-            stream_factory = stream_entry.load()
+        reg = ComponentRegistry()
+        for _name, stream_factory in reg.load_extensions('iotile.cmdstream', name_filter=self.transport):
             return stream_factory(port, conn_string, record=self._record)
 
         #Otherwise attempt to find a DeviceAdapter that we can turn into a CMDStream
-        for adapter_entry in pkg_resources.iter_entry_points('iotile.device_adapter'):
-            if adapter_entry.name != self.transport:
-                continue
-
-            adapter_factory = adapter_entry.load()
+        for _name, adapter_factory in reg.load_extensions('iotile.device_adapter', name_filter=self.transport):
             return AdapterCMDStream(adapter_factory(port), port, conn_string, record=self._record)
 
         raise HardwareError("Could not find transport object registered to handle passed transport type", transport=self.transport)

--- a/iotilecore/iotile/core/hw/proxy/external_proxy.py
+++ b/iotilecore/iotile/core/hw/proxy/external_proxy.py
@@ -4,50 +4,10 @@
 # external_proxy.py
 # Routines for importing proxy modules from registered components on your computer
 
-import os
-import imp
-import inspect
-import sys
-from future.utils import itervalues
-import pkg_resources
 from iotile.core.dev.registry import ComponentRegistry
-from .proxy import TileBusProxyObject
+from iotile.core.exceptions import DataError
 from .plugin import TileBusProxyPlugin
-from iotile.core.exceptions import *
 
-
-def find_proxy(component, proxy_name=None, obj_type=TileBusProxyObject):
-    """
-    Search through the registered component data base for a proxy or proxy plugin module provided by
-    a specific component optionally having a specific name.
-
-    Proxy modules must inherit from TileBusProxyObject. Proxy plugin modules must inherit from TileBusProxyPlugin
-    """
-
-    # Find all of the registered IOTile components and see if we need to add any proxies for them
-    reg = ComponentRegistry()
-    comp = reg.find_component(component)
-
-    proxies = comp.proxy_modules()
-    if len(proxies) != 1:
-        raise DataError("Attempting to find proxy module from component that does not provide exactly 1 proxy", proxies=proxies)
-
-    proxy_mod = proxies[0]
-
-    proxy_objs = import_proxy(proxy_mod, obj_type)
-
-    if len(proxy_objs) == 0:
-        raise DataError("Specified component did not define any proxies but said that it did provide them", component=component)
-    elif len(proxy_objs) > 1 and proxy_name is None:
-        raise DataError("Sepcific component defined multiple proxy objects and a name was not specified", component=component, proxies=proxy_objs)
-    elif len(proxy_objs) == 1 and proxy_name is None:
-        return proxy_objs[0]
-
-    for obj in proxy_objs:
-        if obj.__name__ == proxy_name:
-            return obj
-
-    raise DataError("Named proxy could not be found", component=component, proxies=proxy_objs, desired_name=proxy_name)
 
 def find_proxy_plugin(component, plugin_name):
     """ Attempt to find a proxy plugin provided by a specifc component
@@ -57,61 +17,16 @@ def find_proxy_plugin(component, plugin_name):
         plugin_name (string): The name of the plugin to load
 
     Returns:
-        TileBuxProxPlugin: The plugin, if found, otherwise raises DataError
+        TileBuxProxyPlugin: The plugin, if found, otherwise raises DataError
     """
 
     reg = ComponentRegistry()
 
-    #Try to find plugin in an installed component, otherwise look through installed
-    #packages
-    try:
-        comp = reg.find_component(component)
+    plugins = reg.load_extensions('iotile.proxy_plugin', comp_filter=component, class_filter=TileBusProxyPlugin,
+                                  product_name='proxy_plugin')
 
-        plugins = comp.proxy_plugins()
-
-        for plugin in plugins:
-            objs = import_proxy(plugin, TileBusProxyPlugin)
-            for obj in objs:
-                if obj.__name__ == plugin_name:
-                    return obj
-    except ArgumentError:
-        pass
-
-    for entry in pkg_resources.iter_entry_points('iotile.proxy_plugin'):
-        module = entry.load()
-        objs = [obj for obj in itervalues(module.__dict__) if inspect.isclass(obj) and issubclass(obj, TileBusProxyPlugin) and obj != TileBusProxyPlugin]
-        for obj in objs:
-            if obj.__name__ == plugin_name:
-                return obj
+    for _name, plugin in plugins:
+        if plugin.__name__ == plugin_name:
+            return plugin
 
     raise DataError("Could not find proxy plugin module in registered components or installed distributions", component=component, name=plugin_name)
-
-def import_proxy(path, obj_type):
-    """
-    Add all proxy objects defined in the python module located at path.
-
-    The module is loaded and all classes that inherit from the given object type
-    are loaded and can be used to interact later with modules of that type.
-
-    Returns the total number of proxies added.
-    """
-
-    d,p = os.path.split(path)
-
-    p,ext = os.path.splitext(p)
-    if ext != '.py' and ext != '.pyc' and ext != "":
-        raise ArgumentError("Passed proxy module is not a python package or module (.py or .pyc)", path=path)
-
-    try:
-        fileobj,pathname,description = imp.find_module(p, [d])
-
-        #Don't import twice if we've already imported this module
-        if p in sys.modules:
-            mod = sys.modules[p]
-        else:
-            mod = imp.load_module(p, fileobj, pathname, description)
-    except ImportError as e:
-        raise ArgumentError("could not import module in order to load external proxy modules", module_path=path, parent_directory=d, module_name=p, error=str(e))
-
-    num_added = 0
-    return [obj for obj in itervalues(mod.__dict__) if inspect.isclass(obj) and issubclass(obj, obj_type) and obj != obj_type]

--- a/iotilecore/test/test_dev/comp_w_products/module_settings.json
+++ b/iotilecore/test/test_dev/comp_w_products/module_settings.json
@@ -1,0 +1,49 @@
+{
+    "file_format": "v2",
+    "module_name": "tile_1",
+
+    "targets": ["nrf52832"],
+    "module_version": "3.7.9",
+
+    "products":
+    {
+        "libcontroller_nrf52832.a": "library",
+        "link.ld": "linker_script",
+        "controller_nrf52832.elf": "firmware_image",
+        "python/proxy.py": "proxy_module",
+        "python/app.py": "app_module",
+        "python/buildstep.py:MyStep": "build_step",
+        "python/sensorgraph.py": "proxy_plugin",
+        "python/configmanager.py": "proxy_plugin",
+        "python/controllertest.py": "proxy_plugin",
+        "python/tilemanager.py": "proxy_plugin",
+        "python/remotebridge.py": "proxy_plugin",
+        "python/lib_controller_types": "type_package",
+        "tilebus_definitions":
+        [
+            ["test_interface", "test_interface.bus"],
+            ["tilebus", "tb_fabric.bus"],
+            ["tile_manager", "tile_manager.bus"],
+            ["tile_manager", "config_vars.bus"],
+            ["sensor_graph", "sensor_graph.bus"],
+            ["remote_bridge", "remote_bridge.bus"],
+            ["clock_manager", "clock_manager.bus"],
+            "version/version.bus"
+        ],
+        "include_directories":
+        [
+            "tilebus",
+            ["stream_manager", "include"],
+            ["clock_manager"],
+            ["external_components"],
+            ["state_manager"],
+            ["tile_manager"],
+            ["modules"],
+            ["sensor_graph"],
+            ["state_manager"],
+            ["remote_bridge"],
+            ["version"],
+            ["."]
+        ]
+    }
+}

--- a/iotilecore/test/test_dev/releasemode_comp_w_prod/module_settings.json
+++ b/iotilecore/test/test_dev/releasemode_comp_w_prod/module_settings.json
@@ -1,0 +1,54 @@
+{
+    "file_format": "v2",
+    "module_name": "tile_1",
+
+    "targets": ["nrf52832"],
+    "module_version": "3.7.9",
+
+    "release": true,
+	"release_date": "2016-10-11 02:37:21",
+	"dependency_versions": {
+	},
+
+    "products":
+    {
+        "libcontroller_nrf52832.a": "library",
+        "controller_nrf52832.elf": "firmware_image",
+        "link.ld": "linker_script",
+        "python/proxy.py": "proxy_module",
+        "python/app.py": "app_module",
+        "python/buildstep.py:MyStep": "build_step",
+        "python/sensorgraph.py": "proxy_plugin",
+        "python/configmanager.py": "proxy_plugin",
+        "python/controllertest.py": "proxy_plugin",
+        "python/tilemanager.py": "proxy_plugin",
+        "python/remotebridge.py": "proxy_plugin",
+        "python/lib_controller_types": "type_package",
+        "tilebus_definitions":
+        [
+            ["test_interface", "test_interface.bus"],
+            ["tilebus", "tb_fabric.bus"],
+            ["tile_manager", "tile_manager.bus"],
+            ["tile_manager", "config_vars.bus"],
+            ["sensor_graph", "sensor_graph.bus"],
+            ["remote_bridge", "remote_bridge.bus"],
+            ["clock_manager", "clock_manager.bus"],
+            "version/version.bus"
+        ],
+        "include_directories":
+        [
+            "tilebus",
+            ["stream_manager"],
+            ["clock_manager"],
+            ["external_components"],
+            ["state_manager"],
+            ["tile_manager"],
+            ["modules"],
+            ["sensor_graph"],
+            ["state_manager"],
+            ["remote_bridge"],
+            ["version"],
+            ["."]
+        ]
+    }
+}

--- a/iotilecore/test/test_dev/test_iotile.py
+++ b/iotilecore/test/test_dev/test_iotile.py
@@ -363,6 +363,13 @@ def test_build_step_finding():
     assert tile_rel.find_products('build_step') == tile_rel.build_steps()
 
 
+def test_unicode_finding():
+    """Make sure unicode strings work in find_products()."""
+
+    tile_dev = load_tile('comp_w_products')
+    assert tile_dev.find_products('app_module') == tile_dev.find_products(u'app_module')
+
+
 def test_app_module_finding():
     """Make sure we can find app modules."""
 

--- a/iotilecore/test/test_dev/test_iotile.py
+++ b/iotilecore/test/test_dev/test_iotile.py
@@ -1,9 +1,10 @@
-from iotile.core.dev.iotileobj import IOTile, SemanticVersion
-from iotile.core.exceptions import DataError
+from __future__ import print_function
 import pytest
 import datetime
 from dateutil.tz import tzutc
 import os
+from iotile.core.dev.iotileobj import IOTile, SemanticVersion
+from iotile.core.exceptions import DataError
 
 
 def load_tile(name):
@@ -11,6 +12,13 @@ def load_tile(name):
     path = os.path.join(parent, name)
 
     return IOTile(path)
+
+
+def relative_paths(paths):
+    """Get relative paths to this test file."""
+
+    basedir = os.path.dirname(__file__)
+    return [os.path.relpath(x, start=basedir) for x in paths]
 
 
 def test_load_releasemode():
@@ -97,6 +105,7 @@ def test_builtnewstyle_component():
     assert tile.can_release is False
     assert tile.release_date == datetime.datetime(2018, 3, 15, 14, 42, tzinfo=tzutc())
 
+
 def test_load_invaliddepends():
     with pytest.raises(DataError) as excinfo:
         _tile = load_tile('comp_w_depslist')
@@ -173,3 +182,233 @@ def test_depfinding_overlays():
     assert 'dep3' in deps
     assert 'dep4' in deps
     assert 'dep5' in deps
+
+
+def test_basic_product_finding():
+    """Make sure find_products works."""
+
+
+    tile_dev = load_tile('comp_w_products')
+    tile_rel = load_tile('releasemode_comp_w_prod')
+
+    assert tile_dev.release is False
+    assert tile_rel.release is True
+
+    assert tile_dev.find_products('random_type') == []
+    assert tile_rel.find_products('random_type') == []
+
+    # Make sure unicode works
+    assert tile_dev.find_products('include_directories') == tile_dev.find_products(u'include_directories')
+
+
+def test_include_product_finding():
+    """Make sure finding include_directories works."""
+
+    tile_dev = load_tile('comp_w_products')
+    tile_rel = load_tile('releasemode_comp_w_prod')
+
+    assert tile_dev.release is False
+    assert tile_rel.release is True
+
+    assert tile_dev.find_products('random_type') == []
+    assert tile_rel.find_products('random_type') == []
+
+    # Test include_path finding
+    inc_dev = tile_dev.find_products('include_directories')
+    inc_rel = tile_rel.find_products('include_directories')
+
+    assert len(inc_dev) == 12
+    assert len(inc_rel) == 12
+
+    rel_inc_dev = relative_paths(inc_dev)
+    rel_inc_rel = relative_paths(inc_rel)
+
+    for rel_dev, rel_rel in zip(rel_inc_dev, rel_inc_rel):
+        assert rel_dev.startswith(os.path.join("comp_w_products", "build", "output", "include"))
+        assert rel_rel.startswith(os.path.join("releasemode_comp_w_prod", "include"))
+
+    assert tile_dev.include_directories() == inc_dev
+    assert tile_rel.include_directories() == inc_rel
+
+
+def test_library_finding():
+    """Make sure finding libraries works."""
+
+    tile_dev = load_tile('comp_w_products')
+
+    lib_dev = tile_dev.find_products('library')
+    assert len(lib_dev) == 1
+
+    assert lib_dev == ['libcontroller_nrf52832.a']
+
+    libs = tile_dev.libraries()
+    assert libs == ['controller_nrf52832.a']
+
+
+def test_type_package_finding():
+    """Make sure we can find type packages."""
+
+    tile_dev = load_tile('comp_w_products')
+    tile_rel = load_tile('releasemode_comp_w_prod')
+
+    dev_types = tile_dev.find_products('type_package')
+    rel_types = tile_rel.find_products('type_package')
+
+    assert len(dev_types) == 1
+    assert len(rel_types) == 1
+
+    assert relative_paths(dev_types) == [os.path.join('comp_w_products', 'python', 'lib_controller_types')]
+    assert relative_paths(rel_types) == [os.path.join('releasemode_comp_w_prod', 'python', 'lib_controller_types')]
+
+    assert tile_dev.find_products('type_package') == tile_dev.type_packages()
+    assert tile_rel.find_products('type_package') == tile_rel.type_packages()
+
+
+def test_tilebus_definition_finding():
+    """Make sure we can find tilebus definitions."""
+
+    tile_dev = load_tile('comp_w_products')
+    tile_rel = load_tile('releasemode_comp_w_prod')
+
+    dev_bus = tile_dev.find_products('tilebus_definitions')
+    rel_bus = tile_rel.find_products('tilebus_definitions')
+
+    assert len(dev_bus) == 8
+    assert len(rel_bus) == 8
+
+    rel_dev = relative_paths(dev_bus)
+    rel_rel = relative_paths(rel_bus)
+
+    # Test one list definition and one string definition
+    assert rel_dev[0] == os.path.join('comp_w_products', 'firmware', 'src', 'test_interface', 'test_interface.bus')
+    assert rel_rel[0] == os.path.join('releasemode_comp_w_prod', 'tilebus', 'test_interface.bus')
+
+    assert rel_dev[-1] == os.path.join('comp_w_products', 'firmware', 'src', 'version', 'version.bus')
+    assert rel_rel[-1] == os.path.join('releasemode_comp_w_prod', 'tilebus', 'version.bus')
+
+
+def test_firmware_image_finding():
+    """Make sure we can find firmware images."""
+
+    tile_dev = load_tile('comp_w_products')
+    tile_rel = load_tile('releasemode_comp_w_prod')
+
+    dev_fw = tile_dev.find_products('firmware_image')
+    rel_fw = tile_rel.find_products('firmware_image')
+
+    assert len(dev_fw) == 1
+    assert len(rel_fw) == 1
+
+    assert relative_paths(dev_fw) == [os.path.join("comp_w_products", "build", "output", "controller_nrf52832.elf")]
+    assert relative_paths(rel_fw) == [os.path.join("releasemode_comp_w_prod", "controller_nrf52832.elf")]
+
+    assert dev_fw == tile_dev.firmware_images()
+    assert rel_fw == tile_rel.firmware_images()
+
+
+def test_linker_script_finding():
+    """Make sure we can find linker scripts."""
+
+    tile_dev = load_tile('comp_w_products')
+    tile_rel = load_tile('releasemode_comp_w_prod')
+
+    dev_ld = tile_dev.find_products('linker_script')
+    rel_ld = tile_rel.find_products('linker_script')
+
+    assert len(dev_ld) == 1
+    assert len(rel_ld) == 1
+
+    assert relative_paths(dev_ld) == [os.path.join("comp_w_products", "build", "output", "linker", "link.ld")]
+    assert relative_paths(rel_ld) == [os.path.join("releasemode_comp_w_prod", "linker", "link.ld")]
+
+    assert dev_ld == tile_dev.linker_scripts()
+    assert rel_ld == tile_rel.linker_scripts()
+
+
+def test_proxy_module_finding():
+    """Make sure we can find proxy_modules."""
+
+    tile_dev = load_tile('comp_w_products')
+    tile_rel = load_tile('releasemode_comp_w_prod')
+
+    dev_types = tile_dev.find_products('proxy_module')
+    rel_types = tile_rel.find_products('proxy_module')
+
+    assert len(dev_types) == 1
+    assert len(rel_types) == 1
+
+    assert relative_paths(dev_types) == [os.path.join('comp_w_products', 'python', 'proxy.py')]
+    assert relative_paths(rel_types) == [os.path.join('releasemode_comp_w_prod', 'python', 'proxy.py')]
+
+    assert tile_dev.find_products('proxy_module') == tile_dev.proxy_modules()
+    assert tile_rel.find_products('proxy_module') == tile_rel.proxy_modules()
+
+
+def test_build_step_finding():
+    """Make sure we can find build steps."""
+
+    tile_dev = load_tile('comp_w_products')
+    tile_rel = load_tile('releasemode_comp_w_prod')
+
+    dev_types = tile_dev.find_products('build_step')
+    rel_types = tile_rel.find_products('build_step')
+
+    assert len(dev_types) == 1
+    assert len(rel_types) == 1
+
+    assert relative_paths(dev_types) == [os.path.join('comp_w_products', 'python', 'buildstep.py:MyStep')]
+    assert relative_paths(rel_types) == [os.path.join('releasemode_comp_w_prod', 'python', 'buildstep.py:MyStep')]
+
+    assert tile_dev.find_products('build_step') == tile_dev.build_steps()
+    assert tile_rel.find_products('build_step') == tile_rel.build_steps()
+
+
+def test_app_module_finding():
+    """Make sure we can find app modules."""
+
+    tile_dev = load_tile('comp_w_products')
+    tile_rel = load_tile('releasemode_comp_w_prod')
+
+    dev_types = tile_dev.find_products('app_module')
+    rel_types = tile_rel.find_products('app_module')
+
+    assert len(dev_types) == 1
+    assert len(rel_types) == 1
+
+    assert relative_paths(dev_types) == [os.path.join('comp_w_products', 'python', 'app.py')]
+    assert relative_paths(rel_types) == [os.path.join('releasemode_comp_w_prod', 'python', 'app.py')]
+
+    assert tile_dev.find_products('app_module') == tile_dev.app_modules()
+    assert tile_rel.find_products('app_module') == tile_rel.app_modules()
+
+
+def test_proxy_plugin_finding():
+    """Make sure we can find proxy_plugins."""
+
+    tile_dev = load_tile('comp_w_products')
+    tile_rel = load_tile('releasemode_comp_w_prod')
+
+    dev_bus = tile_dev.find_products('proxy_plugin')
+    rel_bus = tile_rel.find_products('proxy_plugin')
+
+    assert len(dev_bus) == 5
+    assert len(rel_bus) == 5
+
+    rel_dev = sorted(relative_paths(dev_bus))
+    rel_rel = sorted(relative_paths(rel_bus))
+
+    assert rel_dev[0] == os.path.join('comp_w_products', 'python', 'configmanager.py')
+    assert rel_rel[0] == os.path.join('releasemode_comp_w_prod', 'python', 'configmanager.py')
+
+
+def test_product_filtering():
+    """Make sure we can filter products."""
+
+    tile_dev = load_tile('comp_w_products')
+    assert len(tile_dev.find_products('proxy_plugin')) == 5
+
+    tile_dev.filter_products(['proxy_plugin', 'include_directories'])
+    assert len(tile_dev.find_products('proxy_plugin')) == 5
+
+    tile_dev.filter_products(['include_directories'])
+    assert len(tile_dev.find_products('proxy_plugin')) == 0

--- a/iotilecore/test/test_hw/test_appmatching.py
+++ b/iotilecore/test/test_hw/test_appmatching.py
@@ -2,6 +2,7 @@
 
 import os
 import pytest
+from iotile.core.dev import ComponentRegistry
 from iotile.core.hw import HardwareManager, IOTileApp
 from iotile.core.dev.semver import SemanticVersionRange
 from iotile.core.exceptions import HardwareError
@@ -30,12 +31,13 @@ def virtual_app():
 
 @pytest.fixture(scope="function")
 def register_apps():
-    HardwareManager.ClearDevelopmentApps()
-    HardwareManager.RegisterDevelopmentApp(FakeApp)
+    reg = ComponentRegistry()
+    reg.clear_extensions('iotile.app')
+    reg.register_extension('iotile.app', 'app', FakeApp)
 
     yield
-    HardwareManager.ClearDevelopmentApps()
 
+    reg.clear_extensions('iotile.app')
 
 def test_noapp_matching(virtual_app):
     """Make sure we throw an exception when no matching app is found."""
@@ -49,7 +51,7 @@ def test_noapp_matching(virtual_app):
     info = hw.app('device_info')
 
 
-def test_app_matching(virtual_app, register_apps):
+def test_app_matching(register_apps, virtual_app):
     """Make sure matching by name and version works."""
 
     hw = virtual_app

--- a/iotilegateway/test/test_supervisor_commands.py
+++ b/iotilegateway/test/test_supervisor_commands.py
@@ -1,8 +1,9 @@
 """Tests to make sure IOTileSupervisor and RPC dispatching work."""
 
-import pytest
 import struct
 import json
+import pytest
+from iotile.core.dev import ComponentRegistry
 from iotile.core.hw.virtual import RPCDispatcher, tile_rpc
 from iotile.core.hw.hwmanager import HardwareManager
 from iotile.core.hw.proxy.proxy import TileBusProxyObject
@@ -123,6 +124,9 @@ def linked_tile(rpc_agent, tmpdir):
 
     config_path = str(config_path_obj)
 
+    reg = ComponentRegistry()
+    reg.register_extension('iotile.proxy', 'test_proxy', BasicRPCDispatcherProxy)
+
     # This will create a HardwareManager pointed at a virtual tile based device
     # where the tiles that are added to the virtual device are found using the config
     # file specified after the @ symbol.
@@ -136,7 +140,7 @@ def linked_tile(rpc_agent, tmpdir):
     yield hw
 
     hw.disconnect()
-
+    reg.clear_extensions('iotile.proxy')
 
 def test_service_delegate_tile(linked_tile):
     """Make sure our service delegate tile works correctly."""
@@ -151,7 +155,6 @@ def test_service_delegate_tile(linked_tile):
     #    Additional Information:
     #     - known_names: ['Simple', 'NO APP']
     #     - name: 'bsctst'
-    HardwareManager.RegisterDevelopmentProxy(BasicRPCDispatcherProxy)
 
     # When we call get(address) the HardwareManager will ask the tile at that address,
     # in this case the ServiceDelegateTile what it's 6 character name is.  It will


### PR DESCRIPTION
This PR cleans up the process by which `iotile-core` finds and imports plugins.  Over the years there have been many copies of the same importing code committed.  This PR removes them all from `iotile-core` and replaces them with 4 routines on `ComponentRegistry`:

- `load_extensions`: will find and load all extensions of a given type that are either pip installed or locally installed using `ComponentRegistry.add_component()`.  
- `load_extension`: will directly load and validate a single `.py` file that contains an extension.  This allows for directly specifying paths to extensions when required.  It also provides the basis for the automatic `load_extensions` method above.
- `register_extension`: will programmatically add an extension temporarily that will then be returned when is matches criteria specified in `load_extensions`.
- `clear_extensions`: clears any extensions previously registered using `register_extension`.

## Key Changes

- `ComponentRegistry` is now the single place for finding and loading extensions.  
- In order to speed up the creation of ComponentRegistry, all work related to reading its underlying key-value store is made lazy the first time it is actually needed.  This means that creating a ComponentRegistry is now very fast and the latency of reading the kv-store or importing `pkg_resources` is only incurred the first time you use a method that needs one of those two things.
- The `IOTile` object that contains parsed metadata for all locally installed IOTile components has been refactored to prepare for a world where there are more kinds of products that an IOTile component can provide.  In particular, all of the specific methods to list products of a certain kind have been combined into a single `find_products()` method.  The old methods are marked as deprecated and will be removed once the rest of coretools is updated not to need them and those versions get out into the wild for long enough.
- All places in `iotile-core` that directly imported python code have been refactored to use `load_extension` or `load_extensions` as needed. 
- Additional unit test coverage of the `IOTile` class to make sure that `find_products` works correctly in a wider array of circumstances.
- Previous ways to directly register an extension for unit testing purposes that were defined on `HardwareManager` have been generalized for any kind of extension and moved to `ComponentRegistry`.  Existing code has been ported over to the new interface.

Closes #621

Lays the ground work for #618