### PR TITLE
A collection of small fixes and features for CoreTools

### DIFF
--- a/iotilecore/RELEASE.md
+++ b/iotilecore/RELEASE.md
@@ -4,6 +4,7 @@ All major changes in each released version of `iotile-core` are listed here.
 
 ## HEAD
 
+- Remove nuisance log warning when loading extensions by name (Issue #637) 
 - Fix problem loading `module_settings.json` files for components that had been
   built before on python 3.  (Issue #636)
 

--- a/iotilecore/RELEASE.md
+++ b/iotilecore/RELEASE.md
@@ -2,6 +2,11 @@
 
 All major changes in each released version of `iotile-core` are listed here.
 
+## HEAD
+
+- Fix problem loading `module_settings.json` files for components that had been
+  built before on python 3.  (Issue #636)
+
 ## 3.25.0
 
 - Add support for a `__NO_EXTENSION__` flag in classes so that

--- a/iotilecore/iotile/core/dev/iotileobj.py
+++ b/iotilecore/iotile/core/dev/iotileobj.py
@@ -242,7 +242,7 @@ class IOTile(object):
             if os.path.exists(os.path.join(self.output_folder, 'module_settings.json')):
                 release_settings = os.path.join(self.output_folder, 'module_settings.json')
 
-                with open(release_settings, 'rb') as infile:
+                with open(release_settings, 'r') as infile:
                     release_dict = json.load(infile)
 
                 import dateutil.parser

--- a/iotilecore/iotile/core/dev/registry.py
+++ b/iotilecore/iotile/core/dev/registry.py
@@ -141,8 +141,7 @@ class ComponentRegistry(object):
                 for product in products:
                     try:
                         entries = self.load_extension(product, name_filter=name_filter, class_filter=class_filter)
-
-                        if len(entries) == 0:
+                        if len(entries) == 0 and name_filter is None:  # Don't warn if we're filtering by name since most extensions won't match
                             self._logger.warn("Found no valid extensions in product %s of component %s", product, comp.path)
                             continue
 

--- a/iotilecore/test/test_dev/oldstyle_built_component/build/output/module_settings.json
+++ b/iotilecore/test/test_dev/oldstyle_built_component/build/output/module_settings.json
@@ -1,0 +1,58 @@
+{	
+	"module_targets": 
+	{
+		"tile_gpio": ["lpc824"]
+	},
+
+	"dependency_versions": {
+        "iotile_standard_library_lib_cortexm0p_runtime": "1.1.0",
+        "iotile_standard_library_hw_accelerometer_v2": "2.0.1",
+        "iotile_standard_library_lib_lpc824": "1.3.1",
+        "iotile_standard_library_lib_common": "1.3.0"
+    },
+    
+    "release_date": "2018-12-05T21:50:38.283000",
+    "release": true,
+   
+	"modules":
+	{
+		"tile_gpio":
+		{
+			"overlays":
+			{
+				"lpc824":
+				{
+					"defines":
+					{
+						"kModuleHardwareType":	"kLPC824HardwareType"
+					}
+				}
+			},
+			
+			"depends":
+			{
+				"iotile_standard_library/common": ["include_directories"],
+				"iotile_standard_library/liblpc824": ["include_directories", "liblpc824_lpc824.a"],
+				"iotile_standard_library/libcortexm0p_runtime": ["include_directories", "cortex_m0p_cdb_application.ld", "libcortexm0p_runtime_lpc824.a"]
+			},
+
+			"domain": "iotile_standard_library",
+
+			"defines":
+			{
+				"kVoltageControlPin": 9,
+				"kVoltageSourcePin1": 8,
+				"kVoltageSourcePin2": 23,
+				"kVoltageSensePin2": 14,
+				"kVoltageSenseChannel2": 2, 
+				"kSensePin": 6,
+				"kSenseChannel": 1
+			},
+
+			"products":
+			{
+				"python/gpio1_proxy.py": "proxy_module"
+			}
+		}
+	}
+}

--- a/iotilecore/test/test_dev/oldstyle_built_component/module_settings.json
+++ b/iotilecore/test/test_dev/oldstyle_built_component/module_settings.json
@@ -1,0 +1,48 @@
+{	
+	"module_targets": 
+	{
+		"tile_gpio": ["lpc824"]
+	},
+
+	"modules":
+	{
+		"tile_gpio":
+		{
+			"overlays":
+			{
+				"lpc824":
+				{
+					"defines":
+					{
+						"kModuleHardwareType":	"kLPC824HardwareType"
+					}
+				}
+			},
+			
+			"depends":
+			{
+				"iotile_standard_library/common": ["include_directories"],
+				"iotile_standard_library/liblpc824": ["include_directories", "liblpc824_lpc824.a"],
+				"iotile_standard_library/libcortexm0p_runtime": ["include_directories", "cortex_m0p_cdb_application.ld", "libcortexm0p_runtime_lpc824.a"]
+			},
+
+			"domain": "iotile_standard_library",
+
+			"defines":
+			{
+				"kVoltageControlPin": 9,
+				"kVoltageSourcePin1": 8,
+				"kVoltageSourcePin2": 23,
+				"kVoltageSensePin2": 14,
+				"kVoltageSenseChannel2": 2, 
+				"kSensePin": 6,
+				"kSenseChannel": 1
+			},
+
+			"products":
+			{
+				"python/gpio1_proxy.py": "proxy_module"
+			}
+		}
+	}
+}

--- a/iotilecore/test/test_dev/test_iotile.py
+++ b/iotilecore/test/test_dev/test_iotile.py
@@ -106,6 +106,17 @@ def test_builtnewstyle_component():
     assert tile.release_date == datetime.datetime(2018, 3, 15, 14, 42, tzinfo=tzutc())
 
 
+def test_builtoldstyle_component():
+    """Make sure we can load a v2 file format component."""
+    tile = load_tile('oldstyle_built_component')
+
+    assert tile.release is False
+    assert tile.short_name == 'tile_gpio'
+    assert tile.output_folder != tile.folder
+    assert tile.can_release is False
+    assert tile.release_date == datetime.datetime(2018, 12, 5, 21, 50, 38, 283000)
+
+
 def test_load_invaliddepends():
     with pytest.raises(DataError) as excinfo:
         _tile = load_tile('comp_w_depslist')

--- a/iotileemulate/RELEASE.md
+++ b/iotileemulate/RELEASE.md
@@ -6,6 +6,9 @@ All major changes in each released version of iotile-emulate are listed here.
 
 - Fix deadlock_check to work on multiple threads (not just the one that
   `__init__` was called on.).  Issue #638.
+- Add support for notifying sensorgraph when a streaming interface is opened/
+  closed.
+- Add support into ReferenceController for setting app/os tags and versions.
 
 ## 0.2.0
 

--- a/iotileemulate/RELEASE.md
+++ b/iotileemulate/RELEASE.md
@@ -2,7 +2,7 @@
 
 All major changes in each released version of iotile-emulate are listed here.
 
-## 0.1.0
+## 0.2.0
 
 - Add support for sending RPCs from the sensorgraph task in the reference 
   controller. The sensorgraph implementation should now be complete enough

--- a/iotileemulate/RELEASE.md
+++ b/iotileemulate/RELEASE.md
@@ -2,6 +2,11 @@
 
 All major changes in each released version of iotile-emulate are listed here.
 
+## HEAD
+
+- Fix deadlock_check to work on multiple threads (not just the one that
+  `__init__` was called on.).  Issue #638.
+
 ## 0.2.0
 
 - Add support for sending RPCs from the sensorgraph task in the reference 

--- a/iotileemulate/RELEASE.md
+++ b/iotileemulate/RELEASE.md
@@ -4,10 +4,17 @@ All major changes in each released version of iotile-emulate are listed here.
 
 ## HEAD
 
+- Add support for loading and sgf file or string directly using a test_scenario
+  registered on ReferenceController.  The sgf file is directly loaded into 
+  persistent storage as well as the config_database.  An embedded app_tag is
+  also set.
+
 - Fix deadlock_check to work on multiple threads (not just the one that
   `__init__` was called on.).  Issue #638.
+
 - Add support for notifying sensorgraph when a streaming interface is opened/
   closed.
+
 - Add support into ReferenceController for setting app/os tags and versions.
 
 ## 0.2.0

--- a/iotileemulate/iotile/emulate/constants/rpc_controller.py
+++ b/iotileemulate/iotile/emulate/constants/rpc_controller.py
@@ -1,0 +1,41 @@
+"""RPCs that are implemented by a tilebus controller outside of a subsystem.
+
+These are generic RPCs that set configuration information for the entire
+device or store persistent metadata like app or os tags.
+"""
+
+from .rpc_declaration import RPCDeclaration
+
+
+SET_OS_APP_TAG = RPCDeclaration(0x100B, "LLBB", "L")
+"""Update the OS and/or APP tag of the device.
+
+The OS and APP tags are 20 bit numerical identifiers that identify the
+firmware and sensorgraph, respectively running on an IOTile device.  They have
+an associated X.Y version number for each tag that identifies the version
+of os or app running on the device.
+
+Each tag is packed into a 32-bit (little endian) number in the following
+way:
+
+lowest 20 bits: the numerical tag identifier
+6 bits: the minor version number
+6 bits: the major version number
+
+So the highest 12 bits are a 6.6 fixed point integer storing MAJOR.MINOR
+version numbers and the lowest 20 bits are the numerical tag value itself.
+
+This RPC can update both tags/versions at the same time, only one or neither
+based on the flags included in the RPC call.
+
+Args:
+  - uint32_t: The new packed os tag and version.
+  - uint32_t: The new packes app tag and version.
+  - uint8_t: Update the OS tag, if 0 then the new OS tag is ignored and the
+    current one stored is used.
+  - uint8_t: Update the APP tag, if 0 then the new APP tag is ingored and
+    the current one stored is used.
+
+Returns:
+  - uint32_t: An error code.  No error codes are currently possible.
+"""

--- a/iotileemulate/iotile/emulate/constants/rpcs.py
+++ b/iotileemulate/iotile/emulate/constants/rpcs.py
@@ -17,6 +17,7 @@ from .rpc_config_variables import *
 from .rpc_sensorlog import *
 from .rpc_sensorgraph import *
 from .rpc_clockmanager import *
+from .rpc_controller import *
 
 
 # Tile Lifecycle Related RPCS

--- a/iotileemulate/iotile/emulate/constants/streams.py
+++ b/iotileemulate/iotile/emulate/constants/streams.py
@@ -74,6 +74,24 @@ These ticks are most valuable for implementing field-programmable timers that
 are easy to change with a simple RPC.
 """
 
+COMM_TILE_OPEN = declare_stream('system input 1025')
+"""Sent when a communications tile opens its streaming interface.
+
+The value in the stream is the address of the tile that opened its streaming
+interface.  This input to sensor_graph can be used for entering high-power or
+high-speed modes to send more data when there is a user actively connected to
+the device.
+"""
+
+COMM_TILE_CLOSED = declare_stream('system input 1026')
+"""Sent when a communications tile closes its streaming interface.
+
+The value in the stream is the address of the tile the closed its streaming
+interface.  This input can be used for leaving high-power or high-speed data
+collection modes since there is not longer a user actively connected to the
+device.
+"""
+
 DATA_CLEARED = declare_stream('system output 1027')
 """Logs a reading every time the sensor log subsystem receives a clear() command.
 

--- a/iotileemulate/iotile/emulate/reference/controller_features/config_database.py
+++ b/iotileemulate/iotile/emulate/reference/controller_features/config_database.py
@@ -2,6 +2,7 @@
 
 import base64
 import struct
+from iotile.core.exceptions import ArgumentError, DataError
 from iotile.core.hw.virtual import tile_rpc
 from iotile.sg import SlotIdentifier
 from ...virtual import SerializableState
@@ -223,6 +224,34 @@ class ConfigDatabase(SerializableState):
 
         return rpc_list
 
+    def add_direct(self, target, var_id, var_type, data):
+        """Directly add a config variable.
+
+        This method is meant to be called from emulation scenarios that
+        want to directly set config database entries from python.
+
+        Args:
+            target (SlotIdentifer): The target slot for this config variable.
+            var_id (int): The config variable ID
+            var_type (str): The config variable type
+            data (bytes or int or str): The data that will be encoded according
+                to var_type.
+        """
+
+        data = struct.pack("<H", var_id) + _convert_to_bytes(var_type, data)
+
+        if self.data_size - self.data_index < len(data):
+            raise DataError("Not enough space for data in new conig entry", needed_space=len(data), actual_space=(self.data_size - self.data_index))
+
+        new_entry = ConfigEntry(target, var_id, data)
+
+        for entry in self.entries:
+            if entry.target == new_entry.target and entry.var_id == new_entry.var_id:
+                entry.valid = False
+
+        self.entries.append(new_entry)
+        self.data_index += new_entry.data_space()
+
 
 class ConfigDatabaseMixin(object):
     """Persistent data of config variables.
@@ -344,3 +373,24 @@ class ConfigDatabaseMixin(object):
         invalid_entries = sum(1 for x in self.config_database.entries if not x.valid)
 
         return [max_size, used_size, invalid_size, used_entries, invalid_entries, max_entries, 0]
+
+
+def _convert_to_bytes(type_name, value):
+    """Convert a typed value to a binary array"""
+
+    int_types = {'uint8_t': 'B', 'int8_t': 'b', 'uint16_t': 'H', 'int16_t': 'h', 'uint32_t': 'L', 'int32_t': 'l'}
+
+    type_name = type_name.lower()
+
+    if type_name not in int_types and type_name not in ['string', 'binary']:
+        raise ArgumentError('Type must be a known integer type, integer type array, string', known_integers=int_types.keys(), actual_type=type_name)
+
+    if type_name == 'string':
+        #value should be passed as a string
+        bytevalue = bytes(value)
+    elif type_name == 'binary':
+        bytevalue = bytes(value)
+    else:
+        bytevalue = struct.pack("<%s" % int_types[type_name], value)
+
+    return bytevalue

--- a/iotileemulate/iotile/emulate/reference/controller_features/sensor_graph.py
+++ b/iotileemulate/iotile/emulate/reference/controller_features/sensor_graph.py
@@ -50,7 +50,6 @@ device.
 
 TODO:
   - [ ] Add dump/restore support
-  - [ ] Add clock manager integration
   - [ ] Add support for logging information on reset
 """
 

--- a/iotileemulate/iotile/emulate/reference/reference_device.py
+++ b/iotileemulate/iotile/emulate/reference/reference_device.py
@@ -9,7 +9,7 @@ from future.utils import viewitems
 from past.builtins import basestring
 from iotile.core.exceptions import ArgumentError, DataError
 from ..virtual import EmulatedDevice, EmulatedPeripheralTile
-from ..constants import rpcs, RunLevel
+from ..constants import rpcs, RunLevel, streams
 from .reference_controller import ReferenceController
 
 
@@ -127,6 +127,33 @@ class ReferenceDevice(EmulatedDevice):
             self._time_thread.join()
 
         super(ReferenceDevice, self).stop()
+
+    def open_streaming_interface(self):
+        """Called when someone opens a streaming interface to the device.
+
+        This method will automatically notify sensor_graph that there is a
+        streaming interface opened.
+
+        Returns:
+            list: A list of IOTileReport objects that should be sent out
+                the streaming interface.
+        """
+
+        super(ReferenceDevice, self).open_streaming_interface()
+
+        self.deferred_rpc(8, rpcs.SG_GRAPH_INPUT, 8, streams.COMM_TILE_OPEN)
+        return []
+
+    def close_streaming_interface(self):
+        """Called when someone closes the streaming interface to the device.
+
+        This method will automatically notify sensor_graph that there is a no
+        longer a streaming interface opened.
+        """
+
+        super(ReferenceDevice, self).close_streaming_interface()
+
+        self.deferred_rpc(8, rpcs.SG_GRAPH_INPUT, 8, streams.COMM_TILE_CLOSED)
 
     def reset_peripheral_tiles(self):
         """Reset all peripheral tiles (asynchronously)."""

--- a/iotileemulate/iotile/emulate/virtual/__init__.py
+++ b/iotileemulate/iotile/emulate/virtual/__init__.py
@@ -97,7 +97,7 @@ finishes.
 
 from .emulated_device import EmulatedDevice
 from .peripheral_tile import EmulatedPeripheralTile
-from .emulated_tile import EmulatedTile
+from .emulated_tile import EmulatedTile, synchronized
 from .simple_state import SerializableState
 
-__all__ = ['EmulatedDevice', 'EmulatedTile', 'SerializableState', 'EmulatedPeripheralTile']
+__all__ = ['EmulatedDevice', 'EmulatedTile', 'SerializableState', 'EmulatedPeripheralTile', 'synchronized']

--- a/iotileemulate/iotile/emulate/virtual/emulated_device.py
+++ b/iotileemulate/iotile/emulate/virtual/emulated_device.py
@@ -68,8 +68,6 @@ class EmulatedDevice(EmulationMixin, VirtualIOTileDevice):
         thing done by the background thread.
         """
 
-        self._deadlock_check.__dict__.setdefault('is_rpc_thread', False)
-
         def _init_tls():
             self._deadlock_check.is_rpc_thread = True
 
@@ -209,7 +207,7 @@ class EmulatedDevice(EmulationMixin, VirtualIOTileDevice):
             list: A list of the decoded response members from the RPC.
         """
 
-        if self._deadlock_check.is_rpc_thread:
+        if self._deadlock_check.__dict__.get('is_rpc_thread', False):
             self._logger.critical("Deadlock due to rpc thread calling EmulatedDevice.rpc: address: 0x%02X, rpc: 0x%04X",
                                   address, rpc_id)
             raise InternalError("EmulatedDevice.rpc called from rpc dispatch thread.  This would have caused a deadlock")
@@ -251,7 +249,7 @@ class EmulatedDevice(EmulationMixin, VirtualIOTileDevice):
             bytes: The response payload from the RPC
         """
 
-        if self._deadlock_check.is_rpc_thread:
+        if self._deadlock_check.__dict__.get('is_rpc_thread', False):
             self._logger.critical("Deadlock due to rpc thread calling EmulatedDevice.call_rpc")
             raise InternalError("EmulatedDevice.call_rpc called from rpc dispatch thread.  This would have caused a deadlock")
 
@@ -335,7 +333,7 @@ class EmulatedDevice(EmulationMixin, VirtualIOTileDevice):
         method returns.
         """
 
-        if self._deadlock_check.is_rpc_thread:
+        if self._deadlock_check.__dict__.get('is_rpc_thread', False):
             self._logger.critical("Deadlock due to rpc thread calling EmulatedDevice.wait_deferred_rpcs")
             raise InternalError("EmulatedDevice.wait_deferred_rpcs called from rpc dispatch thread.  This would have caused a deadlock")
 
@@ -361,7 +359,7 @@ class EmulatedDevice(EmulationMixin, VirtualIOTileDevice):
         raise an exception.**
         """
 
-        if self._deadlock_check.is_rpc_thread:
+        if self._deadlock_check.__dict__.get('is_rpc_thread', False):
             self._logger.critical("Deadlock due to rpc thread calling EmulatedDevice.wait_idle")
             raise InternalError("EmulatedDevice.wait_idle called from rpc dispatch thread.  This would have caused a deadlock")
 

--- a/iotileemulate/test/test_reference_sensorgraph.py
+++ b/iotileemulate/test/test_reference_sensorgraph.py
@@ -225,7 +225,7 @@ def test_streaming(streaming_sg):
 
     for i, reading in enumerate(readings):
         assert reading.value == 5 + i
-        assert reading.reading_id == 4 + i
+        assert reading.reading_id == 5 + i
 
 
 def test_rpc_engine(rpc_sg):

--- a/iotileemulate/version.py
+++ b/iotileemulate/version.py
@@ -1,1 +1,1 @@
-version = "0.1.0"
+version = "0.2.0"

--- a/iotilesensorgraph/RELEASE.md
+++ b/iotilesensorgraph/RELEASE.md
@@ -3,6 +3,11 @@
 All major changes in each released version of iotile-sensorgraph are listed
 here.
 
+## HEAD
+
+- Add support for directly passing an sgf string to the parser.  This helps
+  when compiling a sensorgraph programmatically.
+
 ## 0.8.1
 
 - Fix bug in iotile-sgcompile that could not write output formats to stdout

--- a/iotilesensorgraph/iotile/sg/output_formats/config.py
+++ b/iotilesensorgraph/iotile/sg/output_formats/config.py
@@ -5,9 +5,9 @@ definitions run using an embedded sensor graph engine on an IOTile Device and
 static configuration information that defines how the IOTile device is configured.
 """
 
-from iotile.core.utilities.command_file import CommandFile
 from binascii import hexlify
 from future.utils import viewitems
+from iotile.core.utilities.command_file import CommandFile
 
 
 def format_config(sensor_graph):

--- a/iotilesensorgraph/iotile/sg/parser/parser_v1.py
+++ b/iotilesensorgraph/iotile/sg/parser/parser_v1.py
@@ -52,17 +52,27 @@ class SensorGraphFileParser(object):
 
         return out
 
-    def parse_file(self, sg_file):
+    def parse_file(self, sg_file=None, data=None):
         """Parse a sensor graph file into an AST describing the file.
 
         This function builds the statements list for this parser.
+        If you pass ``sg_file``, it will be interpreted as the path to a file
+        to parse.  If you pass ``data`` it will be directly interpreted as the
+        string to parse.
         """
 
-        try:
-            with open(sg_file, "r") as inf:
-                data = inf.read()
-        except IOError:
-            raise ArgumentError("Could not read sensor graph file", path=sg_file)
+        if sg_file is not None and data is not None:
+            raise ArgumentError("You must pass either a path to an sgf file or the sgf contents but not both")
+
+        if sg_file is None and data is None:
+            raise ArgumentError("You must pass either a path to an sgf file or the sgf contents, neither passed")
+
+        if sg_file is not None:
+            try:
+                with open(sg_file, "r") as inf:
+                    data = inf.read()
+            except IOError:
+                raise ArgumentError("Could not read sensor graph file", path=sg_file)
 
         # convert tabs to spaces so our line numbers match correctly
         data = data.replace(u'\t', u'    ')

--- a/transport_plugins/websocket/RELEASE.md
+++ b/transport_plugins/websocket/RELEASE.md
@@ -4,7 +4,9 @@ All major changes in each released version of the websocket transport plugin are
 
 ## HEAD
 
-- open_debug_interface has optional arugment connection_string
+- Fix python 3 compatibility issue when calling an RPC that throws an exception.
+  (Issue #639)
+- open_debug_interface has optional argument connection_string
 
 ## 1.0.0
 

--- a/transport_plugins/websocket/iotile_transport_websocket/virtual_websocket.py
+++ b/transport_plugins/websocket/iotile_transport_websocket/virtual_websocket.py
@@ -611,10 +611,10 @@ class WebSocketVirtualInterface(VirtualIOTileInterface):
 
             except (RPCInvalidIDError, RPCNotFoundError):
                 status = (1 << 1)  # Indicates RPC address or id not correct
-                return_value = ''
+                return_value = b''
             except TileNotFoundError:
                 status = 0xFF  # Indicates RPC had an error
-                return_value = ''
+                return_value = b''
 
         result = {
             'success': error is None


### PR DESCRIPTION
This is the day's take of small fixes and incremental features.  

Most of the fixes address python 3 incompatibilities or chatty logs and there are few features added to `iotile-emulate`.

**Each commit in this PR is a feature or fix with a description and linked issue in the commit message**

The new `iotile-emulate` features are:

- Support for notifying the `sensor_graph` subsystem when a streaming interface is open on the device.  This is important because real-world `sgf` files reference this signal to know when to stream high-speed realtime updates.
- Support for directly loading an `sgf` file as a test scenario.  This allows us to produce POD emulators that come with their sensor_graphs already loaded.
- Support for reading the hardware string from `ReferenceController`.
- Support for setting the app/os tag of the `ReferenceController` via an RPC