### PR TITLE
Improve support wheel building and speed up IOTile tool

### DIFF
--- a/iotilebuild/RELEASE.md
+++ b/iotilebuild/RELEASE.md
@@ -2,6 +2,11 @@
 
 All major changes in each released version of IOTileBuild are listed here.
 
+## HEAD
+
+- Refactor to remove all references to `pkg_resources`.  Uses centralized 
+  entrypoint loading system from iotile.core instead.
+
 ## 2.7.0
 
 - Add support for running pytest unit tests as part of the build process.

--- a/iotilebuild/RELEASE.md
+++ b/iotilebuild/RELEASE.md
@@ -4,6 +4,10 @@ All major changes in each released version of IOTileBuild are listed here.
 
 ## HEAD
 
+- Add support for complex python support wheels where there is an actual 
+  python package present in `python/support`.  Makes sure that the 
+  python package contents are properly copied into the output support wheel.
+
 - Refactor to remove all references to `pkg_resources`.  Uses centralized 
   entrypoint loading system from iotile.core instead.
 

--- a/iotilebuild/iotile/build/build/build.py
+++ b/iotilebuild/iotile/build/build/build.py
@@ -10,21 +10,20 @@
 #Return the build settings json file.
 
 from __future__ import print_function, absolute_import
-from builtins import range
-from past.builtins import basestring
 import sys
 from copy import deepcopy
 import itertools
 import os
 from collections import namedtuple
-from pkg_resources import resource_filename, Requirement
+from builtins import range
+from past.builtins import basestring
 from future.utils import viewitems
 from typedargs.annotate import takes_cmdline
 from iotile.core.exceptions import BuildError, InternalError, ArgumentError, DataError
 from iotile.core.dev.iotileobj import IOTile
+from iotile.build.utilities import resource_path
 
 SCONS_VERSION = "3.0.1"
-
 
 
 @takes_cmdline
@@ -37,14 +36,13 @@ def build(args):
     # Do some sluething work to find scons if it's not installed into an importable
     # place, as it is usually not.
     try:
-        scons_path = os.path.join(resource_filename(Requirement.parse("iotile-build"), "iotile/build/config"), 'scons-local-{}'.format(SCONS_VERSION))
+        scons_path = resource_path('scons-local-{}'.format(SCONS_VERSION), expect='folder')
         sys.path.insert(0, scons_path)
         import SCons.Script
     except ImportError:
         raise BuildError("Could not find internal scons packaged with iotile-build.  This is a bug that should be reported", scons_path=scons_path)
 
-    site_tools = os.path.join(resource_filename(Requirement.parse("iotile-build"), "iotile/build/config"), 'site_scons')
-    site_path = os.path.abspath(site_tools)
+    site_path = resource_path('site_scons', expect='folder')
 
     all_args = ['iotile', '--site-dir=%s' % site_path, '-Q']
     sys.argv = all_args + list(args)

--- a/iotilebuild/iotile/build/config/site_scons/autobuild.py
+++ b/iotilebuild/iotile/build/config/site_scons/autobuild.py
@@ -10,24 +10,23 @@
 # scons based iotile build system
 
 from __future__ import print_function
-import utilities
-import unit_test
-import unit_test_qemu
-from SCons.Script import *
 import os.path
 import os
 import sys
-import itertools
+
+from SCons.Script import *
+
+import utilities
+import unit_test
+import unit_test_qemu
 import arm
 import platform
 from docbuild import *
 from pythondist import *
 from release import *
 from iotile.core.exceptions import *
-import iotile.core
-from iotile.core.dev.iotileobj import IOTile
+from iotile.core.dev import IOTile, ComponentRegistry
 from iotile.build.build import ProductResolver
-import pkg_resources
 from trub_script import build_update_script
 
 
@@ -48,10 +47,9 @@ def require(builder_name):
         callable: the autobuilder function found in the search
     """
 
-    for entry in pkg_resources.iter_entry_points('iotile.autobuild'):
-        if entry.name == builder_name:
-            autobuild_func = entry.load()
-            return autobuild_func
+    reg = ComponentRegistry()
+    for _name, autobuild_func in reg.load_extensions('iotile.autobuild', name_filter=builder_name):
+        return autobuild_func
 
     raise BuildError('Cannot find required autobuilder, make sure the distribution providing it is installed', name=builder_name)
 

--- a/iotilebuild/iotile/build/config/site_scons/docbuild.py
+++ b/iotilebuild/iotile/build/config/site_scons/docbuild.py
@@ -1,6 +1,4 @@
-import os
-from pkg_resources import resource_filename, Requirement
-from iotile.build.utilities import render_template
+from iotile.build.utilities import render_template, resource_path
 
 
 def generate_doxygen_file(output_path, iotile):
@@ -25,4 +23,5 @@ def generate_doxygen_file(output_path, iotile):
 
 def doxygen_source_path():
     """Return the absolute path to the doxygen template for dependency linking."""
-    return os.path.abspath(os.path.join(resource_filename(Requirement.parse("iotile-build"), "iotile/build/config"), 'templates', 'doxygen.txt.tpl'))
+
+    return resource_path('templates/doxygen.txt.tpl')

--- a/iotilebuild/iotile/build/config/site_scons/pythondist.py
+++ b/iotilebuild/iotile/build/config/site_scons/pythondist.py
@@ -57,7 +57,7 @@ def iter_support_files(tile):
 
     support_package = get_support_package(tile)
     if support_package is None:
-        for module, _, _ in iter_support_files(tile):
+        for module, _, _ in iter_python_modules(tile):
             yield os.path.basename(module), module
     else:
         for dirpath, _dirnames, filenames in os.walk(support_package):

--- a/iotilebuild/iotile/build/config/site_scons/pythondist.py
+++ b/iotilebuild/iotile/build/config/site_scons/pythondist.py
@@ -1,17 +1,20 @@
+"""Functions for building a python support wheel."""
+
+from __future__ import print_function
 import os.path
 import os
 import sys
 import glob
-import itertools
 import subprocess
+import setuptools.sandbox
+
 from SCons.Script import *
 from docbuild import *
 from release import *
-from iotile.core.exceptions import *
 from dependencies import find_dependency_wheels, _iter_dependencies
 from iotile.build.utilities import render_template
 from iotile.core.dev.iotileobj import IOTile
-import setuptools.sandbox
+from iotile.core.exceptions import *
 
 
 ENTRY_POINT_MAP = {
@@ -23,6 +26,52 @@ ENTRY_POINT_MAP = {
     'virtual_tile': 'iotile.virtual_tile',
     'virtual_device': 'iotile.virtual_device'
 }
+
+
+def get_support_package(tile):
+    """Returns the support_package product."""
+
+    packages = tile.find_products('support_package')
+    if len(packages) == 0:
+        return None
+    elif len(packages) == 1:
+        return packages[0]
+
+    raise BuildError("Tile declared multiple support packages, only one is supported", packages=packages)
+
+
+def iter_support_files(tile):
+    """Iterate over all files that go in the support wheel.
+
+    This method has two possible behaviors.  If there is a 'support_package'
+    product defined, then this recursively enumerates all .py files inside
+    that folder and adds them all in the same hierarchy to the support wheel.
+
+    If there is no support_package product defined, then the old behavior
+    takes over, where all files containing python entrypoints are iterated
+    over using iter_python_modules() and they are copied into the support
+    wheel and then an __init__.py file is added.
+
+    The files are yielded as tuples of (copy_name, input_path).
+    """
+
+    support_package = get_support_package(tile)
+    if support_package is None:
+        for module, _, _ in iter_support_files(tile):
+            yield os.path.basename(module), module
+    else:
+        for dirpath, _dirnames, filenames in os.walk(support_package):
+            for filename in filenames:
+                if not filename.endswith('.py'):
+                    continue
+
+                input_path = os.path.join(dirpath, filename)
+                output_path = os.path.relpath(input_path, start=support_package)
+
+                if output_path == "__init__.py":
+                    continue
+
+                yield output_path, input_path
 
 
 def iter_python_modules(tile):
@@ -63,7 +112,7 @@ def iter_python_modules(tile):
 
 def build_python_distribution(tile):
     env = Environment(tools=[])
-    srcdir = 'python'
+
     builddir = os.path.join('build', 'python')
     packagedir = os.path.join(builddir, tile.support_distribution)
     outdir = os.path.join('build', 'output', 'python')
@@ -72,7 +121,6 @@ def build_python_distribution(tile):
     if not tile.has_wheel:
         return
 
-    srcnames = [os.path.basename(mod) for mod, _import, _entry in iter_python_modules(tile)]
     buildfiles = []
 
     pkg_init = os.path.join(packagedir, '__init__.py')
@@ -95,20 +143,16 @@ def build_python_distribution(tile):
         Mkdir(outsrcdir),
         Touch(os.path.join(outsrcdir, ".timestamp"))])
 
-    for infile in srcnames:
-        inpath = os.path.join(srcdir, infile)
-        outfile = os.path.join(outsrcdir, infile)
-        buildfile = os.path.join(packagedir, infile)
 
-        if os.path.isdir(inpath):
-            srclist = inpath
-        else:
-            srclist = [inpath]
+    for outpath, inpath in iter_support_files(tile):
+        outfile = os.path.join(outsrcdir, outpath)
+        buildfile = os.path.join(packagedir, outpath)
 
-        target = env.Command(outfile, srclist, Copy("$TARGET", "$SOURCE"))
+        target = env.Command(outfile, inpath, Copy("$TARGET", "$SOURCE"))
         env.Depends(target, outsrcnode)
 
-        env.Command(buildfile, [inpath, pkg_init], Copy("$TARGET", "$SOURCE"))
+        target = env.Command(buildfile, inpath, Copy("$TARGET", "$SOURCE"))
+        env.Depends(target, pkg_init)
 
         buildfiles.append(buildfile)
 
@@ -135,7 +179,6 @@ def build_python_distribution(tile):
         required_version = "py3" if sys.version_info[0] == 3 else "py2"
 
     for wheel in wheels:
-
         wheel_name = os.path.basename(wheel)
         wheel_basename = '-'.join(wheel.split('-')[:-3])
         wheel_pattern = wheel_basename + "-*" + required_version + '*'

--- a/iotilebuild/iotile/build/config/site_scons/site_init.py
+++ b/iotilebuild/iotile/build/config/site_scons/site_init.py
@@ -1,12 +1,3 @@
-import pkg_resources
-import os.path
 import SCons
-
-#See if any installed package is advertising scons builders
-for entry in pkg_resources.iter_entry_points('iotile.builder'):
-    path_gen = entry.load()
-    tool_path = path_gen()
-
-    SCons.Tool.DefaultToolpath.insert(0, os.path.abspath(tool_path))
 
 SCons.Defaults.DefaultEnvironment(tools=[])

--- a/iotilebuild/iotile/build/config/site_scons/unit_test.py
+++ b/iotilebuild/iotile/build/config/site_scons/unit_test.py
@@ -126,7 +126,6 @@ class UnitTest (object):
         apply if all of the architectures in the unit test are contained in the module_target.
         """
 
-        print(module_targets)
         for mod_target in module_targets:
             found = False
             if self.targets is not None:

--- a/iotilebuild/iotile/build/release/release.py
+++ b/iotilebuild/iotile/build/release/release.py
@@ -1,9 +1,8 @@
 """Tools for automatically releasing built IOTile components
 """
 
-import pkg_resources
 from builtins import range
-from iotile.core.dev.iotileobj import IOTile
+from iotile.core.dev import IOTile, ComponentRegistry
 from iotile.core.utilities.typedargs import param
 from iotile.core.exceptions import ArgumentError, DataError, BuildError, IOTileException
 
@@ -89,6 +88,7 @@ def release(component=".", cloud=False):
         try:
             prov.release()
         except IOTileException as exc:
+            j = None
             try:
                 #There was an error, roll back
                 for j in range(0, i):
@@ -102,9 +102,6 @@ def release(component=".", cloud=False):
 
 
 def _find_release_providers():
-    provs = {}
-
-    for entry in pkg_resources.iter_entry_points('iotile.build.release_provider'):
-        provs[entry.name] = entry.load()
-
-    return provs
+    reg = ComponentRegistry()
+    return {name: entry for name, entry
+            in reg.load_extensions('iotile.build.release_provider')}

--- a/iotilebuild/iotile/build/tilebus/block.py
+++ b/iotilebuild/iotile/build/tilebus/block.py
@@ -6,7 +6,6 @@
 # Modifications to this file from the original created at WellDone International
 # are copyright Arch Systems Inc.
 
-from pkg_resources import resource_filename, Requirement
 from typedargs.exceptions import ArgumentError
 from iotile.build.utilities import render_template
 

--- a/iotilebuild/iotile/build/tilebus/descriptor.py
+++ b/iotilebuild/iotile/build/tilebus/descriptor.py
@@ -10,14 +10,14 @@
 #Define a Domain Specific Language for specifying MIB endpoints
 
 import os.path
+import struct
 from future.utils import viewitems
 from past.builtins import basestring, long
-import struct
-from pkg_resources import resource_filename, Requirement
 from pyparsing import Regex, Literal, Optional, Group, oneOf, QuotedString, delimitedList, ParseException
-from iotile.core.exceptions import *
+from iotile.core.exceptions import ArgumentError, DataError
 from .block import TBBlock
 from .handler import TBHandler
+from ..utilities import resource_path
 
 
 #DSL for mib definitions
@@ -76,7 +76,7 @@ class TBDescriptor:
         self.configs = {}
         self.valid = False
 
-        self.include_dirs = include_dirs + [resource_filename(Requirement.parse("iotile-build"), "iotile/build/config")]
+        self.include_dirs = include_dirs + [resource_path(expect='folder')]
 
         if isinstance(source, basestring):
             source = [source]

--- a/iotilebuild/iotile/build/utilities/__init__.py
+++ b/iotilebuild/iotile/build/utilities/__init__.py
@@ -1,5 +1,7 @@
 """Common shared utility classes and methods."""
 
 from .template import render_template, render_recursive_template, render_template_inplace
+from .bundled_data import resource_path
 
-__all__ = ['render_template', 'render_recursive_template', 'render_template_inplace']
+__all__ = ['resource_path', 'render_template', 'render_recursive_template',
+           'render_template_inplace']

--- a/iotilebuild/iotile/build/utilities/bundled_data.py
+++ b/iotilebuild/iotile/build/utilities/bundled_data.py
@@ -1,0 +1,65 @@
+"""Helper routine for finding data files bundled with iotile-build.
+
+This module implements similar functionality to
+pkg_resources.resource_filename but does it without the overhead of
+pkg_resources, in particular, the very high module import time.
+
+There are two key differences in the implementation:
+
+1. `pkg_resources` will automatically unzip files if the wheel is
+   installed in a compressed format.  This module does not.
+2. `pkg_resources` lets you specify a distribution by name.  This
+   module just lets you find files relative to the current package.
+
+Both of these restrictions are parts of pkg_resources that we don't use
+anyway, which is why this simpler method was implemented.
+"""
+
+import os
+from iotile.core.exceptions import ArgumentError, DataError
+
+
+def resource_path(relative_path=None, expect=None):
+    """Return the absolute path to a resource in iotile-build.
+
+    This method finds the path to the `config` folder inside
+    iotile-build, appends `relative_path` to it and then
+    checks to make sure the desired file or directory exists.
+
+    You can specify expect=(None, 'file', or 'folder') for
+    what you expect to find at the given path.
+
+    Args:
+        relative_path (str): The relative_path from the config
+            folder to the resource in question.  This path can
+            be specified using / characters on all operating
+            systems since it will be normalized before usage.
+            If None is passed, the based config folder will
+            be returned.
+        expect (str): What the path should resolve to, which is
+            checked before returning, raising a DataError if
+            the check fails.  You can pass None for no checking,
+            file for checking `os.path.isfile`, or folder for
+            checking `os.path.isdir`.  Default: None
+
+    Returns:
+        str: The normalized absolute path to the resource.
+    """
+
+    if expect not in (None, 'file', 'folder'):
+        raise ArgumentError("Invalid expect parameter, must be None, 'file' or 'folder'",
+                            expect=expect)
+
+    this_dir = os.path.dirname(__file__)
+    resource_path = os.path.join(this_dir, '..', 'config')
+
+    if relative_path is not None:
+        path = os.path.normpath(relative_path)
+        resource_path = os.path.join(resource_path, path)
+
+    if expect == 'file' and not os.path.isfile(resource_path):
+        raise DataError("Expected resource %s to be a file and it wasn't" % resource_path)
+    elif expect == 'folder' and not os.path.isdir(resource_path):
+        raise DataError("Expected resource %s to be a folder and it wasn't"% resource_path)
+
+    return os.path.abspath(resource_path)

--- a/iotilebuild/iotile/build/utilities/template.py
+++ b/iotilebuild/iotile/build/utilities/template.py
@@ -10,14 +10,13 @@
 #Utilities for producing skeleton code for application modules, unit tests,
 #etc. using the Cheetah templating library.
 
-import os.path
-from future.utils import viewitems
 import os
 import shutil
+from future.utils import viewitems
 from past.builtins import basestring
-from pkg_resources import resource_filename, Requirement
 from jinja2 import Environment, PackageLoader, FileSystemLoader
 from typedargs.exceptions import ArgumentError
+from .bundled_data import resource_path
 
 
 def render_template_inplace(template_path, info, dry_run=False, extra_filters=None, resolver=None):
@@ -154,8 +153,8 @@ def render_recursive_template(template_folder, info, out_folder, preserve=None, 
 
     preserve = set(preserve)
 
-    template_dir = os.path.join(resource_filename(Requirement.parse("iotile-build"), "iotile/build/config/templates"))
-    indir = os.path.abspath(os.path.join(template_dir, template_folder))
+    template_dir = resource_path('templates', expect='folder')
+    indir = os.path.join(template_dir, template_folder)
 
     if not os.path.exists(indir):
         raise ArgumentError("Input template folder for recursive template not found", template_folder=template_folder, absolute_path=indir)

--- a/iotilecore/RELEASE.md
+++ b/iotilecore/RELEASE.md
@@ -16,6 +16,10 @@ All major changes in each released version of `iotile-core` are listed here.
 - Fix problem loading `module_settings.json` files for components that had been
   built before on python 3.  (Issue #636)
 
+- Adds support for complex python support wheels in ComponentRegistry.  
+  Submodules inside the support package are now imported correctly so that
+  relative imports among the modules work.
+
 ## 3.25.0
 
 - Add support for a `__NO_EXTENSION__` flag in classes so that

--- a/iotilecore/RELEASE.md
+++ b/iotilecore/RELEASE.md
@@ -4,6 +4,10 @@ All major changes in each released version of `iotile-core` are listed here.
 
 ## HEAD
 
+- Support freezing the current list of extensions into a single file that is
+  stored with the virtual environment, speeding up small program invocations
+  by removing the necessity to enumerate all installed packages.
+
 - Make log messages from virtual_device script less chatty by removing audit 
   log messages by default.
 

--- a/iotilecore/RELEASE.md
+++ b/iotilecore/RELEASE.md
@@ -4,7 +4,11 @@ All major changes in each released version of `iotile-core` are listed here.
 
 ## HEAD
 
+- Make log messages from virtual_device script less chatty by removing audit 
+  log messages by default.
+
 - Remove nuisance log warning when loading extensions by name (Issue #637) 
+
 - Fix problem loading `module_settings.json` files for components that had been
   built before on python 3.  (Issue #636)
 

--- a/iotilecore/iotile/core/dev/annotated_registry.py
+++ b/iotilecore/iotile/core/dev/annotated_registry.py
@@ -2,19 +2,19 @@
 # A wrapper to make the IOTile component registry accessible in the iotile
 # tool.  Since the registry is used internally in the type system it cannot
 # itself make use of typedargs annotations
-from iotile.core.utilities.typedargs import annotated, param, return_type, context, iprint
+from iotile.core.utilities.typedargs import annotated, param, return_type, context
+from iotile.core.exceptions import ExternalError
+from .registry import ComponentRegistry
 
 _name_ = "Developer"
 
-#Outside accessible API for this package
-from .registry import ComponentRegistry
 
 @annotated
 def registry():
     return AnnotatedRegistry()
 
 @context()
-class AnnotatedRegistry:
+class AnnotatedRegistry(object):
     """
     AnnotatedRegistry
 
@@ -94,3 +94,26 @@ class AnnotatedRegistry:
     @return_type("string")
     def clear(self, key):
         self.reg.clear_config(key)
+
+    @annotated
+    def freeze(self):
+        """Freeze the current list of extensions to a single file.
+
+        This speeds up the extension loading process but does not check for
+        new extensions each time the program is run. You should only use this
+        method in situations where you know the extension list is static
+        and you need the speedup benefits.
+
+        You can undo this by calling unfreeze().
+        """
+
+        self.reg.freeze_extensions()
+
+    @annotated
+    def unfreeze(self):
+        """Remove any frozen extension list."""
+
+        try:
+            self.reg.unfreeze_extensions()
+        except ExternalError:
+            pass  # This means there was no frozen list of extensions

--- a/iotilecore/iotile/core/dev/iotileobj.py
+++ b/iotilecore/iotile/core/dev/iotileobj.py
@@ -8,7 +8,10 @@ import json
 import os.path
 import sys
 from future.utils import viewitems, itervalues
-from past.builtins import basestring
+
+if sys.version_info >= (3, 0, 0):
+    from past.builtins import basestring
+
 from iotile.core.exceptions import DataError, ExternalError
 from .semver import SemanticVersion, SemanticVersionRange
 

--- a/iotilecore/iotile/core/dev/registry.py
+++ b/iotilecore/iotile/core/dev/registry.py
@@ -6,14 +6,19 @@ import sys
 import logging
 import imp
 import inspect
+import json
 from types import ModuleType
 from future.utils import itervalues
-from past.builtins import basestring
+
+if sys.version_info >= (3, 0, 0):
+    from past.builtins import basestring
+
+import entrypoints
 
 from iotile.core.utilities.kvstore_sqlite import SQLiteKVStore
 from iotile.core.utilities.kvstore_json import JSONKVStore
 from iotile.core.utilities.kvstore_mem import InMemoryKVStore
-from iotile.core.exceptions import ArgumentError
+from iotile.core.exceptions import ArgumentError, ExternalError
 from iotile.core.utilities.paths import settings_directory
 from .iotileobj import IOTile
 
@@ -33,11 +38,19 @@ class ComponentRegistry(object):
 
     _registered_extensions = {}
     _component_overlays = {}
+    _frozen_extensions = None
 
     def __init__(self):
         self._kvstore = None
         self._plugins = None
         self._logger = logging.getLogger(__name__)
+
+    @property
+    def frozen(self):
+        """Return whether we have a cached list of all installed entry_points."""
+
+        frozen_path = os.path.join(_registry_folder(), 'frozen_extensions.json')
+        return os.path.isfile(frozen_path)
 
     @property
     def kvstore(self):
@@ -58,12 +71,9 @@ class ComponentRegistry(object):
         """
 
         if self._plugins is None:
-            import pkg_resources
-
             self._plugins = {}
 
-            for entry in pkg_resources.iter_entry_points('iotile.plugin'):
-                plugin = entry.load()
+            for _, plugin in self.load_extensions('iotile.plugin'):
                 links = plugin()
                 for name, value in links:
                     self._plugins[name] = value
@@ -130,8 +140,6 @@ class ComponentRegistry(object):
 
         found_extensions = []
 
-        import pkg_resources
-
         if product_name is not None:
             for comp in self.iter_components():
                 if comp_filter is not None and comp != comp_filter:
@@ -149,7 +157,7 @@ class ComponentRegistry(object):
                     except:  #pylint:disable=bare-except;We don't want a broken extension to take down the whole system
                         self._logger.exception("Unable to load extension %s from local component %s at path %s", product_name, comp, product)
 
-        for entry in pkg_resources.iter_entry_points(group):
+        for entry in self._iter_entrypoint_group(group):
             name = entry.name
 
             if name_filter is not None and name != name_filter:
@@ -206,6 +214,35 @@ class ComponentRegistry(object):
         if group in self._registered_extensions:
             self._registered_extensions[group] = []
 
+    def freeze_extensions(self):
+        """Freeze the set of extensions into a single file.
+
+        Freezing extensions can speed up the extension loading process on
+        machines with slow file systems since it requires only a single file
+        to store all of the extensions.
+
+        Calling this method will save a file into the current virtual
+        environment that stores a list of all currently found extensions that
+        have been installed as entry_points.  Future calls to
+        `load_extensions` will only search the one single file containing
+        frozen extensions rather than enumerating all installed distributions.
+        """
+
+        output_path = os.path.join(_registry_folder(), 'frozen_extensions.json')
+
+        with open(output_path, "w") as outfile:
+            json.dump(self._dump_extensions(), outfile)
+
+    def unfreeze_extensions(self):
+        """Remove a previously frozen list of extensions."""
+
+        output_path = os.path.join(_registry_folder(), 'frozen_extensions.json')
+        if not os.path.isfile(output_path):
+            raise ExternalError("There is no frozen extension list")
+
+        os.remove(output_path)
+        ComponentRegistry._frozen_extensions = None
+
     def load_extension(self, path, name_filter=None, class_filter=None, unique=False):
         """Load a single python module extension.
 
@@ -246,7 +283,40 @@ class ComponentRegistry(object):
 
         return found[0]
 
-    def _filter_nonextensions(self, obj):
+    def _load_frozen_extensions(self):
+        self._logger.critical("Loading frozen extensions from file, new extensions will not be found")
+
+        frozen_path = os.path.join(_registry_folder(), 'frozen_extensions.json')
+        with open(frozen_path, "r") as infile:
+            extensions = json.load(infile)
+
+        ComponentRegistry._frozen_extensions = {}
+        for group in extensions:
+            ComponentRegistry._frozen_extensions[group] = []
+
+            for ext_info in extensions.get(group, []):
+                name = ext_info['name']
+                obj_path = ext_info['object']
+                distro_info = ext_info['distribution']
+
+                distro = None
+                if distro_info is not None:
+                    distro = entrypoints.Distribution(*distro_info)
+
+                entry = entrypoints.EntryPoint.from_string(obj_path, name, distro=distro)
+                ComponentRegistry._frozen_extensions[group].append(entry)
+
+    def _iter_entrypoint_group(self, group):
+        if not self.frozen:
+            return entrypoints.get_group_all(group)
+
+        if self._frozen_extensions is None:
+            self._load_frozen_extensions()
+
+        return self._frozen_extensions.get(group, [])
+
+    @classmethod
+    def _filter_nonextensions(cls, obj):
         """Remove all classes marked as not extensions.
 
         This allows us to have a deeper hierarchy of classes than just
@@ -261,10 +331,34 @@ class ComponentRegistry(object):
         create a second entry point.
         """
 
-        if obj.__dict__.get('__NO_EXTENSION__', False) is True:
+        # Not all objects have __dict__ attributes.  For example, tuples don't.
+        # and tuples are used in iotile.build for some entry points.
+        if hasattr(obj, '__dict__') and obj.__dict__.get('__NO_EXTENSION__', False) is True:
             return False
 
         return True
+
+    @classmethod
+    def _dump_extensions(cls, prefix="iotile."):
+        extensions = {}
+
+        for config, distro in entrypoints.iter_files_distros():
+            if distro is None:
+                distro_info = None
+            else:
+                distro_info = (distro.name, distro.version)
+
+            for group in config:
+                if prefix is not None and not group.startswith(prefix):
+                    continue
+
+                if group not in extensions:
+                    extensions[group] = []
+
+                for name, epstr in config[group].items():
+                    extensions[group].append(dict(name=name, object=epstr, distribution=distro_info))
+
+        return extensions
 
     def _filter_subclasses(self, obj, class_filter):
         if class_filter is None:
@@ -458,6 +552,20 @@ class ComponentRegistry(object):
         self.kvstore.remove(keyname)
 
 
+def _registry_folder(folder=None):
+    if folder is None:
+        folder = settings_directory()
+
+        #If we are relative to a virtual environment, place the registry into that virtual env
+        #Support both virtualenv and pythnon 3 venv
+        if hasattr(sys, 'real_prefix'):
+            folder = sys.prefix
+        elif hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix:
+            folder = sys.prefix
+
+    return folder
+
+
 def _check_registry_type(folder=None):
     """Check if the user has placed a registry_type.txt file to choose the registry type
 
@@ -468,15 +576,7 @@ def _check_registry_type(folder=None):
         folder (string): The folder that we should check for a default registry type
     """
 
-    if folder is None:
-        folder = settings_directory()
-
-        #If we are relative to a virtual environment, place the registry into that virtual env
-        #Support both virtualenv and pythnon 3 venv
-        if hasattr(sys, 'real_prefix'):
-            folder = sys.prefix
-        elif hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix:
-            folder = sys.prefix
+    folder = _registry_folder(folder)
 
     default_file = os.path.join(folder, 'registry_type.txt')
 

--- a/iotilecore/iotile/core/hw/auth/auth_provider.py
+++ b/iotilecore/iotile/core/hw/auth/auth_provider.py
@@ -6,10 +6,10 @@ methods that it provides with their own implementations.
 
 #pylint:disable=C0103
 
-import pkg_resources
 import hashlib
 import struct
 import hmac
+from iotile.core.dev import ComponentRegistry
 from iotile.core.exceptions import NotFoundError, ArgumentError
 
 
@@ -51,9 +51,9 @@ class AuthProvider(object):
     def FindByName(cls, name):
         """Find a specific installed auth provider by name."""
 
-        for entry in pkg_resources.iter_entry_points('iotile.auth_provider'):
-            if entry.name == name:
-                return entry.load()
+        reg = ComponentRegistry()
+        for _, entry in reg.load_extensions('iotile.auth_provider', name_filter=name):
+            return entry
 
     @classmethod
     def VerifyRoot(cls, root):

--- a/iotilecore/iotile/core/hw/debug/debug_manager.py
+++ b/iotilecore/iotile/core/hw/debug/debug_manager.py
@@ -16,7 +16,6 @@ from future.utils import viewitems
 from typedargs.annotate import context, docannotate
 from iotile.core.exceptions import ArgumentError, ExternalError
 from iotile.core.utilities.console import ProgressBar
-from iotile.core.utilities.intelhex import IntelHex
 
 
 @context("DebugManager")
@@ -249,6 +248,9 @@ class DebugManager(object):
         """This function returns a list of base addresses and a list of the binary data
         for each segment.
         """
+
+        from iotile.core.utilities.intelhex import IntelHex
+
         ihex           = IntelHex(in_path)
         segments       = ihex.segments()
         segments_start = [segment[0] for segment in segments]

--- a/iotilecore/iotile/core/hw/reports/parser.py
+++ b/iotilecore/iotile/core/hw/reports/parser.py
@@ -1,11 +1,11 @@
 """State machine for parsing IOTile reports coming in on a streaming basis
 """
 
-import pkg_resources
 from iotile.core.exceptions import ArgumentError
+from iotile.core.dev import ComponentRegistry
 
 
-class IOTileReportParser (object):
+class IOTileReportParser(object):
     """Accumulates data from a stream and emits IOTileReports
 
     Every time new data is available on the stream, add_data should be called.
@@ -177,10 +177,5 @@ class IOTileReportParser (object):
         """Build a map of all of the known report format processors
         """
 
-        formats = {}
-
-        for entry in pkg_resources.iter_entry_points('iotile.report_format'):
-            report_format = entry.load()
-            formats[report_format.ReportType] = report_format
-
-        return formats
+        return {report_format.ReportType: report_format for _, report_format in
+                ComponentRegistry().load_extensions('iotile.report_format')}

--- a/iotilecore/iotile/core/hw/reports/report.py
+++ b/iotilecore/iotile/core/hw/reports/report.py
@@ -2,7 +2,6 @@
 """
 
 import datetime
-import dateutil.parser
 from iotile.core.exceptions import NotFoundError
 
 
@@ -81,6 +80,7 @@ class IOTileReading(object):
 
         timestamp = obj.get('timestamp')
         if timestamp is not None:
+            import dateutil.parser
             timestamp = dateutil.parser.parse(timestamp)
 
         return IOTileReading(obj.get('device_timestamp'), obj.get('stream'), obj.get('value'), reading_id=obj.get('streamer_local_id'), reading_time=timestamp)
@@ -179,6 +179,7 @@ class IOTileEvent(object):
 
         timestamp = obj.get('timestamp')
         if timestamp is not None:
+            import dateutil.parser
             timestamp = dateutil.parser.parse(timestamp)
 
         return IOTileEvent(obj.get('device_timestamp'), obj.get('stream'), obj.get('extra_data'), obj.get('data'), reading_id=obj.get('streamer_local_id'), reading_time=timestamp)

--- a/iotilecore/iotile/core/hw/transport/__init__.py
+++ b/iotilecore/iotile/core/hw/transport/__init__.py
@@ -7,4 +7,5 @@
 # are copyright Arch Systems Inc.
 
 from .cmdstream import CMDStream
-from .websocketstream import WebSocketStream
+
+__all__ = ['CMDStream']

--- a/iotilecore/iotile/core/hw/update/record.py
+++ b/iotilecore/iotile/core/hw/update/record.py
@@ -5,6 +5,7 @@ All records must inherit from this base class and implement its required methods
 
 from __future__ import (print_function, absolute_import, unicode_literals)
 import struct
+from iotile.core.dev import ComponentRegistry
 from iotile.core.exceptions import ArgumentError, DataError
 
 
@@ -85,10 +86,8 @@ class UpdateRecord(object):
         if cls.PLUGINS_LOADED:
             return
 
-        import pkg_resources
-
-        for entry in pkg_resources.iter_entry_points('iotile.update_record'):
-            record = entry.load()
+        reg = ComponentRegistry()
+        for _, record in reg.load_extensions('iotile.update_record'):
             cls.RegisterRecordType(record)
 
         cls.PLUGINS_LOADED = True
@@ -119,11 +118,12 @@ class UpdateRecord(object):
                 then this will indicate how many binary records are included together.
 
         Returns:
-            int: The match quality between 0 and 100.  You should use the
-                constants defined in MatchQuality as much as possible.  The only
-                exception to the 0 to 100 rules is if you retern MatchQuality.DeferMatch
-                which means that we are matching a multi-record statement with a single
-                logical UpdateRecord.
+            int: The match quality between 0 and 100.
+
+            You should use the constants defined in MatchQuality as much as
+            possible.  The only exception to the 0 to 100 rules is if you
+            retern MatchQuality.DeferMatch which means that we are matching a
+            multi-record statement with a single logical UpdateRecord.
         """
 
         raise NotImplementedError()

--- a/iotilecore/iotile/core/hw/virtual/virtualtile.py
+++ b/iotilecore/iotile/core/hw/virtual/virtualtile.py
@@ -1,8 +1,6 @@
 """A virtual tile that ensapsulates resuable behavior."""
 
-from future.utils import itervalues
-import pkg_resources
-from iotile.core.exceptions import ExternalError, ArgumentError
+from iotile.core.exceptions import ArgumentError
 from iotile.core.dev import ComponentRegistry
 from .base_runnable import BaseRunnable
 from .common_types import tile_rpc, RPCDispatcher

--- a/iotilecore/iotile/core/scripts/iotile_script.py
+++ b/iotilecore/iotile/core/scripts/iotile_script.py
@@ -8,22 +8,22 @@
 
 from __future__ import (absolute_import, division,
                         print_function, unicode_literals)
-from builtins import str, input
-from future.utils import viewitems
 import sys
 import os
 import threading
 import traceback
 import argparse
 import logging
+from builtins import input
+from future.utils import viewitems
 
 from typedargs.shell import HierarchicalShell
 from typedargs import type_system
-from iotile.core.exceptions import IOTileException, APIError
+from iotile.core.exceptions import IOTileException
 from iotile.core.dev.registry import ComponentRegistry
 import iotile.core.hw.transport.cmdstream as cmdstream
 
-DESCRIPTION= \
+DESCRIPTION = \
 """Create an interactive shell that explores the IOTile API.
 
 This tool allows you to run commands that are defined in either CoreTools, or
@@ -270,3 +270,7 @@ def main(argv=None):
     if timeout_thread is not None:
         timeout_stop_event.set()
         timeout_thread.join()
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/iotilecore/iotile/core/scripts/virtualdev_script.py
+++ b/iotilecore/iotile/core/scripts/virtualdev_script.py
@@ -33,6 +33,7 @@ def configure_logging(verbose):
                                       '%y-%m-%d %H:%M:%S')
         handler.setFormatter(formatter)
         loglevels = [logging.ERROR, logging.WARNING, logging.INFO, logging.DEBUG]
+
         if verbose >= len(loglevels):
             verbose = len(loglevels) - 1
 
@@ -118,12 +119,6 @@ def main(argv=None):
         if args.track is not None:
             print("Tracking all state changes to device")
             device.state_history.enable()
-
-        handler = logging.StreamHandler()
-        handler.setFormatter(logging.Formatter('%(asctime)s [AUDIT %(event_name)s] %(message)s'))
-
-        iface.audit_logger.addHandler(handler)
-        iface.audit_logger.setLevel(logging.INFO)
 
         iface.start(device)
         started = True

--- a/iotilecore/iotile/core/utilities/linebuffer_ui.py
+++ b/iotilecore/iotile/core/utilities/linebuffer_ui.py
@@ -37,8 +37,11 @@ that doesn't flicker or scroll.
 
 from collections import namedtuple
 import time
+import sys
 from future.utils import viewvalues
-from past.builtins import basestring
+if sys.version_info >= (3, 0, 0):
+    from past.builtins import basestring
+
 from iotile.core.exceptions import ExternalError
 
 LineEntry = namedtuple("LineEntry", ['text', 'id', 'sort_key', 'object'])

--- a/iotilecore/iotile/core/utilities/typedargs/__init__.py
+++ b/iotilecore/iotile/core/utilities/typedargs/__init__.py
@@ -2,8 +2,6 @@
 
 from __future__ import unicode_literals
 from functools import reduce
-import pkg_resources
-
 
 # Recreate all old imports
 from typedargs.annotate import param, returns, context, finalizer, takes_cmdline, annotated, return_type, stringable
@@ -11,7 +9,7 @@ from typedargs.typeinfo import type_system, iprint
 
 
 def load_external_components(typesys):
-    """Load all external typed defined by iotile plugins.
+    """Load all external types defined by iotile plugins.
 
     This allows plugins to register their own types for type annotations and
     allows all registered iotile components that have associated type libraries to
@@ -24,7 +22,7 @@ def load_external_components(typesys):
     reg = ComponentRegistry()
     modules = reg.list_components()
 
-    typelibs = reduce(lambda x, y: x+y, [reg.find_component(x).type_packages() for x in modules], [])
+    typelibs = reduce(lambda x, y: x+y, [reg.find_component(x).find_products('type_package') for x in modules], [])
     for lib in typelibs:
         if lib.endswith('.py'):
             lib = lib[:-3]

--- a/iotilecore/setup.py
+++ b/iotilecore/setup.py
@@ -31,7 +31,8 @@ setup(
         "future>=0.16.0",
         "typedargs>=0.11.0",
         "sortedcontainers ~= 2.1",
-        "monotonic ~= 1.5"
+        "monotonic ~= 1.5",
+        "entrypoints >= 0.3.0"
     ],
     extras_require={
         'ui': ["asciimatics>=1.9.0"]

--- a/iotileemulate/RELEASE.md
+++ b/iotileemulate/RELEASE.md
@@ -4,6 +4,9 @@ All major changes in each released version of iotile-emulate are listed here.
 
 ## HEAD
 
+- Add support for hardware version RPC on the controller.  The default
+  implementation returns the hardware string 'pythontile'
+
 - Add support for loading and sgf file or string directly using a test_scenario
   registered on ReferenceController.  The sgf file is directly loaded into 
   persistent storage as well as the config_database.  An embedded app_tag is

--- a/iotileemulate/RELEASE.md
+++ b/iotileemulate/RELEASE.md
@@ -20,6 +20,10 @@ All major changes in each released version of iotile-emulate are listed here.
 
 - Add support into ReferenceController for setting app/os tags and versions.
 
+- Improve SerializableState to allow for marking the object types of lists,
+  properties and dicts to enable them to be properly serialized and
+  deserialized without needing to explicitly call `mark_complex_type`.
+
 ## 0.2.0
 
 - Add support for sending RPCs from the sensorgraph task in the reference 

--- a/iotileemulate/iotile/emulate/constants/rpcs.py
+++ b/iotileemulate/iotile/emulate/constants/rpcs.py
@@ -32,6 +32,21 @@ not a straightforward, portable way to determine the response code caused by
 the tile resetting from a response code caused by an issue running this RPC.
 """
 
+HARDWARE_VERSION = RPCDeclaration(2, "", "10s")
+"""Get a hardware identification string.
+
+This RPC returns a string of up to 10 bytes (padded with null bytes) to
+a fixed 10 byte length that contains a hardware identification string.
+The meaning of the string is opaque and defined by the firmware that is
+returning this string.  The typical use of this value is to determine
+what tile hardware is running if a given tile firmware is compatible
+with multiple boards.
+
+Returns:
+  - char[10]: A utf-8 hardware string padded with null bytes to 10
+    bytes.
+"""
+
 TILE_STATUS = RPCDeclaration(4, "", "H6s3BB")
 """Query the tile's name and status.
 

--- a/iotileemulate/iotile/emulate/reference/reference_controller.py
+++ b/iotileemulate/iotile/emulate/reference/reference_controller.py
@@ -205,6 +205,23 @@ class ReferenceController(RawSensorLogMixin, RemoteBridgeMixin,
 
         raise TileNotFoundError("Controller tile was reset via an RPC")
 
+    @tile_rpc(*rpcs.HARDWARE_VERSION)
+    def hardware_version(self):
+        """Get a hardware identification string."""
+
+        hardware_string = self.hardware_string
+
+        if not isinstance(hardware_string, bytes):
+            hardware_string = self.hardware_string.encode('utf-8')
+
+        if len(hardware_string) > 10:
+            self._logger.warn("Truncating hardware string that was longer than 10 bytes: %s", self.hardware_string)
+
+        if len(hardware_string) < 10:
+            hardware_string += b'\0'*(10 - len(hardware_string))
+
+        return [hardware_string]
+
     @tile_rpc(0x1008, "", "L8xLL")
     def controller_info(self):
         """Get the controller UUID, app tag and os tag."""

--- a/iotileemulate/iotile/emulate/virtual/emulated_tile.py
+++ b/iotileemulate/iotile/emulate/virtual/emulated_tile.py
@@ -215,6 +215,8 @@ class EmulatedTile(EmulationMixin, VirtualTile):
     app_started = None
     """Default implementation of tiles does not have a separate phase before application code runs."""
 
+    hardware_string = b'pythontile'
+
     def __init__(self, address, name, device):
         if not isinstance(device, EmulatedDevice):
             raise ArgumentError("You can only add an EmulatedTile to an EmulatedDevice", device=device)

--- a/transport_plugins/websocket/RELEASE.md
+++ b/transport_plugins/websocket/RELEASE.md
@@ -4,6 +4,7 @@ All major changes in each released version of the websocket transport plugin are
 
 ## HEAD
 
+- Remove debug logger level to lower the chattiness of the transport plugin
 - Fix python 3 compatibility issue when calling an RPC that throws an exception.
   (Issue #639)
 - open_debug_interface has optional argument connection_string

--- a/transport_plugins/websocket/iotile_transport_websocket/virtual_websocket.py
+++ b/transport_plugins/websocket/iotile_transport_websocket/virtual_websocket.py
@@ -39,7 +39,6 @@ class WebSocketVirtualInterface(VirtualIOTileInterface):
 
         # Set logger
         self.logger = logging.getLogger(__name__)
-        self.logger.setLevel(logging.DEBUG)  # TODO: remove this line
         self.logger.addHandler(logging.NullHandler())
 
         # Initialize states


### PR DESCRIPTION
There are four main effects of this PR:

1. The process by which support wheels are built in `iotile-build` is extended to support more complicated packages that contain many files.  Previously, it was assumed that there would only be a few python modules in a support wheel that were just directly copied and bundled together as part of the build process.  However, this did not allow for those modules to import other modules reliably since the `load_extensions()` method of importing the modules during development would not create a proper package structure to allow for relative imports.  

    As support packages get more complicated because they include tile emulators, it's become important to allow for multiple modules that import each other so the python code in the support packages can be more easily maintained.  To this end, an IOTile component can now declare a `support_package` product that is a normal python package.  This package will become the support wheel and when individual entry points inside of it are loaded during development they will be loaded as proper submodules so that they can import each other as you would expect.  

    This makes complex support packages inside of a component much easier to design and test since they are just standard python packages.  Importantly, they are always imported using their fully unique support distribution name, even during development so that there are not collisions if multiple development components all put their support packages in the `python/support` directories (causing module shadowing on the `support` global package name).

2. It incrementally enhances `iotile-emulate` to allow for returning hardware versions and improves `SerializableState` to allow for serializing more complicated state trees without needing to specify explicit serializers and deserializers.  There is now support for serializing lists and dicts of objects automatically.

3. It removes all explicit references to pkg_resources from `iotile-core` and `iotile-build`, moving them both to using faster alternatives (the `entrypoints` package for entry points).  This is done primarily to allow for faster startup times in the iotile tool, which is quite slow on machines with slow disks such as those with SD cards.  See #644 and #472.  As part of this process the IOTile tool loading process was profiled and key culprits that are particularly slow to import (~ 100 ms each) are deferred.  This was `past.builtins` and `websockets`.  Neither was required to be loaded eagerly.  In testing, these changes were able to speed up the iotile tool's startup time by more than 2x.

4. It adds experimental support for speeding up the `iotile` tool in embedded contexts where the list of installed plugins is static.  In that scenario, there is no need to enumerate all installed packages looking for plugins since the list will not change.  You can instead just cache a list of plugins and look at that list instead.  Two new routines `iotile registry freeze` and `iotile registry unfreeze` are added to cache and remove the cache of plugins, respectively.  These methods are not yet ready for primetime use.  In particular, the rest of CoreTools needs to move completely off of `pkg_resources` before the cache will work completely.  