### PR TITLE
Major iotile-emulate refactor to use asyncio

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,13 +26,20 @@ script:
 - tox -r
 
 deploy:
-  skip_cleanup: true
-  provider: script
-  script: python scripts/release.py $TRAVIS_TAG
-  on:
-    branch: master
-    tags: true
-    condition: $TRAVIS_PYTHON_VERSION = "2.7"
+  - skip_cleanup: true
+    provider: script
+    script: python scripts/release.py $TRAVIS_TAG
+    on:
+      branch: master
+      tags: true
+      condition: $TRAVIS_PYTHON_VERSION = "2.7"
+  - skip_cleanup: true
+    provider: script
+    script: python scripts/release.py $TRAVIS_TAG
+    on:
+      branch: master
+      tags: true
+      condition: $TRAVIS_PYTHON_VERSION = "3.6"
 notifications:
   on_success: always
   on_failure: always

--- a/iotile_ext_cloud/test/conftest.py
+++ b/iotile_ext_cloud/test/conftest.py
@@ -1,5 +1,6 @@
 """Local fixtures for testing iotile-ext-cloud."""
 
+import sys
 import pytest
 from iotile.core.dev.registry import ComponentRegistry
 from iotile.cloud.cloud import IOTileCloud
@@ -102,6 +103,9 @@ def ota_cloud(mock_cloud_private_nossl):
 
 @pytest.fixture(scope="function")
 def simple_hw():
+
+    if sys.version_info < (3, 5):
+        pytest.skip('requires iotile-emulate on python 3.5+')
 
     simple_file = """{{
         "device":

--- a/iotilecore/RELEASE.md
+++ b/iotilecore/RELEASE.md
@@ -2,10 +2,15 @@
 
 All major changes in each released version of `iotile-core` are listed here.
 
+## HEAD
+
+- Add support for `emulated_tile` product to be included in an IOTile Component.
+  This is necessary now that `iotile-emulate` no longer supported python 2 and
+  requires asyncio inside its emulated tiles.
+
 ## 3.26.5
 
 - Remove past.builtins dependency
-
 
 ## 3.26.4
 

--- a/iotilecore/iotile/core/dev/iotileobj.py
+++ b/iotilecore/iotile/core/dev/iotileobj.py
@@ -66,7 +66,8 @@ class IOTile(object):
         "type_package",
         "proxy_plugin",
         "virtual_tile",
-        "virtual_device"
+        "emulated_tile",
+        "virtual_device",
     ])
     """The canonical list of all product types that contain python code.
 
@@ -97,6 +98,7 @@ class IOTile(object):
         "proxy_module": _DevOnlyProduct,
         "proxy_plugin": _DevOnlyProduct,
         "virtual_tile": _DevOnlyProduct,
+        "emulated_tile": _DevOnlyProduct,
         "virtual_device": _DevOnlyProduct,
         "firmware_image": _ReleaseOnlyProduct
     }

--- a/iotilecore/iotile/core/hw/virtual/common_types.py
+++ b/iotilecore/iotile/core/hw/virtual/common_types.py
@@ -243,7 +243,7 @@ class RPCDispatcher(object):
             payload (bytes): A byte string of payload parameters up to 20 bytes
 
         Returns:
-            str: The response payload from the RPC
+            bytes: The response payload from the RPC
         """
         if rpc_id < 0 or rpc_id > 0xFFFF:
             raise RPCInvalidIDError("Invalid RPC ID: {}".format(rpc_id))

--- a/iotilecore/test/test_hw/test_virtual_device_script.py
+++ b/iotilecore/test/test_hw/test_virtual_device_script.py
@@ -1,6 +1,8 @@
 """Tests of the virtual_device script."""
 
 import json
+import sys
+import pytest
 from iotile.core.scripts.virtualdev_script import main as virtualdev_main
 
 def save_device_args(tmpdir, filename, data, parent=None):
@@ -35,6 +37,7 @@ def test_passing_config(tmpdir):
     virtualdev_main(['null', 'realtime_test', '--config', config])
 
 
+@pytest.mark.skipif(sys.version_info < (3,5), reason="requires iotile-emulate on 3.5+")
 def test_tracking_state(tmpdir):
     """Make sure we can track changes to a device's state."""
 
@@ -45,6 +48,7 @@ def test_tracking_state(tmpdir):
     assert out_state.exists()
 
 
+@pytest.mark.skipif(sys.version_info < (3,5), reason="requires iotile-emulate on 3.5+")
 def test_scenario_loading(tmpdir):
     """Make sure we can load a scenario into a device."""
 
@@ -63,6 +67,7 @@ def test_scenario_loading(tmpdir):
     assert out_state.isfile()
 
 
+@pytest.mark.skipif(sys.version_info < (3,5), reason="requires iotile-emulate on 3.5+")
 def test_scenario_loading_list(tmpdir):
     """Make sure we can load a scenario into a device."""
 

--- a/iotileemulate/RELEASE.md
+++ b/iotileemulate/RELEASE.md
@@ -2,7 +2,16 @@
 
 All major changes in each released version of iotile-emulate are listed here.
 
-## HEAD
+## 0.3.0
+
+- Update emulation_demo device to have its own proxy module for the demo tile.
+
+- Increase documentation and review for accuracy after the asyncio port.
+
+- MAJOR REFACTOR: All internal logic is moved to asyncio and python 2
+  compatibility is dropped.  Previous callback code is converted to coroutines
+  and support for backgrounds tasks is added to all tiles and controller 
+  subsystems.
 
 - Add support for hardware version RPC on the controller.  The default
   implementation returns the hardware string 'pythontile'

--- a/iotileemulate/iotile/emulate/__init__.py
+++ b/iotileemulate/iotile/emulate/__init__.py
@@ -1,3 +1,26 @@
+"""A generic RPC-level emulator for any IOTile device.
+
+This package provides a framework that lets you emulate any IOTile device.
+It includes:
+
+- A generic emulation system based on the EmulationLoop class.  This is the
+  basis for the emulation and allows running coroutines simulating tiles
+  inside a single event loop and communication with those coroutines using
+  RPC.
+- A VirtualIOTileDevice subclass EmulatedDevice that includes the
+  EmulationLoop and wraps it in an interface that can be handled to any
+  VirtualInterface and served like a normal virtual device.  This means that
+  you can make an emulated device available over any protocol that has a
+  virtual interface such as bluetooth, websockets or MQTT.
+- A reference implemention of the IOTile bus controller in Python, in the
+  ReferenceController class.  This allows for the emulation of physical IOTile
+  devices by just writing small classes that emulate the behavior of the
+  peripheral tiles.  The ReferenceDevice class is the correct base class for
+  these endeavors.
+- A device adapter that allows you to directly run an EmulatedDevice inside
+  of the iotile tool for testing and demos.
+"""
+
 from .virtual import EmulatedDevice, EmulatedTile, EmulatedPeripheralTile
 from . import constants
 

--- a/iotileemulate/iotile/emulate/demo/__init__.py
+++ b/iotileemulate/iotile/emulate/demo/__init__.py
@@ -2,5 +2,6 @@
 
 from .demo_device import DemoEmulatedDevice
 from .demo_reference import DemoReferenceDevice
+from .demo_proxy import DemoTileProxy
 
-__all__ = ['DemoEmulatedDevice', 'DemoReferenceDevice']
+__all__ = ['DemoEmulatedDevice', 'DemoReferenceDevice', 'DemoTileProxy']

--- a/iotileemulate/iotile/emulate/demo/demo_device.py
+++ b/iotileemulate/iotile/emulate/demo/demo_device.py
@@ -1,19 +1,123 @@
-"""A simple emulated reference device that includes a blank non-controller tile."""
+"""A simple emulated reference device that includes a demo non-controller tile.
 
+The demo emulated Peripheral tile showcases the 4 kinds of things that you can
+do on an EmulatedPeripheralTile:
+
+- Normal synchronous RPCS: These are methods decorated with the
+  @tile_rpc decorator and directly invocable using the `rpc` method on an
+  EmulatedDevice or via a proxy class.  The methods are run in the
+  EmulationLoop inside of the RPC dispatch task.
+
+  They may not yield since they are not coroutines.  If they block the entire
+  emulation loop will block until they finish.  For that reason, they should
+  not block.
+
+- Asynchronous RPCS: These are RPCs whose implementation requires that they
+  return their result via a callback.  In physical IOTile devices this is
+  usually because the operation requires an unbounded amount of time to
+  complete, such as asking an external sensor for a value that could take many
+  ms to respond.
+
+  These RPCs are typically implemented by queuing work for a background task
+  and then raising AsynchronousRPCResponse().  This notifies the RPC dispatch
+  that the RPC will be returning its response later and allows for other RPCs
+  to be dispatched in the meantime.
+
+  A background worker task associated with this tile can then call
+  EmulatedDevice.finish_async_rpc when it wants to complete the RPC call.
+
+  From the point of view of the caller of the RPC, it will block until
+  finish_async_rpc has been called with the response and it does not have any
+  way to know whether the response was given immediately or via a callback to
+  finish_async_rpc.  Put another way, RPCs are always synchronous from the
+  caller's perspective.  It is just that sometimes you don't want to block the
+  RPC dispatch during a long-running RPC so that other callers can send RPCs
+  while your caller is still waiting for its response.
+
+- Background Loops: In a physical tile, there is a single main loop and
+  RPC handlers are invoked as interrupts.  In EmulatedPeripheralTile subclasses,
+  the _application_main() coroutine is the equivalent of the main loop.
+
+  It is launched when the tile starts and should loop forever.  It is canceled
+  clenaly when the tile is reset and started again.  If you need to perform
+  tasks periodically that are not related to any specific RPC, they should
+  go inside your _application_main().  Similarly, if you support asynchronous
+  rpcs, they should be implemented by queuing work that is processed by
+  _application_main().
+
+- Coroutine RPCs: For some RPCs it may be easier to implement them if they can
+  await an object.  In this case the RPC never raises AsynchronousRPCResponse
+  and still blocks the RPC dispatch thread until it finishes, it is just that
+  you are allowed to `await` an object inside your implementation.  These RPCs
+  must be decorated with `@async_tile_rpc` instead of `@tile_rpc`.
+
+The DemoEmulatedTile class in this module shows an example of how to perform
+each of these 4 things.  Note that for ease of implementation, peripheral
+tiles are able to directly stream and trace data out of the EmulatedDevice
+rather than needing to invoke an RPC on the controller to stream or trace on
+their behalf.
+"""
+
+import asyncio
+import logging
 from iotile.core.hw.virtual import tile_rpc
 from iotile.core.hw.virtual.common_types import AsynchronousRPCResponse, pack_rpc_payload
 from ..virtual import EmulatedPeripheralTile
+from ..internal import async_tile_rpc
 from ..reference import ReferenceDevice
 
 
 class DemoEmulatedTile(EmulatedPeripheralTile):
-    """A basic demo emulated tile with an async rpc."""
+    """A basic emulated tile showing all of the things you can do.
 
-    def __init__(self, address, name, device):
-        super(DemoEmulatedTile, self).__init__(address, name, device)
+    This demo tile has a trivial main loop that pulls work queued by RPCs and
+    executes it.  It has several synchronous RPCs, one asynchronous RPC, an
+    RPC implemented as a coroutine and an RPC that triggers the tile to trace
+    a bunch of binary data.
+    """
+
+    name = b'emudmo'
+
+    def __init__(self, address, device):
+        super(DemoEmulatedTile, self).__init__(address, device)
         self.register_scenario('loaded_counter', self.load_counter)
         self._counter = 0
+        self._work = device.emulator.create_queue(register=False)
+        self._logger = logging.getLogger(__name__)
 
+    async def _application_main(self):
+        self.initialized.set()
+
+        while True:
+            action, args = await self._work.get()
+
+            try:
+                if action == 'echo':
+                    rpc_id, arg = args
+                    self._device.emulator.finish_async_rpc(self.address, rpc_id, pack_rpc_payload("L", (arg,)))
+                elif action == 'trace':
+                    byte_count = args
+                    chunks = byte_count // 20
+                    if byte_count % 20:
+                        chunks += 1
+
+                    for i in range(0, chunks):
+                        chunk_length = min(byte_count - i*20, 20)
+                        data = bytes(range(0, chunk_length))
+
+                        self._logger.debug("Tracing chunk %d/%d (size=%d)", i + 1, chunks, chunk_length)
+
+                        success = await self._device.trace_sync(data)
+                        if not success:
+                            self._logger.error("Failure sending chunk %d, aborting", i)
+                            break
+
+                    if success:
+                        self._logger.info("Finished sending %d chunks of tracing data", chunks)
+                else:
+                    self._logger.error("Unknown action in main loop: %s", action)
+            except:
+                self._logger.exception("Error processing background action: action=%s, args=%s", action, args)
 
     def load_counter(self, counter):
         """Load the counter value of this device."""
@@ -23,7 +127,7 @@ class DemoEmulatedTile(EmulatedPeripheralTile):
     def async_echo(self, arg):
         """Asynchronously echo the argument number."""
 
-        self._device.deferred_task(self._device.finish_async_rpc, self.address, 0x8000, pack_rpc_payload("L", (arg,)), sync=False)
+        self._work.put_nowait(('echo', (0x8000, arg)))
         raise AsynchronousRPCResponse()
 
     @tile_rpc(0x8001, "L", "L")
@@ -40,11 +144,29 @@ class DemoEmulatedTile(EmulatedPeripheralTile):
         self._counter += 1
         return [value]
 
+    @tile_rpc(0x8003, "L", "")
+    def start_trace(self, count):
+        """Start tracing a given number of bytes."""
+
+        self._work.put_nowait(('trace', count))
+        return []
+
+    @async_tile_rpc(0x8004, "L", "L")
+    async def coroutine_echo(self, arg):
+        """Wait for a small delay and then echo.
+
+        This method shows an example of how to implement an RPC as a
+        coroutine.
+        """
+
+        await asyncio.sleep(0.01)
+        return [arg]
+
 
 class DemoEmulatedDevice(ReferenceDevice):
     """A basic emulated device that includes a single blank tile in addition to the reference controller.
 
-    The blank tile in slot 1 has module name abcdef and the following two config variables declared
+    The blank tile in slot 1 has module name emudmo and the following two config variables declared
     to allow for testing config variable usage and streaming:
 
     - 0x8000: uint32_t
@@ -63,7 +185,7 @@ class DemoEmulatedDevice(ReferenceDevice):
     def __init__(self, args):
         super(DemoEmulatedDevice, self).__init__(args)
 
-        peripheral = DemoEmulatedTile(11, 'abcdef', device=self)
+        peripheral = DemoEmulatedTile(11, device=self)
         peripheral.declare_config_variable('test 1', 0x8000, 'uint32_t')
         peripheral.declare_config_variable('test 2', 0x8001, 'uint8_t[16]')
 

--- a/iotileemulate/iotile/emulate/demo/demo_proxy.py
+++ b/iotileemulate/iotile/emulate/demo/demo_proxy.py
@@ -1,0 +1,78 @@
+"""A simply proxy class for controlling the DemoEmulatedTile."""
+
+from typedargs.annotate import docannotate, context
+from iotile.core.hw.proxy import TileBusProxyObject
+from iotile.core.exceptions import ArgumentError
+
+@context("DemoTile")
+class DemoTileProxy(TileBusProxyObject):
+    @classmethod
+    def ModuleName(cls):
+        return 'emudmo'
+
+    @docannotate
+    def trace_data(self, byte_count):
+        """Trigger the tracing of data.
+
+        This method lets you test receiving traced data out of a device. It
+        will synchronously wait unitl the given number of bytes have been
+        received.
+
+        Args:
+            byte_count (int): The number of bytes that should be traced.
+
+        Returns:
+            int: The number of bytes that were successfully received.
+        """
+
+        self.rpc_v2(0x8003, "L", "", byte_count)
+
+        data = self._hwmanager.wait_trace(byte_count, timeout=((.15 * ((byte_count // 20) + 1)) + .5))
+        return len(data)
+
+    @docannotate
+    def fetch_counter(self):
+        """Fetch and increment the tile's counter value.
+
+        This method returns the current counter and causes the tile
+        to increment it by one.
+
+        Returns:
+            int: The current counter value before incrementing.
+        """
+
+        data, = self.rpc_v2(0x8002, "", "L")
+        return data
+
+    @docannotate
+    def echo(self, value, method="sync"):
+        """Echo a number.
+
+        The echo RPC on the emulated tile are implemented using
+        three different methods that you can choose by passing
+        method=(sync|async|coroutine)
+
+        The result of all three methods is the same from the caller's
+        point of view.
+
+        Args:
+            value (int): The value to echo
+            method (str): The specific RPC implementation to use.  This
+                may be sync, async or coroutine.
+
+        Returns:
+            int: The echoed value.
+        """
+
+        rpc_map = {
+            'sync': 0x8001,
+            'async': 0x8000,
+            'coroutine': 0x8004
+        }
+
+        rpc_id = rpc_map.get(method)
+        if rpc_id is None:
+            raise ArgumentError("Unknown method: %s" % method, known_methods=list(rpc_map))
+
+        response, = self.rpc_v2(rpc_id, "L", "L", value)
+        return response

--- a/iotileemulate/iotile/emulate/internal/__init__.py
+++ b/iotileemulate/iotile/emulate/internal/__init__.py
@@ -1,0 +1,11 @@
+"""The internal emulation mechanisms that are used inside EmulatedDevice.
+
+This subpackage provides the EmulationLoop that can run tasks simulating the
+main threads of tiles as well as dispatch rpcs between the tiles.
+"""
+
+from .emulation_loop import EmulationLoop
+from .async_rpc import async_tile_rpc
+from .response import CrossThreadResponse, AwaitableResponse
+
+__all__ = ['EmulationLoop', 'async_tile_rpc', 'CrossThreadResponse', 'AwaitableResponse']

--- a/iotileemulate/iotile/emulate/internal/async_rpc.py
+++ b/iotileemulate/iotile/emulate/internal/async_rpc.py
@@ -1,0 +1,90 @@
+import binascii
+import struct
+from iotile.core.hw.virtual.common_types import RPCInvalidIDError, unpack_rpc_payload, pack_rpc_payload, RPCInvalidArgumentsError, RPCInvalidReturnValueError
+
+
+def async_rpc(address, rpc_id, arg_format, resp_format=None):
+    """Decorator to denote that a function implements an RPC with the given ID and address.
+
+    The underlying function should be a member function that will take
+    individual parameters after the RPC payload has been decoded according
+    to arg_format.
+
+    Arguments to the function are decoded from the 20 byte RPC argument payload according
+    to arg_format, which should be a format string that can be passed to struct.unpack.
+
+    Similarly, the function being decorated should return an iterable of results that
+    will be encoded into a 20 byte response buffer by struct.pack using resp_format as
+    the format string.
+
+    The RPC will respond as if it were implemented by a tile at address ``address`` and
+    the 16-bit RPC id ``rpc_id``.
+
+    Args:
+        address (int): The address of the mock tile this RPC is for
+        rpc_id (int): The number of the RPC
+        arg_format (string): a struct format code (without the <) for the
+            parameter format for this RPC.  This format code may include the final
+            character V, which means that it expects a variable length bytearray.
+        resp_format (string): an optional format code (without the <) for
+            the response format for this RPC. This format code may include the final
+            character V, which means that it expects a variable length bytearray.
+    """
+
+    if rpc_id < 0 or rpc_id > 0xFFFF:
+        raise RPCInvalidIDError("Invalid RPC ID: {}".format(rpc_id))
+
+    def _rpc_wrapper(func):
+        async def _rpc_executor(self, payload):
+            try:
+                args = unpack_rpc_payload(arg_format, payload)
+            except struct.error as exc:
+                raise RPCInvalidArgumentsError(str(exc), arg_format=arg_format, payload=binascii.hexlify(payload))
+
+            resp = await func(self, *args)
+
+            if resp is None:
+                resp = []
+
+            if resp_format is not None:
+                try:
+                    return pack_rpc_payload(resp_format, resp)
+                except struct.error as exc:
+                    raise RPCInvalidReturnValueError(str(exc), resp_format=resp_format, resp=repr(resp))
+
+            return resp
+
+        _rpc_executor.rpc_id = rpc_id
+        _rpc_executor.rpc_addr = address
+        _rpc_executor.is_rpc = True
+        return _rpc_executor
+
+    return _rpc_wrapper
+
+
+def async_tile_rpc(rpc_id, arg_format, resp_format=None):
+    """Decorator to denote that a function implements an RPC with the given ID on a tile.
+
+    The underlying function should be a member function that will take
+    individual parameters after the RPC payload has been decoded according
+    to arg_format.
+
+    Arguments to the function are decoded from the 20 byte RPC argument payload according
+    to arg_format, which should be a format string that can be passed to struct.unpack.
+
+    Similarly, the function being decorated should return an iterable of results that
+    will be encoded into a 20 byte response buffer by struct.pack using resp_format as
+    the format string.
+
+    The RPC will respond as if it were implemented by a tile at address ``address`` and
+    the 16-bit RPC id ``rpc_id``.
+
+    Args:
+        rpc_id (int): The number of the RPC
+        arg_format (string): a struct format code (without the <) for the
+            parameter format for this RPC
+        resp_format (string): an optional format code (without the <) for
+            the response format for this RPC
+    """
+
+    return async_rpc(None, rpc_id, arg_format, resp_format)

--- a/iotileemulate/iotile/emulate/internal/emulation_loop.py
+++ b/iotileemulate/iotile/emulate/internal/emulation_loop.py
@@ -1,0 +1,453 @@
+"""Main class where all emulation takes place."""
+
+import sys
+import threading
+import logging
+import asyncio
+
+from iotile.core.exceptions import ArgumentError, InternalError, TimeoutExpiredError
+from iotile.core.hw.virtual.common_types import unpack_rpc_payload, pack_rpc_payload
+
+from .response import CrossThreadResponse, AwaitableResponse
+from .rpc_queue import RPCQueue
+from ..constants.rpcs import RPCDeclaration
+
+if sys.version_info < (3, 5):
+    raise ImportError("EmulationLoop is only supported on python 3.5 and above")
+
+
+class EmulationLoop:
+    """A background thread that runs an event loop emulating a device.
+
+    The loop is started when start() is called and cleanly stopped when stop()
+    is called.  Coroutines can be added to the event loop that are tracked and
+    can be stopped to simulate a device reset.
+
+    The loop is executed on a background thread so that you can control the
+    loop from the main thread.  Since this loop is designed for simulating an
+    IOTile device as part of a larger emulator, it naturally has support for
+    invoking RPCs inside the loop.  You must provide a handler function that
+    actually dispatches the rpc.  Your handler will always be run inside the
+    event loop.  There are two ways to invoke the rpcs, `await_rpc` and
+    `call_rpc_external`.
+
+    `await_rpc` must always be called from a coroutine inside the event loop
+    and returns an awaitable. `call_rpc_external` must never be called from
+    the event loop and is designed to be used by external callers to inject
+    RPCs into the emulation.
+
+    Unlike a normal asyncio.EventLoop, which does not have an externally
+    visible concept of being idle, there is a method `wait_idle()` on
+    EmulationLoop that will block until the emulator is idle.  Idleness is
+    defined as when all internal workqueues inside the emulated device are
+    empty.  This includes having no pending RPCs as a base condition, but any
+    tile can also register work queues that contain background work and must
+    be empty for the emulator to be considered idle.
+
+    The ``wait_idle()`` method is the primary way that external users are able
+    to synchronously interact with the EmulationLoop.  They can apply a
+    stimulus like sending and RPC and then call wait_idle() to wait until all
+    of the ripples of the RPC have settled down.  This allows for writing
+    simple synchronous code that interacts with the EmulationLoop externally.
+
+    Args:
+        rpc_handler (callable): The method that actually dispatches each RPC.
+            This method will always be invoked inside of the event loop.
+    """
+
+    def __init__(self, rpc_handler):
+        self._loop = asyncio.new_event_loop()
+        self._thread = None
+        self._started = False
+        self._tasks = {}
+        self._rpc_queue = RPCQueue(self._loop, rpc_handler)
+        self._work_queues = set([self._rpc_queue])
+        self._events = set()
+        self._thread_check = threading.local()
+        self._logger = logging.getLogger(__name__)
+
+    def create_event(self, register=False):
+        """Create an asyncio.Event inside the emulation loop.
+
+        This method exists as a convenience to create an Event object that is
+        associated with the correct EventLoop().  If you pass register=True,
+        then the event will be registered as an event that must be set for the
+        EmulationLoop to be considered idle.  This means that whenever
+        wait_idle() is called, it will block until this event is set.
+
+        Examples of when you may want this behavior is when the event is
+        signaling whether a tile has completed restarting itself.  The reset()
+        rpc cannot block until the tile has initialized since it may need to
+        send its own rpcs as part of the initialization process.  However, we
+        want to retain the behavior that once the reset() rpc returns the tile
+        has been completely reset.
+
+        The cleanest way of achieving this is to have the tile set its
+        self.initialized Event when it has finished rebooting and register
+        that event so that wait_idle() nicely blocks until the reset process
+        is complete.
+
+        Args:
+            register (bool): Whether to register the event so that wait_idle
+                blocks until it is set.
+
+        Returns:
+            asyncio.Event: The Event object.
+        """
+
+        event = asyncio.Event(loop=self._loop)
+        if register:
+            self._events.add(event)
+
+        return event
+
+    def create_queue(self, register=False):
+        """Create a new work queue and optionally register it.
+
+        This will make sure the queue is attached to the correct event loop.
+        You can optionally choose to automatically register it so that
+        wait_idle() will block until the queue is empty.
+
+        Args:
+            register (bool): Whether to call register_workqueue() automatically.
+
+        Returns:
+            asyncio.Queue: The newly created queue.
+        """
+
+        queue = asyncio.Queue(loop=self._loop)
+        if register:
+            self._work_queues.add(queue)
+
+        return queue
+
+    def get_current_rpc(self):
+        """Get the currently running RPC for asynchronous responses.
+
+        Returns the address and rpc_id of the RPC that is currently being
+        dispatched. This information can be saved and passed later to
+        finish_async_rpc() to send a response to an asynchronous rpc.
+
+        Returns:
+            (address, rpc_id): A tuple with the currently running RPC.
+        """
+
+        self.verify_calling_thread(True, "Only the emulation thread is allowed to inspect the current rpc")
+        return self._rpc_queue.get_current_rpc()
+
+    def finish_async_rpc(self, address, rpc_id, response):
+        """Finish a previous asynchronous RPC.
+
+        This method should be called by a peripheral tile that previously
+        had an RPC called on it and chose to response asynchronously by
+        raising ``AsynchronousRPCResponse`` in the RPC handler itself.
+
+        The response passed to this function will be returned to the caller
+        as if the RPC had returned it immediately.
+
+        This method must only ever be called from a coroutine inside the
+        emulation loop that is handling background work on behalf of a tile.
+
+        Args:
+            address (int): The tile address the RPC was called on.
+            rpc_id (int): The ID of the RPC that was called.
+            response (bytes): The bytes that should be returned to
+                the caller of the RPC.
+        """
+
+        self.verify_calling_thread(True, "All asynchronous rpcs must be finished from within the emulation loop")
+        self._rpc_queue.finish_async_rpc(address, rpc_id, response)
+
+    def start(self):
+        """Start the background emulation loop."""
+
+        if self._started is True:
+            raise ArgumentError("EmulationLoop.start() called multiple times")
+
+        self._thread = threading.Thread(target=self._loop_thread_main)
+        self._thread.start()
+        self._started = True
+
+    def stop(self):
+        """Stop the background emulation loop."""
+
+        if self._started is False:
+            raise ArgumentError("EmulationLoop.stop() called without calling start()")
+
+        self.verify_calling_thread(False, "Cannot call EmulationLoop.stop() from inside the event loop")
+
+        if self._thread.is_alive():
+            self._loop.call_soon_threadsafe(self._loop.create_task, self._clean_shutdown())
+            self._thread.join()
+
+    def wait_idle(self, timeout=1.0):
+        """Wait until the rpc queue is empty.
+
+        This method may be called either from within the event loop or from
+        outside of it.  If it is called outside of the event loop it will
+        block the calling thread until the rpc queue is temporarily empty.
+
+        If it is called from within the event loop it will return an awaitable
+        object that can be used to wait for the same condition.
+
+        The awaitable object will already have a timeout if the timeout
+        parameter is passed.
+
+        Args:
+            timeout (float): The maximum number of seconds to wait.
+        """
+
+        async def _awaiter():
+            background_work = {x.join() for x in self._work_queues}
+            for event in self._events:
+                if not event.is_set():
+                    background_work.add(event.wait())
+
+            _done, pending = await asyncio.wait(background_work, timeout=timeout)
+            if len(pending) > 0:
+                raise TimeoutExpiredError("Timeout waiting for event loop to become idle", pending=pending)
+
+        if self._on_emulation_thread():
+            return asyncio.wait_for(_awaiter(), timeout=timeout)
+
+        self.run_task_external(_awaiter())
+        return None
+
+    def run_task_external(self, coroutine):
+        """Inject a task into the emulation loop and wait for it to finish.
+
+        The coroutine parameter is run as a Task inside the EmulationLoop
+        until it completes and the return value (or any raised Exception) is
+        pased back into the caller's thread.
+
+        Args:
+            coroutine (coroutine): The task to inject into the event loop.
+
+        Returns:
+            object: Whatever the coroutine returned.
+        """
+
+        self.verify_calling_thread(False, 'run_task_external must not be called from the emulation thread')
+
+        future = asyncio.run_coroutine_threadsafe(coroutine, self._loop)
+        return future.result()
+
+    def call_rpc_external(self, address, rpc_id, arg_payload, timeout=10.0):
+        """Call an RPC from outside of the event loop and block until it finishes.
+
+        This is the main method by which a caller outside of the EmulationLoop
+        can inject an RPC into the EmulationLoop and wait for it to complete.
+        This method is synchronous so it blocks until the RPC completes or the
+        timeout expires.
+
+        Args:
+            address (int): The address of the mock tile this RPC is for
+            rpc_id (int): The number of the RPC
+            payload (bytes): A byte string of payload parameters up to 20 bytes
+            timeout (float): The maximum time to wait for the RPC to finish.
+
+        Returns:
+            bytes: The response payload from the RPC
+        """
+
+        self.verify_calling_thread(False, "call_rpc_external is for use **outside** of the event loop")
+
+        response = CrossThreadResponse()
+
+        self._loop.call_soon_threadsafe(self._rpc_queue.put_rpc, address, rpc_id, arg_payload, response)
+
+        return response.wait(timeout)
+
+    async def await_rpc(self, address, rpc_id, *args, **kwargs):
+        """Send an RPC from inside the EmulationLoop.
+
+        This is the primary method by which tasks running inside the
+        EmulationLoop dispatch RPCs.  The RPC is added to the queue of waiting
+        RPCs to be drained by the RPC dispatch task and this coroutine will
+        block until it finishes.
+
+        **This method must only be called from inside the EmulationLoop**
+
+        Args:
+            address (int): The address of the tile that has the RPC.
+            rpc_id (int): The 16-bit id of the rpc we want to call
+            *args: Any required arguments for the RPC as python objects.
+            **kwargs: Only two keyword arguments are supported:
+                - arg_format: A format specifier for the argument list
+                - result_format: A format specifier for the result
+
+        Returns:
+            list: A list of the decoded response members from the RPC.
+        """
+
+        self.verify_calling_thread(True, "await_rpc must be called from **inside** the event loop")
+
+        if isinstance(rpc_id, RPCDeclaration):
+            arg_format = rpc_id.arg_format
+            resp_format = rpc_id.resp_format
+            rpc_id = rpc_id.rpc_id
+        else:
+            arg_format = kwargs.get('arg_format', None)
+            resp_format = kwargs.get('resp_format', None)
+
+        arg_payload = b''
+
+        if arg_format is not None:
+            arg_payload = pack_rpc_payload(arg_format, args)
+
+        self._logger.debug("Sending rpc to %d:%04X, payload=%s", address, rpc_id, args)
+
+        response = AwaitableResponse()
+        self._rpc_queue.put_rpc(address, rpc_id, arg_payload, response)
+
+        resp_payload = await response.wait(1.0)
+
+        if resp_format is None:
+            return []
+
+        resp = unpack_rpc_payload(resp_format, resp_payload)
+        return resp
+
+    def verify_calling_thread(self, should_be_emulation, message=None):
+        """Verify if the calling thread is or is not the emulation thread.
+
+        This method can be called to make sure that an action is being taken
+        in the appropriate context such as not blocking the event loop thread
+        or modifying an emulate state outside of the event loop thread.
+
+        If the verification fails an InternalError exception is raised,
+        allowing this method to be used to protect other methods from being
+        called in a context that could deadlock or cause race conditions.
+
+        Args:
+            should_be_emulation (bool): True if this call should be taking place
+                on the emulation, thread, False if it must not take place on
+                the emulation thread.
+            message (str): Optional message to include when raising the exception.
+                Otherwise a generic message is used.
+
+        Raises:
+            InternalError: When called from the wrong thread.
+        """
+
+        if should_be_emulation == self._on_emulation_thread():
+            return
+
+        if message is None:
+            message = "Operation performed on invalid thread"
+
+        raise InternalError(message)
+
+    def add_task(self, tile_address, coroutine):
+        """Add a task into the event loop.
+
+        This is the main entry point for registering background tasks that are
+        associated with a tile. The tasks are added to the EmulationLoop and
+        the tile they are a part of is recorded.  When the tile is reset, all
+        of its background tasks are canceled as part of the reset process.
+
+        If you have a task that should not be associated with any tile, you
+        may pass `None` for tile_address and the task will not be cancelled
+        when any tile is reset.
+
+        Args:
+            tile_address (int): The address of the tile running
+                the task.
+            coroutine (coroutine): A coroutine that will be added
+                to the event loop.
+        """
+
+        self._loop.call_soon_threadsafe(self._add_task, tile_address, coroutine)
+
+    def _loop_thread_main(self):
+        try:
+            self._thread_check.is_rpc_thread = True
+            self._logger.debug("Starting emulation loop in background thread")
+
+            self._rpc_queue.start()
+
+            self._loop.run_forever()
+        except:  #pylint:disable=bare-except;This is a logging statement in a background thread
+            self._logger.exception("Exception raised from emulation loop thread")
+        finally:
+            self._logger.debug("Ending emulation loop thread because loop returned")
+
+            self._loop.run_until_complete(self._loop.shutdown_asyncgens())
+            self._loop.close()
+
+            self._logger.debug("Finished loop")
+
+    def _on_emulation_thread(self):
+        """Returns whether we are running on the emulation thread.
+
+        Returns:
+            bool: True if we are on the emulation thread, else False.
+        """
+
+        return self._thread_check.__dict__.get('is_rpc_thread', False)
+
+    async def stop_tasks(self, address):
+        """Clear all tasks pertaining to a tile.
+
+        This coroutine will synchronously cancel all running tasks that were
+        attached to the given tile and wait for them to stop before returning.
+
+        Args:
+            address (int): The address of the tile we should stop.
+        """
+
+        tasks = self._tasks.get(address, [])
+        for task in tasks:
+            task.cancel()
+
+        asyncio.gather(*tasks, return_exceptions=True)
+        self._tasks[address] = []
+
+    async def _clean_shutdown(self):
+        """Cleanly shutdown the emulation loop."""
+
+        # Cleanly stop any other outstanding tasks not associated with tiles
+        remaining_tasks = []
+        for task in self._tasks.get(None, []):
+            self._logger.debug("Cancelling task at shutdown %s", task)
+            task.cancel()
+
+            remaining_tasks.append(task)
+
+        asyncio.gather(*remaining_tasks, return_exceptions=True)
+
+        if len(remaining_tasks) > 0:
+            del self._tasks[None]
+
+        # Shutdown tasks associated with each tile
+        remaining_tasks = []
+
+        for address in sorted(self._tasks, reverse=True):
+            if address is None:
+                continue
+
+            self._logger.debug("Shutting down tasks for tile at %d", address)
+            for task in self._tasks.get(address, []):
+                task.cancel()
+                remaining_tasks.append(task)
+
+        asyncio.gather(*remaining_tasks, return_exceptions=True)
+
+        await self._rpc_queue.stop()
+
+        self._loop.stop()
+
+    def _add_task(self, tile_address, coroutine):
+        """Add a task from within the event loop.
+
+        All tasks are associated with a tile so that they can be cleanly
+        stopped when that tile is reset.
+        """
+
+        self.verify_calling_thread(True, "_add_task is not thread safe")
+
+        if tile_address not in self._tasks:
+            self._tasks[tile_address] = []
+
+        task = self._loop.create_task(coroutine)
+        self._tasks[tile_address].append(task)

--- a/iotileemulate/iotile/emulate/internal/response.py
+++ b/iotileemulate/iotile/emulate/internal/response.py
@@ -1,0 +1,165 @@
+"""Response objects that allow synchronously waiting for things from the EmulationLoop.
+
+There are two kinds of Response objects: AwaitableResponse that wraps a Future
+object for use from a coroutine and CrossThreadResponse that is for waiting
+for a response from the event loop by another thread.
+
+Their APIs are identical so that they can be used interchangeably.
+"""
+
+import sys
+import threading
+import asyncio
+
+from iotile.core.exceptions import InternalError, TimeoutExpiredError
+
+class GenericResponse:
+    """Base class for asynchronous operation responses."""
+
+    def __init__(self):
+        self._result = None
+        self._exception = None
+
+    def set_result(self, result):
+        """Finish this response and set the result."""
+
+        if self.is_finished():
+            raise InternalError("set_result called on finished AsynchronousResponse",
+                                result=self._result, exception=self._exception)
+
+        self._result = result
+        self.finish()
+
+    def set_exception(self, exc_class, exc_info, exc_stack):
+        """Set an exception as the result of this operation.
+
+        Args:
+            exc_class (object): The exception type """
+
+        if self.is_finished():
+            raise InternalError("set_exception called on finished AsynchronousResponse",
+                                result=self._result, exception=self._exception)
+
+        self._exception = (exc_class, exc_info, exc_stack)
+        self.finish()
+
+    def capture_exception(self):
+        """Capture the current exception context."""
+
+        self.set_exception(*sys.exc_info())
+
+    # Implementation from future.utils.raise_
+    def _raise_exception(self):
+        if self._exception is None:
+            raise InternalError("No exception stored in call to _raise_exception")
+
+        exc_type, value, traceback = self._exception
+
+        if value is not None and isinstance(exc_type, Exception):
+            raise TypeError("instance exception may not have a separate value")
+
+        if value is not None:
+            exc = exc_type(value)
+        else:
+            exc = exc_type
+
+        if exc.__traceback__ is not traceback:
+            raise exc.with_traceback(traceback)
+
+        raise exc
+
+    def finish(self):
+        """Finish this operation without any value."""
+        raise NotImplementedError()
+
+    def is_finished(self):
+        """Check if this operation is finished.
+
+        Returns:
+            bool: True if the operation is finished.
+        """
+        raise NotImplementedError()
+
+
+class CrossThreadResponse(GenericResponse):
+    """A cross-thread future object that can be waited on.
+
+    This object encapsulates returning a response from the EmulationLoop to a
+    caller in a different thread.  It is waitable and can pass either a result
+    or an exception, which is raised in the calling thread.
+    """
+
+    def __init__(self):
+        super(CrossThreadResponse, self).__init__()
+        self._finished = threading.Event()
+        self._callbacks = []
+
+    def finish(self):
+        self._finished.set()
+
+        if len(self._callbacks) > 0:
+            for callback in self._callbacks:
+                callback(self._exception, self._result)
+
+    def add_callback(self, callback):
+        """TEMPORARY METHOD"""
+        self._callbacks.append(callback)
+
+    def is_finished(self):
+        return self._finished.is_set()
+
+    def wait(self, timeout=None):
+        """Wait for this operation to finish.
+
+        You can specify an optional timeout that defaults to no timeout if
+        None is passed.  The result of the operation is returned from this
+        method. If the operation raised an exception, it is reraised from this
+        method.
+
+        Args:
+            timeout (float): The maximum number of seconds to wait before timing
+                out.
+        """
+
+        flag = self._finished.wait(timeout=timeout)
+        if flag is False:
+            raise TimeoutExpiredError("Timeout waiting for response to event loop operation")
+
+        if self._exception is not None:
+            self._raise_exception()
+
+        return self._result
+
+
+class AwaitableResponse(GenericResponse):
+    """Asynchronous response for use inside the event loop."""
+
+    def __init__(self):
+        super(AwaitableResponse, self).__init__()
+        self._future = asyncio.get_event_loop().create_future()
+
+    def finish(self):
+        self._future.set_result(None)
+
+    def is_finished(self):
+        return self._future.done()
+
+    async def wait(self, timeout=None):
+        """Wait for this operation to finish.
+
+        You can specify an optional timeout that defaults to no timeout if
+        None is passed.  The result of the operation is returned from this
+        method. If the operation raised an exception, it is reraised from this
+        method.
+
+        Args:
+            timeout (float): The maximum number of seconds to wait before timing
+                out.
+        """
+
+        await asyncio.wait_for(self._future, timeout)
+
+        if self._exception is not None:
+            self._raise_exception()
+
+        return self._result

--- a/iotileemulate/iotile/emulate/internal/rpc_queue.py
+++ b/iotileemulate/iotile/emulate/internal/rpc_queue.py
@@ -1,0 +1,192 @@
+"""Helper class for dispatching rpcs inside the emulation loop."""
+
+import asyncio
+import logging
+import inspect
+from iotile.core.exceptions import InternalError, ArgumentError
+from iotile.core.hw.virtual.common_types import AsynchronousRPCResponse
+
+class RPCQueue:
+    """Coroutine based RPC dispatcher.
+
+    This class wraps a coroutine draining an asyncio.Queue to dispatch RPCS.
+    It keeps track of RPCs that are in progress and allows joining the queue
+    to wait for an idle moment when no RPCs are pending or in progress.
+
+    This class is primarily used to simplify the implementation of
+    EmulationLoop, which creates an RPCQueue and interacts with it.
+
+    The primary mode of interaction with this class is to call:
+
+    - put_rpc(address, rpc_id, payload, response)
+    - put_task(func, args, response)
+
+    Those methods will add work to the RPC queue, which will be performed
+    asynchronously by the background dispatcher task.  When a work item is
+    finished, the response object passed in will be notified with the result.
+
+    Args:
+        loop (asyncio.EventLoop): The event loop this queue should be attached
+            to.
+        rpc_handler (callable): The actual handler function that we should use
+            to run each RPC and get the result.
+    """
+
+    def __init__(self, loop, rpc_handler):
+        self._rpc_handler = rpc_handler
+        self._loop = loop
+        self._rpc_queue = asyncio.Queue(loop=loop)
+        self._current_rpc = None
+        self._rpc_task = None
+        self._pending_rpcs = {}
+        self._logger = logging.getLogger(__name__)
+
+    def put_task(self, func, args, response):
+        """Place a task onto the RPC queue.
+
+        This temporary functionality will go away but it lets you run a
+        task synchronously with RPC dispatch by placing it onto the
+        RCP queue.
+
+        Args:
+            func (callable): The function to execute
+            args (iterable): The function arguments
+            response (GenericResponse): The response object to signal the
+                result on.
+        """
+
+        self._rpc_queue.put_nowait((func, args, response))
+
+    def put_rpc(self, address, rpc_id, arg_payload, response):
+        """Place an RPC onto the RPC queue.
+
+        The rpc will be dispatched asynchronously by the background dispatch
+        task.  This method must be called from the event loop.  This method
+        does not block.
+
+        Args:
+            address (int): The address of the tile with the RPC
+            rpc_id (int): The id of the rpc you want to call
+            arg_payload (bytes): The RPC payload
+            respones (GenericResponse): The object to use to signal the result.
+        """
+
+        self._rpc_queue.put_nowait((address, rpc_id, arg_payload, response))
+
+    def join(self):
+        """Wait for the RPC queue to be empty.
+
+        Returns:
+            awaitable
+        """
+
+        return self._rpc_queue.join()
+
+    def get_current_rpc(self):
+        """Get the currently running RPC for asynchronous responses.
+
+        Returns the address and rpc_id of the RPC that is currently being
+        dispatched. This information can be saved and passed later to
+        finish_async_rpc() to send a response to an asynchronous rpc.
+
+        Returns:
+            (address, rpc_id): A tuple with the currently running RPC.
+        """
+
+        if self._current_rpc is None:
+            raise InternalError("There is no current RPC running")
+
+        return self._current_rpc
+
+    def finish_async_rpc(self, address, rpc_id, response):
+        """Finish a previous asynchronous RPC.
+
+        This method should be called by a peripheral tile that previously
+        had an RPC called on it and chose to response asynchronously by
+        raising ``AsynchronousRPCResponse`` in the RPC handler itself.
+
+        The response passed to this function will be returned to the caller
+        as if the RPC had returned it immediately.
+
+        This method must only ever be called from a coroutine inside the
+        emulation loop that is handling background work on behalf of a tile.
+
+        Args:
+            address (int): The tile address the RPC was called on.
+            rpc_id (int): The ID of the RPC that was called.
+            response (bytes): The bytes that should be returned to
+                the caller of the RPC.
+        """
+
+        pending = self._pending_rpcs.get(address)
+
+        if pending is None:
+            raise ArgumentError("No asynchronously RPC currently in progress on tile %d" % address)
+
+        responder = pending.get(rpc_id)
+        if responder is None:
+            raise ArgumentError("RPC %04X is not running asynchronous on tile %d" % (rpc_id, address))
+
+        del pending[rpc_id]
+
+        responder.set_result(response)
+        self._rpc_queue.task_done()
+
+    def start(self):
+        """Start this task from the event loop thread."""
+
+        self._rpc_task = self._loop.create_task(self._rpc_dispatch_task())
+
+    async def stop(self):
+        """Stop the rpc queue from inside the event loop."""
+
+        if self._rpc_task is not None:
+            self._rpc_task.cancel()
+
+        try:
+            await self._rpc_task
+        except asyncio.CancelledError:
+            pass
+
+        self._rpc_task = None
+
+    async def _rpc_dispatch_task(self):
+        self._logger.debug("Starting RPC dispatch task")
+
+        while True:
+            try:
+                obj = await self._rpc_queue.get()
+
+                if len(obj) == 3:
+                    address = None
+                    rpc_id = None
+                    func, args, response = obj
+                    result = func(*args)
+                else:
+                    address, rpc_id, arg_payload, response = obj
+
+                    self._current_rpc = (address, rpc_id)
+                    result = self._rpc_handler(address, rpc_id, arg_payload)
+
+                    if inspect.iscoroutine(result):
+                        result = await result
+
+                    self._current_rpc = None
+
+                response.set_result(result)
+                self._rpc_queue.task_done()
+            except AsynchronousRPCResponse:
+                self._queue_async_rpc(address, rpc_id, response)
+            except asyncio.CancelledError:
+                raise
+            except:  #pylint:disable=bare-except;We want to send all exceptions to the caller.
+                response.capture_exception()
+                self._rpc_queue.task_done()
+
+    def _queue_async_rpc(self, address, rpc_id, response):
+        if address not in self._pending_rpcs:
+            self._pending_rpcs[address] = {}
+
+        self._pending_rpcs[address][rpc_id] = response
+
+        self._logger.debug("Queued asynchronous rpc on tile %d, rpc_id: 0x%04X", address, rpc_id)

--- a/iotileemulate/iotile/emulate/reference/controller_features/clock_manager.py
+++ b/iotileemulate/iotile/emulate/reference/controller_features/clock_manager.py
@@ -70,12 +70,12 @@ TODO: figure out a good set of options for resuming a device when utc time
       is set.
 """
 
-from future.utils import viewitems
 from iotile.core.hw.virtual import tile_rpc
 from ...constants import rpcs, pack_error, Error, ControllerSubsystem, streams
+from .controller_system import ControllerSubsystemBase
 
 
-class ClockManagerSubsystem(object):
+class ClockManagerSubsystem(ControllerSubsystemBase):
     """Container state of the clock manager subsystem."""
 
     FAST_TICK = 0
@@ -95,7 +95,9 @@ class ClockManagerSubsystem(object):
         'user2': streams.USER_TICK_2
     }
 
-    def __init__(self, has_rtc=False):
+    def __init__(self, emulator, has_rtc=False):
+        super(ClockManagerSubsystem, self).__init__(emulator)
+
         self.uptime = 0
         self.time_offset = 0
         self.is_utc = False
@@ -116,6 +118,8 @@ class ClockManagerSubsystem(object):
         - is `has_rtc` is True, the utc_offset is preserved
         - otherwise the utc_offset is cleared to none
         """
+
+        super(ClockManagerSubsystem, self).clear_to_reset(config_vars)
 
         self.tick_counters = dict(fast=0, user1=0, user2=0, normal=0)
 
@@ -141,7 +145,7 @@ class ClockManagerSubsystem(object):
 
         self.uptime += 1
 
-        for name, interval in viewitems(self.ticks):
+        for name, interval in self.ticks.items():
             if interval == 0:
                 continue
 
@@ -228,8 +232,8 @@ class ClockManagerSubsystem(object):
 class ClockManagerMixin(object):
     """Mixin to add the clock manager subsystem into ReferenceController."""
 
-    def __init__(self, has_rtc):
-        self.clock_manager = ClockManagerSubsystem(has_rtc)
+    def __init__(self, emulator, has_rtc):
+        self.clock_manager = ClockManagerSubsystem(emulator, has_rtc)
 
         self.declare_config_variable('fast_tick', 0x2000, 'uint32_t', default=0)
         self.declare_config_variable('user_tick_1', 0x2002, 'uint32_t', default=0)

--- a/iotileemulate/iotile/emulate/reference/controller_features/controller_system.py
+++ b/iotileemulate/iotile/emulate/reference/controller_features/controller_system.py
@@ -1,0 +1,57 @@
+"""Base class for controller subsystems."""
+
+import asyncio
+from iotile.core.exceptions import InternalError
+
+class ControllerSubsystemBase:
+    """Base class for Controller subsystems.
+
+    This class allows subsystems to define tasks that run in the background
+    and are automatically associated with the parent controller.  It also
+    allows the subsytems to update an `initialized` Event that lets the
+    controller know when their background tasks are up and running.
+
+    Args:
+        emulator (EmulationLoop): The underlying emulation loop that all
+            tasks should be added to.
+    """
+
+    def __init__(self, emulator):
+        self._emulator = emulator
+        self.initialized = emulator.create_event()
+
+    async def _reset_vector(self):
+        """Initialize any background tasks associated with this subsystem.
+
+        Subclasses that choose to override this method must set the
+        self.initialized Event() inside their reset vector once it starts up.
+        """
+
+        self.initialized.set()
+
+    def clear_to_reset(self, config_vars):
+        """Clear all volatile information across a reset.
+
+        Classes that override this method must call super().clear_to_reset()
+        to ensure that their base class is initialized correctly.
+
+        Args:
+            config_vars (dict): The map of all config variables that are
+                declared on the controller.
+        """
+
+        self.initialized.clear()
+
+    async def initialize(self, timeout=2.0):
+        """Launch any background tasks associated with this subsystem.
+
+        This method will synchronously await self.initialized() which makes
+        sure that the background tasks start up correctly.
+        """
+
+        if self.initialized.is_set():
+            raise InternalError("initialize called when already initialized")
+
+        self._emulator.add_task(8, self._reset_vector())
+
+        await asyncio.wait_for(self.initialized.wait(), timeout=timeout)

--- a/iotileemulate/iotile/emulate/transport/emulatedadapter.py
+++ b/iotileemulate/iotile/emulate/transport/emulatedadapter.py
@@ -6,7 +6,6 @@ into the emulated devices.
 """
 
 import logging
-from future.utils import itervalues
 from iotile.core.hw.transport.virtualadapter import VirtualDeviceAdapter
 from ..virtual import EmulatedDevice
 
@@ -127,5 +126,5 @@ class EmulatedDeviceAdapter(VirtualDeviceAdapter):
 
         super(EmulatedDeviceAdapter, self).periodic_callback()
 
-        for dev in itervalues(self.devices):
+        for dev in self.devices.values():
             dev.wait_idle()

--- a/iotileemulate/iotile/emulate/utilities/format_rpc.py
+++ b/iotileemulate/iotile/emulate/utilities/format_rpc.py
@@ -26,7 +26,7 @@ def format_rpc(data):
     if isinstance(resp, (bytes, bytearray)):
         resp_str = hexlify(resp)
     else:
-        resp = repr(resp)
+        resp_str = repr(resp)
 
     #FIXME: Check and print status as well
     return "%s called on address %d, payload=%s, response=%s" % (name, address, arg_str, resp_str)

--- a/iotileemulate/iotile/emulate/virtual/__init__.py
+++ b/iotileemulate/iotile/emulate/virtual/__init__.py
@@ -42,6 +42,7 @@ them, emulated devices are designed to act as standins for physical IOTile
 devices that do need to follow a very specific initialization process.
 
 The process is as follows:
+
 - First the controller tile for the device boots and initializes itself.
 - Each peripheral tile checks in with the controller tile and registers itself
     - this triggers the controller tile to stream any config variables that
@@ -97,7 +98,7 @@ finishes.
 
 from .emulated_device import EmulatedDevice
 from .peripheral_tile import EmulatedPeripheralTile
-from .emulated_tile import EmulatedTile, synchronized
+from .emulated_tile import EmulatedTile
 from .simple_state import SerializableState
 
-__all__ = ['EmulatedDevice', 'EmulatedTile', 'SerializableState', 'EmulatedPeripheralTile', 'synchronized']
+__all__ = ['EmulatedDevice', 'EmulatedTile', 'SerializableState', 'EmulatedPeripheralTile']

--- a/iotileemulate/iotile/emulate/virtual/emulation_mixin.py
+++ b/iotileemulate/iotile/emulate/virtual/emulation_mixin.py
@@ -1,9 +1,7 @@
 """Mixin class to add property change tracking to an emulated device."""
 
-from __future__ import unicode_literals, absolute_import, print_function
 import json
 from enum import IntEnum
-from future.utils import viewitems
 from iotile.core.exceptions import ArgumentError
 
 
@@ -180,7 +178,7 @@ def _clean_intenum(obj):
     """Remove all IntEnum classes from a map."""
 
     if isinstance(obj, dict):
-        for key, value in viewitems(obj):
+        for key, value in obj.items():
             if isinstance(value, IntEnum):
                 obj[key] = value.value
             elif isinstance(value, (dict, list)):

--- a/iotileemulate/iotile/emulate/virtual/state_log.py
+++ b/iotileemulate/iotile/emulate/virtual/state_log.py
@@ -1,7 +1,5 @@
 """A list of changes to an emulated device for verification purposes."""
 
-from __future__ import unicode_literals, absolute_import, print_function
-
 import sys
 import threading
 from collections import namedtuple

--- a/iotileemulate/setup.py
+++ b/iotileemulate/setup.py
@@ -16,8 +16,9 @@ setup(
     ],
     entry_points={'iotile.virtual_device': ['reference_1_0 = iotile.emulate.demo:DemoReferenceDevice',
                                             'emulation_demo = iotile.emulate.demo:DemoEmulatedDevice'],
+                  'iotile.proxy': ['emudmo = iotile.emulate.demo:DemoTileProxy'],
                   'iotile.device_adapter': ['emulated = iotile.emulate.transport:EmulatedDeviceAdapter'],
-                  'iotile.virtual_tile': ['refcon_1 = iotile.emulate.reference:ReferenceController']},
+                  'iotile.emulated_tile': ['refcon_1 = iotile.emulate.reference:ReferenceController']},
     author="Arch",
     author_email="info@arch-iot.com",
     url="https://github.com/iotile/coretools/iotilesensorgraph",
@@ -29,8 +30,6 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Topic :: Software Development :: Libraries :: Python Modules"
         ],
     long_description="""\

--- a/iotileemulate/test/test_eventloop.py
+++ b/iotileemulate/test/test_eventloop.py
@@ -1,0 +1,77 @@
+"""Tests to ensure that our coroutine based emulation loop works."""
+
+import pytest
+import asyncio
+from iotile.emulate.internal import EmulationLoop
+from iotile.core.hw.virtual.common_types import AsynchronousRPCResponse
+from iotile.core.exceptions import TimeoutExpiredError
+
+
+def test_basic_eventloop():
+    """Make sure basic things work."""
+
+    def _rpc_executor(_address, rpc_id, arg_payload):
+        if rpc_id == 0x8000:
+            raise ValueError("Error")
+
+        return arg_payload
+
+    loop = EmulationLoop(_rpc_executor)
+    loop.start()
+
+
+
+    try:
+        assert loop.call_rpc_external(8, 0x8001, b'abcd') == b'abcd'
+
+        with pytest.raises(ValueError):
+            loop.call_rpc_external(8, 0x8000, b'')
+
+    finally:
+        loop.stop()
+
+
+def test_async_rpc():
+    """Make sure we can send an asynchronous RPC."""
+    loop = None
+
+    def _rpc_executor(_address, rpc_id, arg_payload):
+        if rpc_id == 0x8000:
+            raise ValueError("Error")
+        elif rpc_id == 0x8002:
+            address, rpc_id = loop.get_current_rpc()
+            asyncio.get_event_loop().call_soon(loop.finish_async_rpc, address, rpc_id, b'4444')
+            raise AsynchronousRPCResponse()
+
+        return arg_payload
+
+    loop = EmulationLoop(_rpc_executor)
+    loop.start()
+
+    try:
+        assert loop.call_rpc_external(8, 0x8001, b'abcd') == b'abcd'
+        assert loop.call_rpc_external(8, 0x8002, b'abcd') == b'4444'
+        loop.wait_idle()
+
+    finally:
+        loop.stop()
+
+
+def test_rpc_timeout():
+    """Make sure we can timeout an RPC."""
+
+    def _rpc_executor(_address, rpc_id, arg_payload):
+        raise AsynchronousRPCResponse()
+
+    loop = EmulationLoop(_rpc_executor)
+    loop.start()
+
+    try:
+        with pytest.raises(TimeoutExpiredError):
+            loop.call_rpc_external(8, 0x8001, b'abcd', timeout=0.001)
+
+        with pytest.raises(TimeoutExpiredError):
+            loop.wait_idle(timeout=0.001)
+
+    finally:
+        loop.stop()

--- a/iotileemulate/test/test_reference.py
+++ b/iotileemulate/test/test_reference.py
@@ -16,7 +16,7 @@ def reference():
     """Get a reference device with a controller and single peripheral tile."""
 
     device = ReferenceDevice({'simulate_time': False})
-    peripheral = EmulatedPeripheralTile(10, b'abcdef', device)
+    peripheral = EmulatedPeripheralTile(10, device)
     device.add_tile(10, peripheral)
 
     device.start()
@@ -29,7 +29,7 @@ def reference_hw():
     """Get a reference device and connected HardwareManager."""
 
     device = ReferenceDevice({'simulate_time': False})
-    peripheral = EmulatedPeripheralTile(11, b'abcdef', device)
+    peripheral = EmulatedPeripheralTile(11, device)
     peripheral.declare_config_variable("test 1", 0x8000, 'uint16_t')
     peripheral.declare_config_variable('test 2', 0x8001, 'uint32_t[5]')
 
@@ -59,7 +59,7 @@ def test_peripheral_tiles():
 
     # Don't use the fixture since the purpose of this test is to make sure the fixture works
     device = ReferenceDevice({'simulate_time': False})
-    peripheral = EmulatedPeripheralTile(10, b'abcdef', device)
+    peripheral = EmulatedPeripheralTile(10, device)
     device.add_tile(10, peripheral)
 
     device.start()
@@ -104,7 +104,7 @@ def test_config_variable_rpcs(reference):
     assert packed_size == (1 << 15) | (5*4)
 
     # Test setting (make sure to artificially force pre-app started state)
-    peripheral._app_started.clear()
+    peripheral.initialized.clear()
     err, = device.rpc(10, rpcs.SET_CONFIG_VARIABLE, 0x8000, 0, bytes(bytearray([5, 6])))
     assert err == 0
 
@@ -117,7 +117,7 @@ def test_config_variable_rpcs(reference):
     err, = device.rpc(10, rpcs.SET_CONFIG_VARIABLE, 0x8002, 0, bytes(bytearray([7, 8])))
     assert err == Error.INVALID_ARRAY_KEY
 
-    peripheral._app_started.set()
+    peripheral.initialized.set()
     err, = device.rpc(10, rpcs.SET_CONFIG_VARIABLE, 0x8000, 0, bytes(bytearray([5, 6])))
     assert err == Error.STATE_CHANGE_AT_INVALID_TIME
 
@@ -225,10 +225,10 @@ def test_tile_manager(reference_hw):
     # Work around inconsistency in output of iotile-support-lib-controller-3 on python 2 and 3
     if sys.version_info.major < 3:
         con_str = 'refcn1, version 1.0.0 at slot 0'
-        peri_str = 'abcdef, version 1.0.0 at slot 1'
+        peri_str = 'noname, version 1.0.0 at slot 1'
     else:
         con_str = "b'refcn1', version 1.0.0 at slot 0"
-        peri_str = "b'abcdef', version 1.0.0 at slot 1"
+        peri_str = "b'noname', version 1.0.0 at slot 1"
 
     hw, _device, _peripheral = reference_hw
 

--- a/iotileemulate/test/test_reference_sensorgraph.py
+++ b/iotileemulate/test/test_reference_sensorgraph.py
@@ -18,7 +18,7 @@ def sg_device():
     """Get a reference device and connected HardwareManager."""
 
     device = ReferenceDevice({'simulate_time': False})
-    peripheral = EmulatedPeripheralTile(11, b'abcdef', device)
+    peripheral = EmulatedPeripheralTile(11, device)
     peripheral.declare_config_variable("test 1", 0x8000, 'uint16_t')
     peripheral.declare_config_variable('test 2', 0x8001, 'uint32_t[5]')
 
@@ -40,7 +40,7 @@ def basic_sg():
     """A preprogrammed basic sensorgraph for testing."""
 
     device = ReferenceDevice({'simulate_time': False})
-    peripheral = EmulatedPeripheralTile(11, b'abcdef', device)
+    peripheral = EmulatedPeripheralTile(11, device)
     peripheral.declare_config_variable("test 1", 0x8000, 'uint16_t')
     peripheral.declare_config_variable('test 2', 0x8001, 'uint32_t[5]')
 

--- a/iotileemulate/version.py
+++ b/iotileemulate/version.py
@@ -1,1 +1,1 @@
-version = "0.2.0"
+version = "0.3.0"

--- a/iotileship/test/test_recipe_manager/test_on_reference_device.py
+++ b/iotileship/test/test_recipe_manager/test_on_reference_device.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import time
 import pytest
 from iotile.core.hw import HardwareManager
@@ -29,6 +30,9 @@ def resman():
 @pytest.fixture
 def recipe_fixture(request, resman):
     """Create a fixture with a hardware manager connected to our reference dev."""
+
+    if sys.version_info < (3, 5):
+        pytest.skip("test requires iotile-emulate on python 3.5+")
 
     recipe = resman.get_recipe(request.param)
 

--- a/iotileship/test/test_recipe_manager/test_recipes.py
+++ b/iotileship/test/test_recipe_manager/test_recipes.py
@@ -1,5 +1,6 @@
 import os
 import time
+import sys
 import pytest
 
 from iotile.ship.recipe import RecipeObject
@@ -87,6 +88,7 @@ def test_verify_device_step(resman):
     resman.get_recipe('test_verify_device_step')
 
 
+@pytest.mark.skipif(sys.version_info < (3, 5), reason="requires iotile-emulate")
 def test_hardware_manager_resource(resman):
     """Make sure we can create a shared hardware manager resource."""
 

--- a/scripts/components.py
+++ b/scripts/components.py
@@ -1,16 +1,29 @@
 # Final boolean is whether the package is python 3 clean
+
+class Component(object):
+    def __init__(self, distro, path, compat="universal"):
+        if compat not in ('universal', 'python2', 'python3'):
+            raise ValueError("Unknown python compatibility: %s" % compat)
+
+        self.distro = distro
+        self.path = path
+        self.compat = compat
+        self.py3k_clean = compat in ('universal', 'python3')
+        self.py2k_clean = compat in ('universal', 'python2')
+
+
 comp_names = {
-    'iotilecore': ['iotile-core', 'iotilecore', True],
-    'iotilebuild': ['iotile-build', 'iotilebuild', True],
-    'iotiletest': ['iotile-test', 'iotiletest', True],
-    'iotilegateway': ['iotile-gateway', 'iotilegateway', True],
-    'iotilesensorgraph': ['iotile-sensorgraph', 'iotilesensorgraph', True],
-    'iotileemulate': ['iotile-emulate', 'iotileemulate', True],
-    'iotileship' : ['iotile-ship', 'iotileship', True],
-    'iotile_transport_bled112': ['iotile-transport-bled112', 'transport_plugins/bled112', True],
-    'iotile_transport_awsiot': ['iotile-transport-awsiot', 'transport_plugins/awsiot', False],
-    'iotile_transport_websocket': ['iotile-transport-websocket', 'transport_plugins/websocket', True],
-    'iotile_transport_native_ble': ['iotile-transport-native-ble', 'transport_plugins/native_ble', True],
-    'iotile_transport_jlink': ['iotile-transport-jlink', 'transport_plugins/jlink', False],
-    'iotile_ext_cloud': ['iotile-ext-cloud', 'iotile_ext_cloud', True]
+    'iotilecore': Component('iotile-core', 'iotilecore'),
+    'iotilebuild': Component('iotile-build', 'iotilebuild'),
+    'iotiletest': Component('iotile-test', 'iotiletest'),
+    'iotilegateway': Component('iotile-gateway', 'iotilegateway'),
+    'iotilesensorgraph': Component('iotile-sensorgraph', 'iotilesensorgraph'),
+    'iotileemulate': Component('iotile-emulate', 'iotileemulate', compat="python3"),
+    'iotileship' : Component('iotile-ship', 'iotileship'),
+    'iotile_transport_bled112': Component('iotile-transport-bled112', 'transport_plugins/bled112'),
+    'iotile_transport_awsiot': Component('iotile-transport-awsiot', 'transport_plugins/awsiot', compat="python2"),
+    'iotile_transport_websocket': Component('iotile-transport-websocket', 'transport_plugins/websocket'),
+    'iotile_transport_native_ble': Component('iotile-transport-native-ble', 'transport_plugins/native_ble'),
+    'iotile_transport_jlink': Component('iotile-transport-jlink', 'transport_plugins/jlink', compat="python2"),
+    'iotile_ext_cloud': Component('iotile-ext-cloud', 'iotile_ext_cloud')
 }

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -9,6 +9,7 @@ subdirectory for the component for the release to proceed.
 """
 
 from __future__ import unicode_literals, print_function, absolute_import
+import argparse
 import sys
 import os
 import glob
@@ -16,6 +17,14 @@ import requests
 import setuptools.sandbox
 from twine.commands.upload import upload
 from components import comp_names
+
+def build_parser():
+    """Build argument parsers."""
+
+    parser = argparse.ArgumentParser("Release packages to pypi")
+    parser.add_argument('--check', '-c', action="store_true", help="Do a dry run without uploading")
+    parser.add_argument('component', help="The component to release as component-version")
+    return parser
 
 def send_slack_message(message):
     """Send a message to the slack channel #coretools
@@ -30,14 +39,10 @@ def send_slack_message(message):
     if r.status_code != 200:
         raise RuntimeError("Could not post message to slack channel")
 
-def get_release_component():
+def get_release_component(comp):
     """Split the argument passed on the command line into a component name and expected version
     """
 
-    if len(sys.argv) < 2:
-        raise EnvironmentError("Usage: python release.py <component_name>-<version>")
-
-    comp = sys.argv[-1]
     name, vers = comp.split("-")
 
     if name not in comp_names:
@@ -49,13 +54,32 @@ def get_release_component():
 
     return name, vers
 
+
+def check_compatibility(name):
+    """Verify if we can release this component on the running interpreter.
+
+    All components are released from python 2.7 by default unless they specify
+    that they are python 3 only, in which case they are released from python 3.6
+    """
+
+    comp = comp_names[name]
+
+    if sys.version_info.major < 3 and comp.compat == "python3":
+        return False
+
+    if sys.version_info.major >= 3 and comp.compat != "python3":
+        return False
+
+    return True
+
+
 def check_version(component, expected_version):
     """Make sure the package version in setuptools matches what we expect it to be
     """
 
-    _, relative_compath, _py3 = comp_names[component]
+    comp = comp_names[component]
 
-    compath = os.path.realpath(os.path.abspath(relative_compath))
+    compath = os.path.realpath(os.path.abspath(comp.path))
     sys.path.insert(0, compath)
 
     import version
@@ -63,16 +87,22 @@ def check_version(component, expected_version):
     if version.version != expected_version:
         raise EnvironmentError("Version mismatch during release, expected={}, found={}".format(expected_version, version.version))
 
+
 def build_component(component):
     """Create an sdist and a wheel for the desired component
     """
 
-    _, relative_compath, _py3 = comp_names[component]
+    comp = comp_names[component]
 
     curr = os.getcwd()
-    os.chdir(relative_compath)
+    os.chdir(comp.path)
+
+    args = ['-q', 'clean', 'sdist', 'bdist_wheel']
+    if comp.compat == 'universal':
+        args.append('--universal')
+
     try:
-        setuptools.sandbox.run_setup('setup.py', ['-q', 'clean', 'sdist', 'bdist_wheel'])
+        setuptools.sandbox.run_setup('setup.py', args)
     finally:
         os.chdir(curr)
 
@@ -91,8 +121,8 @@ def upload_component(component):
         pypi_pass = None
         print("No PYPI user information in environment")
 
-    _, relative_compath, _py3 = comp_names[component]
-    distpath = os.path.join(relative_compath, 'dist', '*')
+    comp = comp_names[component]
+    distpath = os.path.join(comp.path, 'dist', '*')
     distpath = os.path.realpath(os.path.abspath(distpath))
     dists = glob.glob(distpath)
 
@@ -104,9 +134,10 @@ def upload_component(component):
     #Invoke upload this way since subprocess call of twine cli has cross platform issues
     upload(dists, 'pypi', False, None, pypi_user, pypi_pass, None, None, '~/.pypirc', False, None, None, None)
 
+
 def get_release_notes(component, version):
-    _, relative_compath, _py3 = comp_names[component]
-    notes_path = os.path.join(relative_compath, 'RELEASE.md')
+    comp = comp_names[component]
+    notes_path = os.path.join(comp.path, 'RELEASE.md')
 
     try:
         with open(notes_path, "r") as f:
@@ -122,7 +153,7 @@ def get_release_notes(component, version):
         sys.exit(1)
 
     start_line = release_lines[version]
-    past_releases = [x for x in release_lines.itervalues() if x > start_line]
+    past_releases = [x for x in release_lines.values() if x > start_line]
 
     if len(past_releases) == 0:
         release_string = "".join(lines[start_line+1:])
@@ -136,26 +167,34 @@ def get_release_notes(component, version):
     return release_string
 
 def main():
-    if len(sys.argv) < 2:
-        print("Usage: release.py [--check] <component_name>-<version>")
-        sys.exit(1)
+    parser = build_parser()
+    args = parser.parse_args()
 
-    dry_run = False
-    if sys.argv[-2] == '--check':
-        dry_run = True
-
-    component, version = get_release_component()
+    component, version = get_release_component(args.component)
     check_version(component, version)
+    compat = check_compatibility(component)
+
+    # We do not return an error so this script can be called on both python 2
+    # and python 3 and just release once without failing on the other
+    # interpreter.
+    if not compat:
+        print("Not releasing {} because of interpreter version mismatch.".format(component))
+        print("Run this script from a different python version.")
+        return
+
     build_component(component)
 
     release_notes = get_release_notes(component, version)
 
-    if dry_run:
+    if args.check:
         print("Check Release\nName: {}\nVersion: {}".format(component, version))
-        print("Release Notes:\n" + release_notes)
+        print("Compatibility: {}".format(comp_names[component].compat))
+        print("\nRelease Notes:\n" + release_notes)
+
     else:
         upload_component(component)
-        send_slack_message('*Released {} version {} to PYPI*\n\nRelease Notes for version {}:\n```\n{}```'.format(component, version, version, release_notes))
+        send_slack_message('*Released {0} version {1} to PYPI*\n\nRelease Notes for version {1}:\n```\n{2}```'.format(component, version, release_notes))
+
 
 if __name__ == '__main__':
     main()

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -8,18 +8,20 @@ import components
 
 
 def run_test(component, args):
-    distribution, subdir, python3_compat = components.comp_names[component]
+    comp = components.comp_names[component]
 
     currdir = os.getcwd()
 
     testcmd = ['pytest'] + list(args)
     output_status = 0
 
-    if sys.version_info.major >= 3 and not python3_compat:
+    if sys.version_info.major >= 3 and not comp.py3k_clean:
+        return None, ""
+    elif sys.version_info.major == 2 and not comp.py2k_clean:
         return None, ""
 
     try:
-        os.chdir(subdir)
+        os.chdir(comp.path)
 
         with open(os.devnull, "wb") as devnull:
                 output = subprocess.check_output(testcmd, stderr=subprocess.STDOUT)
@@ -63,7 +65,7 @@ class TestProcessor(cmdln.Cmdln):
             duration = end - start
 
             if status is None:
-                print("SKIPPED ON PYTHON 3")
+                print("SKIPPED ON UNSUPPORTED PYTHON INTERPRETER")
             elif status == 5:
                 print("NO TESTS RAN (%.1f seconds)" % duration)
             elif status != 0:

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ deps =
     ./iotiletest
     ./iotilegateway
     ./iotilesensorgraph
-    ./iotileemulate
+    py36: ./iotileemulate
     ./iotileship
     ./transport_plugins/bled112
     ./transport_plugins/awsiot


### PR DESCRIPTION
## Overview

Previously we had the goal that `iotile-emulate` would work on both python 2 and python 3, which meant that it could not leverage any python 3 only features.  This led to a design using multiple threads for emulating each tile and a bunch of chained callbacks when we needed to defer activity that could not safely be performed in a given thread.  

The end result was that it was difficult to write the equivalent of a `main()` loop running on a tile which made it difficult to write an `EmulatedTile` that needed to emulate a tile with a non-trivial `main()` loop.

Given the pending EOL of python 2 and the significant maintainability advantage of using `asyncio` to implement the underlying emulator efficiently, we made the decision to move `iotile-emulate` to python 3 only (python 3.5+) and drop the goal of python 2 compatibility.

## Major Changes to iotile-emulate

> The key commits in this PR are squashed already to separate the large `iotile-emulate` change from the small tweaks to the other packages to avoid referencing iotile-emulate on python 2 and support releasing a python 3 only package.

- All emulation happens now in a single thread using the `EmulationLoop` class.  Previously there was an RPC dispatch thread, a separate clock thread and would have needed to be a thread for each tile with a non-trivial `main()` loop.  Now all of those threads are `coroutines` running inside of `EmulationLoop`.  The resulting code is significantly cleaner.
- All of the ReferenceController subsystems have been refactored to use coroutines for their background work rather than callbacks.
- The model for how an EmulatedPeripheralTile should implement a `main()` loop has been worked out and implemented in `DemoEmulatedTile` as a reference example with documentation of what you can do in an EmulatedTile and how to do it.
- The inheritance between `EmulatedTile` and `VirtualTile` has been broken since they no longer share any commonalities and `VirtualTile` assumes a threading based model of background activity.  
- The model of what it means for an emulated device to be `idle` has been adjusted to allow for background tasks.  This is a very important concept because it is what allows for a user to invoke an RPC in a test and then inspect the state of the emulated device without a race condition.  The `EmulationLoop` now has a concept of work queues that are tracked for when they are empty/have pending work and the EmulatedDevice is declared idle when there are no pending RPCs and no tracked work queue has unfinished work.

### Consequences of Dropping Python 2 in iotile-emulate

- There were a few unit tests in `iotile-ext-cloud`, `iotile-core` and `iotile-ship` that used an emulated device to perform integration tests.  Theses tests can only run now on python 3 and not python 2.  The first commit in this PR fixes all of those tests.
- The release scripts were not written to allow for a package to be released only on python 3, which means the `wheel` needs to be built on python 3.6, not python 2.7 since it is not a universal wheel.  The scripts were updated in the first commit of this PR as well.
- Firmware components that include an emulated tile will only be able to run unit tests against that emulator on python 3.
- Support wheels for tiles/devices that include emulators will only be able to use those emulators on python 3 CoreTools installations.

The net result of this move is that it marks a sea-change in CoreTools from being python 2.7 first with support for most things on python 3.6 to needing to be python 3 first with slowly ebbing support for python 2.7.  Given that python 2.7 is EOL in less than a year, this is probably an acceptable thing.  

From a user's standpoint, it means that installations on python 3.6 will be first class citizens now and any remaining code that is python 2.7 only will need to be updated.

From a development standpoint, moving additional packages to being python 3 only will give us a good opportunity to clean up a lot of legacy code whose structure has evolved gradually over the years but we now know what it should look like.