### PR TITLE
Fix latent python 3 incompatibilities in building.

### DIFF
--- a/iotilebuild/RELEASE.md
+++ b/iotilebuild/RELEASE.md
@@ -2,7 +2,7 @@
 
 All major changes in each released version of IOTileBuild are listed here.
 
-## HEAD
+## 2.8.0
 
 - Add support for complex python support wheels where there is an actual 
   python package present in `python/support`.  Makes sure that the 
@@ -11,6 +11,9 @@ All major changes in each released version of IOTileBuild are listed here.
 - Refactor to remove all references to `pkg_resources`.  Uses centralized 
   entrypoint loading system from iotile.core instead.
 
+- Fix additional python 3 incompatibilities with `iotile build` that prevented
+  builds from running correctly on python 3.
+ 
 ## 2.7.0
 
 - Add support for running pytest unit tests as part of the build process.

--- a/iotilebuild/iotile/build/config/site_scons/release.py
+++ b/iotilebuild/iotile/build/config/site_scons/release.py
@@ -20,7 +20,7 @@ def create_release_settings_action(target, source, env):
     """Copy module_settings.json and add release and build information
     """
 
-    with open(str(source[0]), "rb") as fileobj:
+    with open(str(source[0]), "r") as fileobj:
         settings = json.load(fileobj)
 
     settings['release'] = True

--- a/iotilebuild/iotile/build/dev/resolverchain.py
+++ b/iotilebuild/iotile/build/dev/resolverchain.py
@@ -181,7 +181,7 @@ class DependencyResolverChain(object):
     def _load_depsettings(self, deptile):
         settings_file = os.path.join(deptile.folder, 'dep_settings.json')
 
-        with open(settings_file, 'rb') as f:
+        with open(settings_file, 'r') as f:
             settings = json.load(f)
 
         return settings

--- a/iotilebuild/version.py
+++ b/iotilebuild/version.py
@@ -1,1 +1,1 @@
-version = "2.7.0"
+version = "2.8.0"


### PR DESCRIPTION
This fixes issues related to opening text files in `rb` mode on python 3, which breaks `json.load`.  These issues prevent `iotile build` from working correctly on python 3.  The PR also prepares for releasing v2.8.0 of `iotile-build.

Closes #671.