### PR TITLE
Fix bug with sharing extensions between ComponentRegistry objects

### DIFF
--- a/iotilecore/RELEASE.md
+++ b/iotilecore/RELEASE.md
@@ -7,6 +7,7 @@ All major changes in each released version of `iotile-core` are listed here.
 - Add support for `emulated_tile` product to be included in an IOTile Component.
   This is necessary now that `iotile-emulate` no longer supported python 2 and
   requires asyncio inside its emulated tiles.
+- Fix bug with sharing extensions between ComponentRegistry objects
 
 ## 3.26.5
 

--- a/iotilecore/iotile/core/dev/registry.py
+++ b/iotilecore/iotile/core/dev/registry.py
@@ -209,7 +209,7 @@ class ComponentRegistry(object):
         """Clear all previously registered extensions."""
 
         if group is None:
-            self._registered_extensions = {}
+            self._registered_extensions.clear()
             return
 
         if group in self._registered_extensions:

--- a/iotilecore/iotile/core/dev/registry.py
+++ b/iotilecore/iotile/core/dev/registry.py
@@ -209,7 +209,7 @@ class ComponentRegistry(object):
         """Clear all previously registered extensions."""
 
         if group is None:
-            self._registered_extensions.clear()
+            ComponentRegistry._registered_extensions = {}
             return
 
         if group in self._registered_extensions:


### PR DESCRIPTION
I found that in clear_extensions() function, we didn't clear _registered_extensions object, we are assigning a new one to it, so when we are creating 2 ComponentRegistry objects, and adding an extension to the each one, second one would have an extension that we added to the first one.