### PR TITLE
657 issue fix

### DIFF
--- a/transport_plugins/bled112/RELEASE.md
+++ b/transport_plugins/bled112/RELEASE.md
@@ -2,6 +2,10 @@
 
 All major changes in each released version of the bled112 transport plugin are listed here.
 
+## HEAD
+
+- Ctrl+C breaks if you accidentally double book the bled112 dongle fix(#657)
+
 ## 1.8.0
 
 - Update virtual interface for compatibility with new iotile-core version that

--- a/transport_plugins/bled112/iotile_transport_bled112/bled112.py
+++ b/transport_plugins/bled112/iotile_transport_bled112/bled112.py
@@ -100,8 +100,7 @@ class BLED112Adapter(DeviceAdapter):
 
         self._logger = logging.getLogger(__name__)
         self._logger.addHandler(logging.NullHandler())
-
-        self._serial_port = serial.Serial(port, 256000, timeout=0.01, rtscts=True)
+        self._serial_port = serial.Serial(port, 256000, timeout=0.01, rtscts=True, exclusive=True)
         self._stream = AsyncPacketBuffer(self._serial_port, header_length=4, length_function=packet_length)
         self._commands = Queue()
         self._command_task = BLED112CommandProcessor(self._stream, self._commands, stop_check_interval=stop_check_interval)

--- a/transport_plugins/bled112/iotile_transport_bled112/virtual_bled112.py
+++ b/transport_plugins/bled112/iotile_transport_bled112/virtual_bled112.py
@@ -77,7 +77,7 @@ class BLED112VirtualInterface(VirtualIOTileInterface):
             else:
                 raise ExternalError("Could not find any BLED112 adapters connected to this computer")
 
-        self._serial_port = serial.Serial(port, 256000, timeout=0.01, rtscts=True)
+        self._serial_port = serial.Serial(port, 256000, timeout=0.01, rtscts=True, exclusive=True)
         self._stream = AsyncPacketBuffer(self._serial_port, header_length=4, length_function=packet_length)
         self._commands = Queue()
         self._command_task = BLED112CommandProcessor(self._stream, self._commands, stop_check_interval=0.01)


### PR DESCRIPTION
Added exclusive variable in the **Serial** constructor(Pyserial module). This both works on windows and on linux. On windows, it just ignores this flag, while on linux, it creates a lock file.