### PR TITLE
Complete the left out checklist to complete CoreTools' community prof…

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,74 @@
+## Code of Conduct
+
+### Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+### Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+### Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+### Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+### Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at [help@archsys.io]. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+### Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing
 
 When contributing to this repository, please first discuss the change you wish to make via issue,
-email, or any other method with the owners of this repository before making a change. 
+email, or any other method with the owners of this repository before submitting a PR. If the 
 
 Please note we have a code of conduct, please follow it in all your interactions with the project.
 
@@ -35,93 +35,22 @@ Using this for development will make it easier for you to merge pull requests.
 
 ## Pull Request Process
 
-1. If you are releasing a feature that will create a new version of a package, update the RELEASE.md 
-   and version.py of each component you are modifying with the details of your changes. If you
-   are not changing the version, you should still add your changes to a HEAD section in README.md
-   regardless. The versioning scheme we use is [SemVer](http://semver.org/).
+1. Make sure you update the RELEASE.md by adding a summary of changes to the ##HEAD section 
+   (add one if there isn't in the same form as releases are). If you are a maintainer, you can
+   promote the HEAD changes to a new version release, and also amend the `version.py` for 
+   your updated component. We will eventually stabilize our release process and establish 
+   a cadence of tagging releases, but this is the process for now. For reference, we version 
+   our releases following [SemVer](http://semver.org/).
 2. You must clean up your commits in to logical changes before merging. If you are changing multiple
    packages, you should consider using multiple commits. Good practice suggests that smaller, more contained
-   feature PRs are easier to review and less prone to regressions.
+   feature PRs are easier to review and less prone to regressions. In general, it's good if your PR can be squashed
+   to a single commit, but we do realize that is not always the best way to track history for some changes.
 3. In order to accomplish the above, you can either use git's squash and merge feature, or modify the history
-   yourself using something like `git rebase -i` to clean up your history in to modules before rebase and merge.
-   We do not permit pure merges (the option that creates Merge commits) at this time.
+   yourself using something like `git rebase -i` to clean up your history in to modules (and force pushing to your feature
+   branch or fork branch) before rebase and merge. We do not allow merge commits at this time in order to keep 
+   a more linear commit history for easier rollbacks.
 4. You are required to get at least one maintainer to sign off before you can merge. If nobody has reviewed your
    commit within a day or two, please try to get in touch by tagging or messaging them.
    
 In general, it's a good idea to look through some of the most recent closed PRs to get a real sense of 
 how we conduct them.
-
-## Code of Conduct
-
-### Our Pledge
-
-In the interest of fostering an open and welcoming environment, we as
-contributors and maintainers pledge to making participation in our project and
-our community a harassment-free experience for everyone, regardless of age, body
-size, disability, ethnicity, gender identity and expression, level of experience,
-nationality, personal appearance, race, religion, or sexual identity and
-orientation.
-
-### Our Standards
-
-Examples of behavior that contributes to creating a positive environment
-include:
-
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
-
-Examples of unacceptable behavior by participants include:
-
-* The use of sexualized language or imagery and unwelcome sexual attention or
-advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or electronic
-  address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
-  professional setting
-
-### Our Responsibilities
-
-Project maintainers are responsible for clarifying the standards of acceptable
-behavior and are expected to take appropriate and fair corrective action in
-response to any instances of unacceptable behavior.
-
-Project maintainers have the right and responsibility to remove, edit, or
-reject comments, commits, code, wiki edits, issues, and other contributions
-that are not aligned to this Code of Conduct, or to ban temporarily or
-permanently any contributor for other behaviors that they deem inappropriate,
-threatening, offensive, or harmful.
-
-### Scope
-
-This Code of Conduct applies both within project spaces and in public spaces
-when an individual is representing the project or its community. Examples of
-representing a project or community include using an official project e-mail
-address, posting via an official social media account, or acting as an appointed
-representative at an online or offline event. Representation of a project may be
-further defined and clarified by project maintainers.
-
-### Enforcement
-
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at [contact@archsys.io]. All
-complaints will be reviewed and investigated and will result in a response that
-is deemed necessary and appropriate to the circumstances. The project team is
-obligated to maintain confidentiality with regard to the reporter of an incident.
-Further details of specific enforcement policies may be posted separately.
-
-Project maintainers who do not follow or enforce the Code of Conduct in good
-faith may face temporary or permanent repercussions as determined by other
-members of the project's leadership.
-
-### Attribution
-
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at [http://contributor-covenant.org/version/1/4][version]
-
-[homepage]: http://contributor-covenant.org
-[version]: http://contributor-covenant.org/version/1/4/

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+## Overview
+
+High level summary of the purpose of this PR
+
+## Major Changes
+
+A more granular list of the changes made, ideally with links to issues
+
+- item 1
+- item 2
+- etc
+
+### Additional Notes
+
+- Side effects or wider-ranging impacts, if applicable.
+

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 - [Continuous Deployment](#continuous-deployment)
 - [Manually Releasing](#manually-releasing)
 - [Contributing](#Contributing)
+- [Code of Conduct](#Code of Conduct)
 - [License](#license)
 
 <!-- /MarkdownTOC -->
@@ -78,6 +79,14 @@ If you want to use the IOTile testing tools (necessary for testing CoreTools amo
 
 ```shell
 pip install iotile-test
+```
+
+## Installation (for development)
+
+You can install any given package if you have the repository cloned locally in the normal way.
+For example, to install a development (i.e. master / your branch tip) of iotile-core:
+```shell
+pip install -e coretools/iotilecore
 ```
 
 ### Working with Encrypted Device Data
@@ -166,6 +175,9 @@ SLACK_WEB_HOOK
 
 If you are interesting in contributing to CoreTools, please see the [Contributing](CONTRIBUTING.md) guide!
 
+### Code of Conduct
+
+Please familiarize yourself with our [Code of Conduct](CODE_OF_CONDUCT.md)
 
 ### License
 

--- a/bug_report.md
+++ b/bug_report.md
@@ -1,0 +1,33 @@
+	---
+name: Bug report
+about: Create a report to help us improve
+title: "[BUG]"
+labels: ''
+assignees: ''
+
+ ---
+
+ **Describe the bug**
+A clear and concise description of what the bug is.
+
+ **To Reproduce**
+Steps to reproduce the behavior:
+1. Command run:
+```
+```
+2. Stack trace 
+```
+```
+
+ **Expected behavior**
+A clear and concise description of what you expected to happen.
+
+ **Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+ **Desktop (please complete the following information):**
+ - OS: [e.g. iOS8.1]
+ - package list [e.g. output of pip list] 
+
+ **Additional context**
+Add any other context about the problem here.

--- a/feature_request.md
+++ b/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: '[FEAT]'
+labels: ''
+assignees: ''
+
+ ---
+
+ **Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+ **Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+ **Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+ **Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
…ile, which should help us have a clearer contribution path and lightweight process around it.


- Made some small modifications to our contribution guide that should be less confusing for those who want to contribute from outside of Arch. It also sets the stage for a more controlled release cadence of our components.
- Moved the code of conduct to its own file as recommended by the Github Community profile (https://github.com/iotile/coretools/community) .

