### PR TITLE
Bump iotile-core major version to drop python2 support. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,13 @@ cache:
   directories:
   - ~/arm_gcc
   - ~/arm_qemu
-sudo: false
-python:
-- '2.7'
-- '3.6'
+matrix:
+  include:
+    - python: '3.5'
+    - python: '3.6'
+    - python: '3.7'
+      dist: xenial
+      sudo: true
 before_install:
 - pwd
 - cd ~
@@ -26,13 +29,6 @@ script:
 - tox -r
 
 deploy:
-  - skip_cleanup: true
-    provider: script
-    script: python scripts/release.py $TRAVIS_TAG
-    on:
-      branch: master
-      tags: true
-      condition: $TRAVIS_PYTHON_VERSION = "2.7"
   - skip_cleanup: true
     provider: script
     script: python scripts/release.py $TRAVIS_TAG

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@
 - [Installing Support for IOTile Based Devices](#installing-support-for-iotile-based-devices)
 - [Continuous Deployment](#continuous-deployment)
 - [Manually Releasing](#manually-releasing)
-- [Contributing](#Contributing)
-- [Code of Conduct](#Code of Conduct)
+- [Contributing](#contributing)
+- [Code of Conduct](#code-of-conduct)
 - [License](#license)
 
 <!-- /MarkdownTOC -->

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,9 @@ environment:
     # The list here is complete (excluding Python 2.6, which
     # isn't covered by this document) at the time of writing.
 
-    - PYTHON: "C:\\Python27"
+    - PYTHON: "C:\\Python35"
+    - PYTHON: "C:\\Python36"
+    - PYTHON: "C:\\Python37"
 
 # Make sure we don't keep redownloading gcc every time
 cache:

--- a/build_requirements.txt
+++ b/build_requirements.txt
@@ -1,6 +1,6 @@
-setuptools>=30.2.0
+setuptools>=40.8.0
 wheel
 pip
 twine==1.11.0
-requests >= 2.4.2
+requests >= 2.21.0
 cmdln >= 2.0.0

--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -1,9 +1,9 @@
 tornado>=4.5.3
-ws4py>=0.3.5
-msgpack>=0.5.5
+ws4py>=0.5.1
+msgpack>=0.6.1
 python-dateutil>=2.6.0
-future>=0.16.0
-typedargs>=0.11.0
+future>=0.17.1
+typedargs>=0.13.7
 sortedcontainers~=2.1
 monotonic~=1.5
 entrypoints>=0.3.0

--- a/iotile_ext_cloud/RELEASE.md
+++ b/iotile_ext_cloud/RELEASE.md
@@ -2,10 +2,11 @@
 
 All major changes in each released version of the iotile-ext-cloud plugin are listed here.
 
-## HEAD
+## 1.0.0
 
 - Fix username/password prompting to work correctly on python 2 and 3 if not
   already specified in `iotile config link_cloud`.
+- Drop python2 support
 
 ## 0.6.0
 

--- a/iotile_ext_cloud/setup.py
+++ b/iotile_ext_cloud/setup.py
@@ -8,8 +8,8 @@ setup(
     version=version.version,
     license="LGPLv3",
     install_requires=[
-        "iotile-core>=3.6.2",
-        "iotile_cloud>=0.8.11"
+        "iotile-core>=4.0.0",
+        "iotile_cloud>=0.9.9"
     ],
 
     entry_points={'iotile.config_function': ['link_cloud = iotile.cloud.config:link_cloud'],

--- a/iotile_ext_cloud/tox.ini
+++ b/iotile_ext_cloud/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py36
+envlist = py35, py36, py37
 
 [testenv]
 passenv=APPDATA
@@ -9,4 +9,5 @@ deps=
     pytest-localserver
     ../iotilecore
     ../iotiletest
+    ../iotileemulate
 commands=py.test {posargs}

--- a/iotile_ext_cloud/version.py
+++ b/iotile_ext_cloud/version.py
@@ -1,1 +1,1 @@
-version = "0.6.0"
+version = "1.0.0"

--- a/iotilebuild/RELEASE.md
+++ b/iotilebuild/RELEASE.md
@@ -2,6 +2,10 @@
 
 All major changes in each released version of IOTileBuild are listed here.
 
+## 3.0.0
+
+- Drop python2 support
+
 ## 2.8.1
 
 - Add support for `emulated_tile` product to `iotile build`.

--- a/iotilebuild/setup.py
+++ b/iotilebuild/setup.py
@@ -28,7 +28,7 @@ setup(
     license="LGPLv3",
     install_requires=[
         "crcmod>=1.7.0",
-        "iotile-core >=3.25.0, < 4.0.0",
+        "iotile-core>=4.0.0",
         "sphinx>=1.3.1",
         "jinja2>=2.10.0",
         "breathe>=4.2.0",

--- a/iotilebuild/tox.ini
+++ b/iotilebuild/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py36
+envlist = py35, py36, py37
 
 [testenv]
 passenv=APPDATA TRAVIS

--- a/iotilebuild/version.py
+++ b/iotilebuild/version.py
@@ -1,1 +1,1 @@
-version = "2.8.1"
+version = "3.0.0"

--- a/iotilecore/RELEASE.md
+++ b/iotilecore/RELEASE.md
@@ -2,6 +2,10 @@
 
 All major changes in each released version of `iotile-core` are listed here.
 
+## 4.0.0
+
+- Drop python2 support
+
 ## 3.27.2
 
 - Fix support for `support_package` products in `IOTile` object and 

--- a/iotilecore/iotile/core/hw/transport/virtualadapter.py
+++ b/iotilecore/iotile/core/hw/transport/virtualadapter.py
@@ -181,7 +181,7 @@ class VirtualDeviceAdapter(DeviceAdapter):
         elif config[0] == '#':
             # Allow passing base64 encoded json directly in the port string to ease testing.
             import base64
-            config_str = base64.b64decode(config[1:])
+            config_str = str(base64.b64decode(config[1:]), 'utf-8')
             config_dict = json.loads(config_str)
         else:
             try:

--- a/iotilecore/setup.cfg
+++ b/iotilecore/setup.cfg
@@ -2,4 +2,4 @@
 description-file = README.md
 
 [bdist_wheel]
-universal=1
+universal=0

--- a/iotilecore/setup.py
+++ b/iotilecore/setup.py
@@ -25,18 +25,17 @@ setup(
     version=version.version,
     license="LGPLv3",
     install_requires=[
-        "ws4py>=0.3.5",
-        "msgpack>=0.5.5",
-        "enum34>=1.1.6;python_version<'3.4'",
-        "python-dateutil>=2.6.0",
-        "future>=0.16.0",
-        "typedargs>=0.11.0",
-        "sortedcontainers ~= 2.1",
+        "ws4py>=0.5.1",
+        "msgpack>=0.6.1",
+        "python-dateutil>=2.8.0",
+        "future>=0.17.1",
+        "typedargs>=0.13.7",
+        "sortedcontainers~=2.1",
         "monotonic ~= 1.5",
-        "entrypoints >= 0.3.0"
+        "entrypoints>=0.3.0"
     ],
     extras_require={
-        'ui': ["asciimatics>=1.9.0"]
+        'ui': ["asciimatics>=1.10.0"]
     },
     entry_points={
         'console_scripts': [
@@ -89,9 +88,9 @@ setup(
         "License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.7",
         "Topic :: Software Development :: Libraries :: Python Modules"
         ],
     long_description="""\

--- a/iotilecore/tox.ini
+++ b/iotilecore/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py36
+envlist = py35, py36, py37
 
 [testenv]
 passenv=APPDATA

--- a/iotilecore/version.py
+++ b/iotilecore/version.py
@@ -1,1 +1,1 @@
-version = "3.27.2"
+version = "4.0.0"

--- a/iotileemulate/RELEASE.md
+++ b/iotileemulate/RELEASE.md
@@ -2,6 +2,10 @@
 
 All major changes in each released version of iotile-emulate are listed here.
 
+## 0.4.0
+
+- Drop python2 support
+
 ## 0.3.1
 
 - Fix streaming controller subsystem to properly mark streamers as complete

--- a/iotileemulate/setup.py
+++ b/iotileemulate/setup.py
@@ -10,9 +10,8 @@ setup(
     license="LGPLv3",
     description="IOTile Device Emulation",
     install_requires=[
-        "iotile-core >=3.25.0, < 4.0.0",
-        "iotile-sensorgraph>=0.7.2",
-        'enum34;python_version<"3.4"'
+        "iotile-core>=4.0.0",
+        "iotile-sensorgraph>=0.8.1"
     ],
     entry_points={'iotile.virtual_device': ['reference_1_0 = iotile.emulate.demo:DemoReferenceDevice',
                                             'emulation_demo = iotile.emulate.demo:DemoEmulatedDevice'],
@@ -29,7 +28,9 @@ setup(
         "License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Topic :: Software Development :: Libraries :: Python Modules"
         ],
     long_description="""\

--- a/iotileemulate/tox.ini
+++ b/iotileemulate/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py36
+envlist = py35, py36, py37
 
 [testenv]
 passenv=APPDATA

--- a/iotileemulate/version.py
+++ b/iotileemulate/version.py
@@ -1,1 +1,1 @@
-version = "0.3.1"
+version = "0.4.0"

--- a/iotilegateway/RELEASE.md
+++ b/iotilegateway/RELEASE.md
@@ -2,9 +2,10 @@
 
 All major changes in each released version of IOTileGateway are listed here.
 
-## HEAD
+## 2.0.0
 
 - Fix recurring errors when iotile-supervisor not present while running iotile-gateway
+- Drop python2 support
 
 ## 1.8.1
 

--- a/iotilegateway/setup.py
+++ b/iotilegateway/setup.py
@@ -22,10 +22,10 @@ setup(
     license="LGPLv3",
     install_requires=[
         "tornado>=4.5.0,<5.0.0",
-        "iotile-core>=3.0.1",
-        "monotonic",
-        "msgpack>=0.5.6",
-        "ws4py>=0.3.5"
+        "iotile-core>=4.0.0",
+        "monotonic~=1.5",
+        "msgpack>=0.6.1",
+        "ws4py>=0.5.1"
     ],
     entry_points={
         'console_scripts': [

--- a/iotilegateway/tox.ini
+++ b/iotilegateway/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py36
+envlist = py35, py36, py37
 
 [testenv]
 passenv=APPDATA
@@ -8,7 +8,7 @@ deps=
     pytest-logging
     ../iotilecore
     ../iotiletest
-    tornado>=4.5.0,<5.0.0
+    tornado>=4.5.3,<5.0.0
     futures
 commands=
 	py.test {posargs}

--- a/iotilegateway/version.py
+++ b/iotilegateway/version.py
@@ -1,1 +1,1 @@
-version = "1.8.1"
+version = "2.0.0"

--- a/iotilesensorgraph/RELEASE.md
+++ b/iotilesensorgraph/RELEASE.md
@@ -3,10 +3,11 @@
 All major changes in each released version of iotile-sensorgraph are listed
 here.
 
-## HEAD
+## 1.0.0
 
 - Add support for directly passing an sgf string to the parser.  This helps
   when compiling a sensorgraph programmatically.
+- Drop python2 support
 
 ## 0.8.1
 

--- a/iotilesensorgraph/setup.cfg
+++ b/iotilesensorgraph/setup.cfg
@@ -2,4 +2,4 @@
 description-file = README.md
 
 [bdist_wheel]
-universal=1
+universal=0

--- a/iotilesensorgraph/setup.py
+++ b/iotilesensorgraph/setup.py
@@ -24,10 +24,10 @@ setup(
     description="IOTile SensorGraph Management and Simulation Package",
     install_requires=[
         "pyparsing~=2.2.0",
-        "future>=0.16.0",
-        "monotonic>=1.3.0",
+        "future>=0.17.1",
+        "monotonic~=1.5",
         "toposort>=1.5",
-        "iotile-core>=3.16.7"
+        "iotile-core>=4.0.0"
     ],
     entry_points={'iotile.sg_processor': ['copy_all_a = iotile.sg.processors:copy_all_a',
                                           'copy_latest_a = iotile.sg.processors:copy_latest_a',
@@ -57,9 +57,9 @@ setup(
         "License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.7",
         "Topic :: Software Development :: Libraries :: Python Modules"
         ],
     long_description="""\

--- a/iotilesensorgraph/tox.ini
+++ b/iotilesensorgraph/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py36
+envlist = py35,py36, py37
 
 [testenv]
 deps=

--- a/iotilesensorgraph/version.py
+++ b/iotilesensorgraph/version.py
@@ -1,1 +1,1 @@
-version = "0.8.1"
+version = "1.0.0"

--- a/iotileship/RELEASE.md
+++ b/iotileship/RELEASE.md
@@ -2,6 +2,10 @@
 
 All major changes in each released version of IOTileShip are listed here.
 
+## 1.0.0
+
+- Drop python2 support
+
 ## 0.2.0
 
 - Refactor extension importing system to use new 

--- a/iotileship/setup.py
+++ b/iotileship/setup.py
@@ -22,8 +22,8 @@ setup(
     version=version.version,
     license="LGPLv3",
     install_requires=[
-        "iotile-core >=3.25.0, < 4.0.0",
-        "pyaml>=17.12.0"
+        "iotile-core>=4.0.0",
+        "pyaml>=18.11.0"
     ],
     include_package_data=True,
     entry_points={

--- a/iotileship/tox.ini
+++ b/iotileship/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py36
+envlist = py35, py36, ,py37
 
 [testenv]
 passenv=APPDATA

--- a/iotileship/version.py
+++ b/iotileship/version.py
@@ -1,1 +1,1 @@
-version = "0.2.0"
+version = "1.0.0"

--- a/iotiletest/RELEASE.md
+++ b/iotiletest/RELEASE.md
@@ -2,6 +2,10 @@
 
 All major changes in each released version of IOTileTest are listed here.
 
+## 1.0.0
+
+- Drop python2 support
+
 ## 0.11.1
 
 - Remove `past.builtins`

--- a/iotiletest/setup.cfg
+++ b/iotiletest/setup.cfg
@@ -2,4 +2,4 @@
 description-file = README.md
 
 [bdist_wheel]
-universal=1
+universal=0

--- a/iotiletest/setup.py
+++ b/iotiletest/setup.py
@@ -42,9 +42,9 @@ setup(
         "Operating System :: OS Independent",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7"
+        "Programming Language :: Python :: 3.7",
         ],
     long_description="""\
 IOTileTest

--- a/iotiletest/tox.ini
+++ b/iotiletest/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py36
+envlist = py35, py36, py37
 
 [testenv]
 passenv=APPDATA

--- a/iotiletest/version.py
+++ b/iotiletest/version.py
@@ -1,1 +1,1 @@
-version = "0.11.1"
+version = "1.0.0"

--- a/scripts/components.py
+++ b/scripts/components.py
@@ -1,7 +1,7 @@
 # Final boolean is whether the package is python 3 clean
 
 class Component(object):
-    def __init__(self, distro, path, compat="universal"):
+    def __init__(self, distro, path, compat="python3"):
         if compat not in ('universal', 'python2', 'python3'):
             raise ValueError("Unknown python compatibility: %s" % compat)
 
@@ -18,12 +18,12 @@ comp_names = {
     'iotiletest': Component('iotile-test', 'iotiletest'),
     'iotilegateway': Component('iotile-gateway', 'iotilegateway'),
     'iotilesensorgraph': Component('iotile-sensorgraph', 'iotilesensorgraph'),
-    'iotileemulate': Component('iotile-emulate', 'iotileemulate', compat="python3"),
+    'iotileemulate': Component('iotile-emulate', 'iotileemulate'),
     'iotileship' : Component('iotile-ship', 'iotileship'),
     'iotile_transport_bled112': Component('iotile-transport-bled112', 'transport_plugins/bled112'),
-    'iotile_transport_awsiot': Component('iotile-transport-awsiot', 'transport_plugins/awsiot', compat="python2"),
+    'iotile_transport_awsiot': Component('iotile-transport-awsiot', 'transport_plugins/awsiot'),
     'iotile_transport_websocket': Component('iotile-transport-websocket', 'transport_plugins/websocket'),
     'iotile_transport_native_ble': Component('iotile-transport-native-ble', 'transport_plugins/native_ble'),
-    'iotile_transport_jlink': Component('iotile-transport-jlink', 'transport_plugins/jlink', compat="python2"),
+    'iotile_transport_jlink': Component('iotile-transport-jlink', 'transport_plugins/jlink'),
     'iotile_ext_cloud': Component('iotile-ext-cloud', 'iotile_ext_cloud')
 }

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,36}-{mac_windows,linux_only}
+envlist = py{35,36,37}-{mac_windows,linux_only}
 skipsdist = True
 
 [testenv]
@@ -19,8 +19,8 @@ deps =
     ./iotiletest
     ./iotilegateway
     ./iotilesensorgraph
-    py36: ./iotileemulate
     ./iotileship
+    ./iotileemulate
     ./transport_plugins/bled112
     ./transport_plugins/awsiot
     ./transport_plugins/jlink
@@ -29,8 +29,7 @@ deps =
     linux_only: ./transport_plugins/native_ble
     ./iotile_ext_cloud
     requests-mock
-    tornado>=4.5.0,<5.0.0
-    py27: futures
+    tornado>=4.5.3,<5.0.0
     pycryptodome
     configparser
 commands =

--- a/transport_plugins/awsiot/RELEASE.md
+++ b/transport_plugins/awsiot/RELEASE.md
@@ -2,6 +2,11 @@
 
 All major changes in each released version of iotile-transport-awsiot are listed here.
 
+## 1.0.0
+
+- Drop python2 support
+- Fix py3 compatibility
+
 ## 0.2.2
 
 - Clean code and improve compatibility with Python3

--- a/transport_plugins/awsiot/setup.py
+++ b/transport_plugins/awsiot/setup.py
@@ -8,9 +8,9 @@ setup(
     version=version.version,
     license="LGPLv3",
     install_requires=[
-        "iotile-core>=3.6.2",
-        "AWSIoTPythonSDK>=1.0.0",
-        "monotonic"
+        "iotile-core>=4.0.0",
+        "AWSIoTPythonSDK>=1.4.3",
+        "monotonic~=1.5"
     ],
 
     entry_points={'iotile.device_adapter': ['awsiot = iotile_transport_awsiot.device_adapter:AWSIOTDeviceAdapter'],

--- a/transport_plugins/awsiot/test/conftest.py
+++ b/transport_plugins/awsiot/test/conftest.py
@@ -159,7 +159,7 @@ def hw_man(gateway, local_broker):
 def gateway(local_broker, args):
     """Create a gateway serving over a mock AWS IOT MQTT server."""
 
-    with open(os.path.join(os.path.dirname(__file__), 'gateway_config.json'), "rb") as infile:
+    with open(os.path.join(os.path.dirname(__file__), 'gateway_config.json'), "r") as infile:
         args = json.load(infile)
 
     gate = IOTileGateway(args)

--- a/transport_plugins/awsiot/tox.ini
+++ b/transport_plugins/awsiot/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py36
+envlist = py35, py36, py37
 
 [testenv]
 passenv=APPDATA

--- a/transport_plugins/awsiot/version.py
+++ b/transport_plugins/awsiot/version.py
@@ -1,1 +1,1 @@
-version = "0.2.2"
+version = "1.0.0"

--- a/transport_plugins/bled112/RELEASE.md
+++ b/transport_plugins/bled112/RELEASE.md
@@ -2,9 +2,10 @@
 
 All major changes in each released version of the bled112 transport plugin are listed here.
 
-## HEAD
+## 2.0.0
 
 - Ctrl+C breaks if you accidentally double book the bled112 dongle fix(#657)
+- Drop python2 support
 
 ## 1.8.0
 

--- a/transport_plugins/bled112/setup.py
+++ b/transport_plugins/bled112/setup.py
@@ -9,8 +9,8 @@ setup(
     version=version.version,
     license="LGPLv3",
     install_requires=[
-        "iotile-core>=3.6.2",
-        "pyserial>=3.1.1"
+        "iotile-core>=4.0.0",
+        "pyserial>=3.4.0"
     ],
 
     entry_points={'iotile.device_adapter': ['bled112 = iotile_transport_bled112.bled112:BLED112Adapter'],

--- a/transport_plugins/bled112/tox.ini
+++ b/transport_plugins/bled112/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py36
+envlist = py35, py36, py37
 
 [testenv]
 passenv=APPDATA

--- a/transport_plugins/bled112/version.py
+++ b/transport_plugins/bled112/version.py
@@ -1,1 +1,1 @@
-version = "1.8.0"
+version = "2.0.0"

--- a/transport_plugins/jlink/RELEASE.md
+++ b/transport_plugins/jlink/RELEASE.md
@@ -3,6 +3,12 @@
 All major changes in each released version of the jlink transport plugin are
 listed here.
 
+
+
+## 1.0.0
+- Drop python2 support 
+- Enable python3 compatibility
+
 ## 0.3.2
 - Fix setup.py info documentation string
 - Add _open_streaming_interface function to the JLinkAdapter interface

--- a/transport_plugins/jlink/iotile_transport_jlink/devices.py
+++ b/transport_plugins/jlink/iotile_transport_jlink/devices.py
@@ -1,6 +1,4 @@
 """Information about known device types that we can control over jlink."""
-
-from __future__ import (unicode_literals, print_function, absolute_import)
 from collections import namedtuple
 
 RPCTriggerViaSWI = namedtuple('RPCTriggerViaSWI', ['register', 'bit'])

--- a/transport_plugins/jlink/setup.py
+++ b/transport_plugins/jlink/setup.py
@@ -9,8 +9,8 @@ setup(
     version=version.version,
     license="LGPLv3",
     install_requires=[
-        "iotile-core>=3.6.2",
-        "pylink-square>=0.0.10",
+        "iotile-core>=4.0.0",
+        "pylink-square>=0.1.3",
         "pylibftdi>=0.17.0"
     ],
 

--- a/transport_plugins/jlink/tox.ini
+++ b/transport_plugins/jlink/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py
+envlist = py35, py36, py37
 
 [testenv]
 passenv=APPDATA

--- a/transport_plugins/jlink/version.py
+++ b/transport_plugins/jlink/version.py
@@ -1,1 +1,1 @@
-version = "0.3.2"
+version = "1.0.0"

--- a/transport_plugins/native_ble/RELEASE.md
+++ b/transport_plugins/native_ble/RELEASE.md
@@ -2,6 +2,10 @@
 
 All major changes in each released version of the native BLE transport plugin are listed here.
 
+## 2.0.0
+
+- Drop python2 support
+
 ## 1.0.0
 
 - Initial public release (only works on Linux)

--- a/transport_plugins/native_ble/setup.py
+++ b/transport_plugins/native_ble/setup.py
@@ -8,8 +8,8 @@ setup(
     version=version.version,
     license="LGPLv3",
     install_requires=[
-        "iotile-core>=3.6.2",
-        "monotonic",
+        "iotile-core>=4.0.0",
+        "monotonic~=1.5",
         "bable-interface>=1.2.0"
     ],
     entry_points={'iotile.device_adapter': ['ble = iotile_transport_native_ble.device_adapter:NativeBLEDeviceAdapter'],
@@ -22,10 +22,10 @@ setup(
     keywords=["iotile", "arch", "embedded", "hardware", "firmware", "ble", "bluetooth"],
     classifiers=[
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Development Status :: 3 - Alpha",
         "License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)",
         "Operating System :: Unix",  # FIXME: change as soon as bable-interface will be deployed on Windows and Mac

--- a/transport_plugins/native_ble/test/devices_factory.py
+++ b/transport_plugins/native_ble/test/devices_factory.py
@@ -6,7 +6,7 @@ from iotile.mock.devices import ReportTestDevice, TracingTestDevice
 # ====== Report test device ======
 
 def build_report_device():
-    with open(os.path.join(os.path.dirname(__file__), 'report_device_config.json'), "rb") as conf_file:
+    with open(os.path.join(os.path.dirname(__file__), 'report_device_config.json'), "r") as conf_file:
         config = json.load(conf_file)
 
     return ReportTestDevice(config['device'])
@@ -21,7 +21,7 @@ def get_report_device_string():
 # ====== Tracing test device ======
 
 def build_tracing_device():
-    with open(os.path.join(os.path.dirname(__file__), 'tracing_device_config.json'), "rb") as conf_file:
+    with open(os.path.join(os.path.dirname(__file__), 'tracing_device_config.json'), "r") as conf_file:
         config = json.load(conf_file)
 
     return TracingTestDevice(config['device'])

--- a/transport_plugins/native_ble/test/test_virtual_interface.py
+++ b/transport_plugins/native_ble/test/test_virtual_interface.py
@@ -126,7 +126,7 @@ def test_rpc(connected_virtual_interface):
 def test_stream(connected_virtual_interface):
     """Test to stream reports after streaming interface has been opened."""
     # Get the device configuration from the configuration file.
-    with open(get_report_device_string().split('@')[-1], "rb") as conf_file:
+    with open(get_report_device_string().split('@')[-1], "r") as conf_file:
         config = json.load(conf_file)
         num_reports = int(config['device']['num_readings']) / int(config['device']['report_length'])
 
@@ -172,7 +172,7 @@ def test_stream(connected_virtual_interface):
 def test_tracing(connected_virtual_interface):
     """Test to send traces after the tracing interface has been opened."""
     # Get the device configuration from the configuration file.
-    with open(get_tracing_device_string().split('@')[-1], "rb") as conf_file:
+    with open(get_tracing_device_string().split('@')[-1], "r") as conf_file:
         config = json.load(conf_file)
         traces_sent = config['device']['ascii_data']
 

--- a/transport_plugins/native_ble/tox.ini
+++ b/transport_plugins/native_ble/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,36}-{linux_only}
+envlist = py{35,36,37}-{linux_only}
 
 [testenv]
 passenv=APPDATA

--- a/transport_plugins/native_ble/version.py
+++ b/transport_plugins/native_ble/version.py
@@ -1,1 +1,1 @@
-version = "1.0.0"
+version = "2.0.0"

--- a/transport_plugins/websocket/RELEASE.md
+++ b/transport_plugins/websocket/RELEASE.md
@@ -2,12 +2,13 @@
 
 All major changes in each released version of the websocket transport plugin are listed here.
 
-## HEAD
+## 2.0.0
 
 - Remove debug logger level to lower the chattiness of the transport plugin
 - Fix python 3 compatibility issue when calling an RPC that throws an exception.
   (Issue #639)
 - open_debug_interface has optional argument connection_string
+- Drop python2 support
 
 ## 1.0.0
 

--- a/transport_plugins/websocket/setup.py
+++ b/transport_plugins/websocket/setup.py
@@ -9,8 +9,8 @@ setup(
     version=version.version,
     license="LGPLv3",
     install_requires=[
-        "iotile-core>=3.22.0",
-        "msgpack>=0.5.5"
+        "iotile-core>=4.0.0",
+        "msgpack>=0.6.1"
     ],
 
     entry_points={
@@ -31,10 +31,10 @@ setup(
     keywords=["iotile", "arch", "embedded", "hardware", "firmware"],
     classifiers=[
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Development Status :: 3 - Alpha",
         "License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)",
         "Operating System :: OS Independent",

--- a/transport_plugins/websocket/test/devices_factory.py
+++ b/transport_plugins/websocket/test/devices_factory.py
@@ -6,7 +6,7 @@ from iotile.mock.devices import ReportTestDevice, TracingTestDevice
 # ====== Report test device ======
 
 def build_report_device():
-    with open(os.path.join(os.path.dirname(__file__), 'report_device_config.json'), "rb") as conf_file:
+    with open(os.path.join(os.path.dirname(__file__), 'report_device_config.json'), "r") as conf_file:
         config = json.load(conf_file)
 
     return ReportTestDevice(config['device'])
@@ -21,7 +21,7 @@ def get_report_device_string():
 # ====== Tracing test device ======
 
 def build_tracing_device():
-    with open(os.path.join(os.path.dirname(__file__), 'tracing_device_config.json'), "rb") as conf_file:
+    with open(os.path.join(os.path.dirname(__file__), 'tracing_device_config.json'), "r") as conf_file:
         config = json.load(conf_file)
 
     return TracingTestDevice(config['device'])

--- a/transport_plugins/websocket/test/test_multiple_wshandler.py
+++ b/transport_plugins/websocket/test/test_multiple_wshandler.py
@@ -14,7 +14,7 @@ report_device_string = get_report_device_string()
 tracing_device_string = get_tracing_device_string()
 
 # Get traces sent from the config file
-with open(tracing_device_string.split('@')[-1], "rb") as conf_file:
+with open(tracing_device_string.split('@')[-1], "r") as conf_file:
     config = json.load(conf_file)
     traces_sent = config['device']['ascii_data']
 

--- a/transport_plugins/websocket/test/test_virtual_interface.py
+++ b/transport_plugins/websocket/test/test_virtual_interface.py
@@ -12,7 +12,7 @@ from devices_factory import build_report_device, build_tracing_device, get_traci
 tracing_device_string = get_tracing_device_string()
 
 # Get traces sent from the config file
-with open(tracing_device_string.split('@')[-1], "rb") as conf_file:
+with open(tracing_device_string.split('@')[-1], "r") as conf_file:
     config = json.load(conf_file)
     traces_sent = config['device']['ascii_data']
 

--- a/transport_plugins/websocket/test/test_wshandler.py
+++ b/transport_plugins/websocket/test/test_wshandler.py
@@ -14,7 +14,7 @@ report_device_string = get_report_device_string()
 tracing_device_string = get_tracing_device_string()
 
 # Get traces sent from the config file
-with open(tracing_device_string.split('@')[-1], "rb") as conf_file:
+with open(tracing_device_string.split('@')[-1], "r") as conf_file:
     config = json.load(conf_file)
     traces_sent = config['device']['ascii_data']
 

--- a/transport_plugins/websocket/tox.ini
+++ b/transport_plugins/websocket/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py36
+envlist = py35, py36, py37
 
 [testenv]
 passenv=APPDATA

--- a/transport_plugins/websocket/version.py
+++ b/transport_plugins/websocket/version.py
@@ -1,1 +1,1 @@
-version = "1.0.0"
+version = "2.0.0"


### PR DESCRIPTION
Submitting this separately from the other packages due to their dependency on it to test, and just for clarity. If there's another way to bundle everything together, happy to amend this PR to include those.

## Overview

We are EOL for python2 in preparation for the 2020 upstream EOL. Moving future dev work to python3 only helps as a forcing function to fix any remaining incompatibilities and lets us take advantage of py3 only features without breaking workflows when you support both.

## Major Changes

- iotilecore package dependency updates (some of them were quite out of date and likely invalid)
- Adjust package release to be non-universal py3 only.
