### PR TITLE
Fix the new major release version to actually enforce py3

### DIFF
--- a/iotilecore/RELEASE.md
+++ b/iotilecore/RELEASE.md
@@ -2,9 +2,14 @@
 
 All major changes in each released version of `iotile-core` are listed here.
 
+## 4.0.1
+
+- Actually drop python2 support
+
 ## 4.0.0
 
 - Drop python2 support
+- This version was not officially released
 
 ## 3.27.2
 

--- a/iotilecore/setup.py
+++ b/iotilecore/setup.py
@@ -82,6 +82,7 @@ setup(
     author_email="info@arch-iot.com",
     url="https://github.com/iotile/coretools/iotilecore",
     keywords=["iotile", "arch", "embedded", "hardware"],
+    python_requires=">=3.5, <4",
     classifiers=[
         "Programming Language :: Python",
         "Development Status :: 5 - Production/Stable",

--- a/iotilecore/version.py
+++ b/iotilecore/version.py
@@ -1,1 +1,1 @@
-version = "4.0.0"
+version = "4.0.1"


### PR DESCRIPTION
pypi needs another qualifier in setup.py to prevent py2 installs from getting bad packages.