### PR TITLE
Fix the rest of the packages for true python3

### DIFF
--- a/iotile_ext_cloud/RELEASE.md
+++ b/iotile_ext_cloud/RELEASE.md
@@ -2,7 +2,7 @@
 
 All major changes in each released version of the iotile-ext-cloud plugin are listed here.
 
-## 1.0.0
+## 1.0.1
 
 - Fix username/password prompting to work correctly on python 2 and 3 if not
   already specified in `iotile config link_cloud`.

--- a/iotile_ext_cloud/setup.py
+++ b/iotile_ext_cloud/setup.py
@@ -11,13 +11,12 @@ setup(
         "iotile-core>=4.0.0",
         "iotile_cloud>=0.9.9"
     ],
-
+    python_requires=">=3.5,<4",
     entry_points={'iotile.config_function': ['link_cloud = iotile.cloud.config:link_cloud'],
                   'iotile.config_variables': ['iotile-ext-cloud = iotile.cloud.config:get_variables'],
                   'iotile.plugin': ['cloud = iotile.cloud.plugin:setup_plugin'],
                   'iotile.app': ['cloud_uploader = iotile.cloud.apps.cloud_uploader',
                                  'ota_updater = iotile.cloud.apps.ota_updater']},
-
     description="IOTile.cloud integration into CoreTools",
     author="Arch",
     author_email="info@arch-iot.com",
@@ -28,6 +27,10 @@ setup(
         "Development Status :: 3 - Alpha",
         "License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)",
         "Operating System :: OS Independent",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Topic :: Software Development :: Libraries :: Python Modules"
         ],
     long_description="""\

--- a/iotile_ext_cloud/version.py
+++ b/iotile_ext_cloud/version.py
@@ -1,1 +1,1 @@
-version = "1.0.0"
+version = "1.0.1"

--- a/iotilebuild/RELEASE.md
+++ b/iotilebuild/RELEASE.md
@@ -2,7 +2,7 @@
 
 All major changes in each released version of IOTileBuild are listed here.
 
-## 3.0.0
+## 3.0.1
 
 - Drop python2 support
 

--- a/iotilebuild/setup.py
+++ b/iotilebuild/setup.py
@@ -39,6 +39,7 @@ setup(
         "pycparser>=2.17",
         "pyparsing~=2.2.0"
     ],
+    python_requires=">=3.5,<4",
     include_package_data=True,
     entry_points={'iotile.plugin': ['.build = iotile.build.plugin:setup_plugin'],
                   'iotile.build.default_depresolver': ['registry_resolver = iotile.build.dev.resolvers:DEFAULT_REGISTRY_RESOLVER'],
@@ -58,6 +59,10 @@ setup(
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)",
         "Operating System :: OS Independent",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Topic :: Software Development :: Libraries :: Python Modules"
         ],
     long_description="""\

--- a/iotilebuild/version.py
+++ b/iotilebuild/version.py
@@ -1,1 +1,1 @@
-version = "3.0.0"
+version = "3.0.1"

--- a/iotileemulate/RELEASE.md
+++ b/iotileemulate/RELEASE.md
@@ -2,7 +2,7 @@
 
 All major changes in each released version of iotile-emulate are listed here.
 
-## 0.4.0
+## 0.4.1
 
 - Drop python2 support
 

--- a/iotileemulate/setup.py
+++ b/iotileemulate/setup.py
@@ -13,6 +13,7 @@ setup(
         "iotile-core>=4.0.0",
         "iotile-sensorgraph>=0.8.1"
     ],
+    python_requires=">=3.5,<4",
     entry_points={'iotile.virtual_device': ['reference_1_0 = iotile.emulate.demo:DemoReferenceDevice',
                                             'emulation_demo = iotile.emulate.demo:DemoEmulatedDevice'],
                   'iotile.proxy': ['emudmo = iotile.emulate.demo:DemoTileProxy'],

--- a/iotileemulate/version.py
+++ b/iotileemulate/version.py
@@ -1,1 +1,1 @@
-version = "0.4.0"
+version = "0.4.1"

--- a/iotilegateway/RELEASE.md
+++ b/iotilegateway/RELEASE.md
@@ -2,7 +2,7 @@
 
 All major changes in each released version of IOTileGateway are listed here.
 
-## 2.0.0
+## 2.0.1
 
 - Fix recurring errors when iotile-supervisor not present while running iotile-gateway
 - Drop python2 support

--- a/iotilegateway/setup.py
+++ b/iotilegateway/setup.py
@@ -27,6 +27,7 @@ setup(
         "msgpack>=0.6.1",
         "ws4py>=0.5.1"
     ],
+    python_requires=">=3.5,<4",
     entry_points={
         'console_scripts': [
             'iotile-gateway = iotilegateway.main:main',
@@ -50,6 +51,10 @@ setup(
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)",
         "Operating System :: OS Independent",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Topic :: Software Development :: Libraries :: Python Modules"
         ],
     long_description="""\

--- a/iotilegateway/version.py
+++ b/iotilegateway/version.py
@@ -1,1 +1,1 @@
-version = "2.0.0"
+version = "2.0.1"

--- a/iotilesensorgraph/RELEASE.md
+++ b/iotilesensorgraph/RELEASE.md
@@ -3,7 +3,7 @@
 All major changes in each released version of iotile-sensorgraph are listed
 here.
 
-## 1.0.0
+## 1.0.1
 
 - Add support for directly passing an sgf string to the parser.  This helps
   when compiling a sensorgraph programmatically.

--- a/iotilesensorgraph/setup.py
+++ b/iotilesensorgraph/setup.py
@@ -29,6 +29,7 @@ setup(
         "toposort>=1.5",
         "iotile-core>=4.0.0"
     ],
+    python_requires=">=3.5,<4",
     entry_points={'iotile.sg_processor': ['copy_all_a = iotile.sg.processors:copy_all_a',
                                           'copy_latest_a = iotile.sg.processors:copy_latest_a',
                                           'copy_count_a = iotile.sg.processors:copy_count_a',

--- a/iotilesensorgraph/version.py
+++ b/iotilesensorgraph/version.py
@@ -1,1 +1,1 @@
-version = "1.0.0"
+version = "1.0.1"

--- a/iotileship/RELEASE.md
+++ b/iotileship/RELEASE.md
@@ -2,7 +2,7 @@
 
 All major changes in each released version of IOTileShip are listed here.
 
-## 1.0.0
+## 1.0.1
 
 - Drop python2 support
 

--- a/iotileship/setup.py
+++ b/iotileship/setup.py
@@ -25,6 +25,7 @@ setup(
         "iotile-core>=4.0.0",
         "pyaml>=18.11.0"
     ],
+    python_requires=">=3.5,<4",
     include_package_data=True,
     entry_points={
         'console_scripts': [
@@ -56,6 +57,10 @@ setup(
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)",
         "Operating System :: OS Independent",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Topic :: Software Development :: Libraries :: Python Modules"
         ],
     long_description="""\

--- a/iotileship/version.py
+++ b/iotileship/version.py
@@ -1,1 +1,1 @@
-version = "1.0.0"
+version = "1.0.1"

--- a/iotiletest/RELEASE.md
+++ b/iotiletest/RELEASE.md
@@ -2,7 +2,7 @@
 
 All major changes in each released version of IOTileTest are listed here.
 
-## 1.0.0
+## 1.0.1
 
 - Drop python2 support
 

--- a/iotiletest/setup.py
+++ b/iotiletest/setup.py
@@ -22,6 +22,7 @@ setup(
     version=version.version,
     license="LGPLv3",
     description="IOTile Test Infrastructure",
+    python_requires=">=3.5,<4",
     entry_points={'iotile.virtual_device': ['simple = iotile.mock.devices.simple_virtual_device:SimpleVirtualDevice',
                                             'report_test = iotile.mock.devices.report_test_device:ReportTestDevice',
                                             'realtime_test = iotile.mock.devices.realtime_test_device:RealtimeTestDevice',

--- a/iotiletest/version.py
+++ b/iotiletest/version.py
@@ -1,1 +1,1 @@
-version = "1.0.0"
+version = "1.0.1"

--- a/transport_plugins/awsiot/RELEASE.md
+++ b/transport_plugins/awsiot/RELEASE.md
@@ -2,7 +2,7 @@
 
 All major changes in each released version of iotile-transport-awsiot are listed here.
 
-## 1.0.0
+## 1.0.1
 
 - Drop python2 support
 - Fix py3 compatibility

--- a/transport_plugins/awsiot/setup.py
+++ b/transport_plugins/awsiot/setup.py
@@ -12,7 +12,7 @@ setup(
         "AWSIoTPythonSDK>=1.4.3",
         "monotonic~=1.5"
     ],
-
+    python_requires=">=3.5,<4",
     entry_points={'iotile.device_adapter': ['awsiot = iotile_transport_awsiot.device_adapter:AWSIOTDeviceAdapter'],
                   'iotile.virtual_interface': ['awsiot = iotile_transport_awsiot.virtual_interface:AWSIOTVirtualInterface'],
                   'iotile.gateway_agent': ['awsiot = iotile_transport_awsiot.gateway_agent:AWSIOTGatewayAgent']},
@@ -26,6 +26,10 @@ setup(
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)",
         "Operating System :: OS Independent",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Topic :: Software Development :: Libraries :: Python Modules"
         ],
     long_description="""\

--- a/transport_plugins/awsiot/version.py
+++ b/transport_plugins/awsiot/version.py
@@ -1,1 +1,1 @@
-version = "1.0.0"
+version = "1.0.1"

--- a/transport_plugins/bled112/RELEASE.md
+++ b/transport_plugins/bled112/RELEASE.md
@@ -2,7 +2,7 @@
 
 All major changes in each released version of the bled112 transport plugin are listed here.
 
-## 2.0.0
+## 2.0.1
 
 - Ctrl+C breaks if you accidentally double book the bled112 dongle fix(#657)
 - Drop python2 support

--- a/transport_plugins/bled112/setup.py
+++ b/transport_plugins/bled112/setup.py
@@ -12,7 +12,7 @@ setup(
         "iotile-core>=4.0.0",
         "pyserial>=3.4.0"
     ],
-
+    python_requires=">=3.5,<4",
     entry_points={'iotile.device_adapter': ['bled112 = iotile_transport_bled112.bled112:BLED112Adapter'],
                   'iotile.virtual_interface': ['bled112 = iotile_transport_bled112.virtual_bled112:BLED112VirtualInterface'],
                   'iotile.config_variables': ['bled112 = iotile_transport_bled112.config_variables:get_variables']},
@@ -26,6 +26,10 @@ setup(
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)",
         "Operating System :: OS Independent",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Topic :: Software Development :: Libraries :: Python Modules"
         ],
     long_description="""\

--- a/transport_plugins/bled112/version.py
+++ b/transport_plugins/bled112/version.py
@@ -1,1 +1,1 @@
-version = "2.0.0"
+version = "2.0.1"

--- a/transport_plugins/jlink/RELEASE.md
+++ b/transport_plugins/jlink/RELEASE.md
@@ -5,7 +5,7 @@ listed here.
 
 
 
-## 1.0.0
+## 1.0.1
 - Drop python2 support 
 - Enable python3 compatibility
 

--- a/transport_plugins/jlink/setup.py
+++ b/transport_plugins/jlink/setup.py
@@ -13,7 +13,7 @@ setup(
         "pylink-square>=0.1.3",
         "pylibftdi>=0.17.0"
     ],
-
+    python_requires=">=3.5,<4",
     entry_points={'iotile.device_adapter': ['jlink = iotile_transport_jlink.jlink:JLinkAdapter']},
     description="IOTile JLINK Transport Plugin",
     author="Arch",
@@ -25,6 +25,10 @@ setup(
         "Development Status :: 2 - Pre-Alpha",
         "License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)",
         "Operating System :: OS Independent",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Topic :: Software Development :: Libraries :: Python Modules"
         ],
     long_description="""\

--- a/transport_plugins/jlink/version.py
+++ b/transport_plugins/jlink/version.py
@@ -1,1 +1,1 @@
-version = "1.0.0"
+version = "1.0.1"

--- a/transport_plugins/native_ble/RELEASE.md
+++ b/transport_plugins/native_ble/RELEASE.md
@@ -2,7 +2,7 @@
 
 All major changes in each released version of the native BLE transport plugin are listed here.
 
-## 2.0.0
+## 2.0.1
 
 - Drop python2 support
 

--- a/transport_plugins/native_ble/setup.py
+++ b/transport_plugins/native_ble/setup.py
@@ -12,6 +12,7 @@ setup(
         "monotonic~=1.5",
         "bable-interface>=1.2.0"
     ],
+    python_requires=">=3.5,<4",
     entry_points={'iotile.device_adapter': ['ble = iotile_transport_native_ble.device_adapter:NativeBLEDeviceAdapter'],
                   'iotile.virtual_interface': ['ble = iotile_transport_native_ble.virtual_ble:NativeBLEVirtualInterface'],
                   'iotile.config_variables': ['ble = iotile_transport_native_ble.config_variables:get_variables']},

--- a/transport_plugins/native_ble/version.py
+++ b/transport_plugins/native_ble/version.py
@@ -1,1 +1,1 @@
-version = "2.0.0"
+version = "2.0.1"

--- a/transport_plugins/websocket/RELEASE.md
+++ b/transport_plugins/websocket/RELEASE.md
@@ -2,7 +2,7 @@
 
 All major changes in each released version of the websocket transport plugin are listed here.
 
-## 2.0.0
+## 2.0.1
 
 - Remove debug logger level to lower the chattiness of the transport plugin
 - Fix python 3 compatibility issue when calling an RPC that throws an exception.

--- a/transport_plugins/websocket/setup.py
+++ b/transport_plugins/websocket/setup.py
@@ -12,7 +12,7 @@ setup(
         "iotile-core>=4.0.0",
         "msgpack>=0.6.1"
     ],
-
+    python_requires=">=3.5,<4",
     entry_points={
         'iotile.device_adapter': [
             'ws2 = iotile_transport_websocket.device_adapter:WebSocketDeviceAdapter'

--- a/transport_plugins/websocket/version.py
+++ b/transport_plugins/websocket/version.py
@@ -1,1 +1,1 @@
-version = "2.0.0"
+version = "2.0.1"


### PR DESCRIPTION
This will prevent pip from installing them when using a py2 interpreter

This actually enforces py3 only for the packages. I thought that having `py3` be part of the wheel would be sufficient for pip, but you actually need `python_requires` in the setup.

Side note, if you're using a pip older than 9.0, it apparently ignores this flag and will install the newest package anyways. So I hope everyone is using pip 9...