### PR TITLE
Feat emu improvement

### DIFF
--- a/iotileemulate/RELEASE.md
+++ b/iotileemulate/RELEASE.md
@@ -6,6 +6,10 @@ All major changes in each released version of iotile-emulate are listed here.
 
 - Make `EmulationLoop.finish_async_rpc` easier to use by automatically packing
   rpc responses.  Issue #721.
+- Add support for raising `RPCRuntimeError` from an RPC implementation in order
+  to return an error code.  This simplifies the implementation logic of complex
+  RPCs.  Issue #718.
+- Fixes bug inside CrossThreadResponse that does not properly reraise exceptions.
 
 ## 0.4.1
 

--- a/iotileemulate/RELEASE.md
+++ b/iotileemulate/RELEASE.md
@@ -2,6 +2,11 @@
 
 All major changes in each released version of iotile-emulate are listed here.
 
+## HEAD
+
+- Make `EmulationLoop.finish_async_rpc` easier to use by automatically packing
+  rpc responses.  Issue #721.
+
 ## 0.4.1
 
 - Drop python2 support

--- a/iotileemulate/RELEASE.md
+++ b/iotileemulate/RELEASE.md
@@ -2,7 +2,7 @@
 
 All major changes in each released version of iotile-emulate are listed here.
 
-## HEAD
+## 0.4.2
 
 - Make `EmulationLoop.finish_async_rpc` easier to use by automatically packing
   rpc responses.  Issue #721.

--- a/iotileemulate/iotile/emulate/__init__.py
+++ b/iotileemulate/iotile/emulate/__init__.py
@@ -23,5 +23,6 @@ It includes:
 
 from .virtual import EmulatedDevice, EmulatedTile, EmulatedPeripheralTile
 from . import constants
+from .common import RPCRuntimeError
 
-__all__ = ['EmulatedTile', 'EmulatedDevice', 'EmulatedPeripheralTile', 'constants']
+__all__ = ['EmulatedTile', 'EmulatedDevice', 'EmulatedPeripheralTile', 'constants', 'RPCRuntimeError']

--- a/iotileemulate/iotile/emulate/common/__init__.py
+++ b/iotileemulate/iotile/emulate/common/__init__.py
@@ -1,0 +1,5 @@
+"""Common types shared across multiple iotile-emulate subsystems."""
+
+from .emulator_errors import RPCRuntimeError
+
+__all__ = ['RPCRuntimeError']

--- a/iotileemulate/iotile/emulate/common/emulator_errors.py
+++ b/iotileemulate/iotile/emulate/common/emulator_errors.py
@@ -1,0 +1,44 @@
+"""Custom exceptions for iotile-emulate."""
+
+import struct
+from iotile.core.exceptions import InternalError
+from ..constants import pack_error
+
+class RPCRuntimeError(Exception):
+    """Exception that indicates an RPC had a runtime error.
+
+    Runtime errors are application defined and are translated
+    to a 16-bit or 32-bit return value containing the error
+    code.
+
+    Args:
+        code (int): The error code that should be returned from
+            the RPC.
+        subsystem (int): The subsystem that the error code should
+            be returned from.  This may only be passed if size=L
+        size (str): Whether to return a 32-bit long-form error
+            including subsystem or a 16-bit short-firm error.
+            You may pass L or H.  The default is L, meaning
+            32 bit errors.
+    """
+
+    def __init__(self, code, subsystem=None, size="L"):
+        super(RPCRuntimeError, self).__init__()
+
+        if size not in ("L", "H"):
+            raise InternalError("Unknown size {} in RPCRuntimeError".format(size))
+
+        if subsystem is not None and size == 'H':
+            raise InternalError("You cannot combine size=H with a subsystem, subsystem={}".format(subsystem))
+
+        if subsystem is not None:
+            error = pack_error(subsystem, code)
+        else:
+            error = code
+
+        self.code = error
+        self.subsystem = subsystem
+        self.packed_error = error
+
+        print("Packed error: %r" % self.packed_error)
+        self.binary_error = struct.pack("<{}".format(size), self.packed_error)

--- a/iotileemulate/iotile/emulate/demo/demo_device.py
+++ b/iotileemulate/iotile/emulate/demo/demo_device.py
@@ -94,7 +94,7 @@ class DemoEmulatedTile(EmulatedPeripheralTile):
             try:
                 if action == 'echo':
                     rpc_id, arg = args
-                    self._device.emulator.finish_async_rpc(self.address, rpc_id, pack_rpc_payload("L", (arg,)))
+                    self._device.emulator.finish_async_rpc(self.address, rpc_id, "L", arg)
                 elif action == 'trace':
                     byte_count = args
                     chunks = byte_count // 20

--- a/iotileemulate/iotile/emulate/internal/response.py
+++ b/iotileemulate/iotile/emulate/internal/response.py
@@ -54,11 +54,6 @@ class GenericResponse:
             raise InternalError("No exception stored in call to _raise_exception")
 
         exc_type, value, traceback = self._exception
-
-        print(exc_type)
-        print("%r" % value)
-        print(traceback)
-
         if value is not None and isinstance(exc_type, Exception):
             raise TypeError("instance exception may not have a separate value")
 

--- a/iotileemulate/iotile/emulate/internal/response.py
+++ b/iotileemulate/iotile/emulate/internal/response.py
@@ -55,13 +55,14 @@ class GenericResponse:
 
         exc_type, value, traceback = self._exception
 
+        print(exc_type)
+        print("%r" % value)
+        print(traceback)
+
         if value is not None and isinstance(exc_type, Exception):
             raise TypeError("instance exception may not have a separate value")
 
-        if value is not None:
-            exc = exc_type(value)
-        else:
-            exc = exc_type
+        exc = value
 
         if exc.__traceback__ is not traceback:
             raise exc.with_traceback(traceback)

--- a/iotileemulate/test/test_eventloop.py
+++ b/iotileemulate/test/test_eventloop.py
@@ -54,8 +54,6 @@ def test_runtime_errors():
     loop = EmulationLoop(_rpc_executor)
     loop.start()
 
-
-
     try:
         assert loop.call_rpc_external(8, 0x8000, b'abcd') == struct.pack("<L", 0xabcd)
         assert loop.call_rpc_external(8, 0x8001, b'abcd') == struct.pack("<L", 0x1abcd)

--- a/iotileemulate/version.py
+++ b/iotileemulate/version.py
@@ -1,1 +1,1 @@
-version = "0.4.1"
+version = "0.4.2"


### PR DESCRIPTION
## Overview

This PR improves the usability of `finish_async_rpc` by handling the RPC response formatting rather than making the user convert their response to bytes.  

It also allows rpc implementations to raise a new exception `RPCRuntimeError` that will set a binary error code as the response of the RPC.  This is a common pattern inside firmware so this should reduce the work required to implement complex rpcs by letting them fail early with an error code.

### Additional Notes

- It looks like the `CrossThreadResponse` implementation of reraising an exception was broken so I also fixed it.

