### PR TITLE
Tag was reused, need 3.0.3 bump

### DIFF
--- a/iotilebuild/RELEASE.md
+++ b/iotilebuild/RELEASE.md
@@ -2,13 +2,9 @@
 
 All major changes in each released version of IOTileBuild are listed here.
 
-## HEAD
+## 3.0.3
 
 - Remove past/future/monotonic, pylint cleanup
-
-## 3.0.2
-
-- Remove python2 references and dead code
 
 ## 3.0.1
 

--- a/iotilebuild/version.py
+++ b/iotilebuild/version.py
@@ -1,1 +1,1 @@
-version = "3.0.2"
+version = "3.0.3"


### PR DESCRIPTION
I just learned that you can't just create a new tag with the same master target on the repo, even if the pypi package wasn't released it still uses what the tag was originally created with (probably a good idea on their part). However, this means I do need to move it to 3.0.3