### PR TITLE
Add support for passing gcc arguments via a command file.

### DIFF
--- a/iotilebuild/RELEASE.md
+++ b/iotilebuild/RELEASE.md
@@ -2,6 +2,17 @@
 
 All major changes in each released version of IOTileBuild are listed here.
 
+## 3.0.4
+
+- Change gcc calling routine to use command files (@path_to_args_file) rather
+  than passing all arguments on the command line.  This lead to very long
+  command lines that broke on windows because of the built-in command line
+  limit.
+
+- Clean up instances where we created an Scons Environment without specifying
+  tools=[].  This causes a warning on Windows if Visual Studio is not installed
+  because it assumes you wanted to use Visual Studio's compiler by default.
+
 ## 3.0.3
 
 - Remove more builtins/__future__ imports

--- a/iotilebuild/iotile/build/config/site_scons/autobuild.py
+++ b/iotilebuild/iotile/build/config/site_scons/autobuild.py
@@ -184,7 +184,7 @@ def autobuild_doxygen(tile):
     doxyfile = os.path.join(doxydir, 'doxygen.txt')
 
     outfile = os.path.join(doxydir, '%s.timestamp' % tile.unique_id)
-    env = Environment(ENV = os.environ)
+    env = Environment(ENV=os.environ, tools=[])
     env['IOTILE'] = iotile
 
     # There is no /dev/null on Windows
@@ -210,7 +210,7 @@ def autobuild_documentation(tile):
     outdir = os.path.join('build', 'output', 'doc', tile.unique_id)
     outfile = os.path.join(outdir, '%s.timestamp' % tile.unique_id)
 
-    env = Environment(ENV=os.environ)
+    env = Environment(ENV=os.environ, tools=[])
 
     # Only build doxygen documentation if we have C firmware to build from
     if os.path.exists('firmware'):

--- a/iotilebuild/iotile/build/config/site_scons/unit_test_qemu.py
+++ b/iotilebuild/iotile/build/config/site_scons/unit_test_qemu.py
@@ -134,7 +134,7 @@ class QEMUSemihostedUnitTest(unit_test.UnitTest):
     def _run_test(self, logpath, statuspath, test_elf):
         """Run a test elf under qemu."""
 
-        env = Environment()
+        env = Environment(tools=[])
         env.Command([logpath, statuspath], [test_elf], action=env.Action(run_qemu_command, "Running Test"))
 
 

--- a/iotilebuild/version.py
+++ b/iotilebuild/version.py
@@ -1,1 +1,1 @@
-version = "3.0.3"
+version = "3.0.4"


### PR DESCRIPTION
Update `iotile-build` to support pulling out `-D` and `-I` flags from GCC and handling them via an arguments file.

This is now used by default when compiling elf files. It prevents running out of command line argument space on Windows.

It also cleans up a few places where we created an `SCons.Environment()` without overriding the default tools.  This leads to a useless warning on Windows about "VIsual Studio" not being installed.

## Testing Performed

- Tested compiling all internal elf projects and library projects to ensure that all work.

Closes #726.
Closes #714.