### PR TITLE
Add the ability to completely undefine a -D symbol.

### DIFF
--- a/iotilebuild/RELEASE.md
+++ b/iotilebuild/RELEASE.md
@@ -2,6 +2,13 @@
 
 All major changes in each released version of IOTileBuild are listed here.
 
+## 3.0.5
+
+- Add support for completely undefining a symbol previously included in an
+  architecture's `defines` key in a subsequent architecture.  Now if a "defines"
+  key has the value None (null in json), it will be ignored and not passed 
+  as a -D flag to the compiler.  (Issue #730)
+
 ## 3.0.4
 
 - Change gcc calling routine to use command files (@path_to_args_file) rather

--- a/iotilebuild/iotile/build/config/site_scons/utilities.py
+++ b/iotilebuild/iotile/build/config/site_scons/utilities.py
@@ -56,7 +56,14 @@ def join_path(path):
 
 
 def build_defines(defines):
-    return ['-D"%s=%s"' % (x,str(y)) for x,y in defines.items()]
+    """Build a list of `-D` directives to pass to the compiler.
+
+    This will drop any definitions whose value is None so that
+    you can get rid of a define from another architecture by
+    setting its value to null in the `module_settings.json`.
+    """
+
+    return ['-D"%s=%s"' % (x, str(y)) for x, y in defines.items() if y is not None]
 
 
 def get_family(modulefile):

--- a/iotilebuild/test/test_iotilebuild/arm_def_component/SConstruct
+++ b/iotilebuild/test/test_iotilebuild/arm_def_component/SConstruct
@@ -1,0 +1,3 @@
+import autobuild
+
+autobuild.autobuild_arm_program('progtest')

--- a/iotilebuild/test/test_iotilebuild/arm_def_component/firmware/linker/linker.ld
+++ b/iotilebuild/test/test_iotilebuild/arm_def_component/firmware/linker/linker.ld
@@ -1,0 +1,191 @@
+/*
+ * Linker Script for NXP LPC824 Cortex M0+ Processor
+ */
+
+__flash_size = 32K;
+__ram_size = 8K;
+__exec_size = 6K;
+__exec_ram_size = 128;
+
+__api_size	= 64;
+__info_size = 32;
+__api_start = __exec_size - __api_size - __info_size;
+
+__app_start = __exec_size;
+
+__flash_start 	= 0x0;
+__flash_end 	= __flash_size;
+
+__ram_start 	= 0x10000000 + __exec_ram_size;
+__ram_end 		= __ram_start + __ram_size - __exec_ram_size;
+
+MEMORY
+{
+	app_flash	(rx)	: ORIGIN = __exec_size, 				LENGTH = __flash_size - __exec_size - __info_size
+	app_info 	(rx)	: ORIGIN = __flash_size - __info_size,	LENGTH = __info_size
+ 	app_ram 	(rwx) 	: ORIGIN = __ram_start, 				LENGTH = __ram_size - __exec_ram_size
+}
+
+/*
+ * Define symbols for the start and end of each region
+ */
+
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+	/*
+	 * Flash Sections
+	 */
+
+	 /*
+	  * NB, this .text section must remain the same as the initial section in the lpc824 executive since
+	  * we need to know the offset of section .optional_config.
+	  */
+	.text.isr_region : ALIGN(4)
+	{
+		FILL(0xff)
+
+		__isr_vectors_start__ = ABSOLUTE(.);
+		KEEP(*(.isr_vector))
+
+		/* 
+		 * Section Table for loading initialized values into RAM
+		 * and clearing uninitialized values to zero.
+		 */
+
+		. = ALIGN(4); 
+		__section_table_start = ABSOLUTE(.);
+		
+		__data_table_start = ABSOLUTE(.);
+		LONG(LOADADDR(.data));
+		LONG(ADDR(.data));
+		LONG(SIZEOF(.data));
+		__data_table_end = ABSOLUTE(.);
+		
+		__bss_table_start = ABSOLUTE(.);
+		LONG(ADDR(.bss));
+		LONG(SIZEOF(.bss));
+		__bss_section_table_end = ABSOLUTE(.);
+
+		__section_table_end = ABSOLUTE(.);
+
+		. = ALIGN(4);
+		
+		/* This needs to be placed directly after the section tables and right before .optional_config */
+		LONG(SIZEOF(.optional_config));
+	} > app_flash =0xFF
+
+	/*
+	 * Place config variables with default values directly after isr table so that we know
+	 * where they are and can copy them into place. 
+	 */
+	.optional_config : ALIGN(4)
+    {
+    	FILL(0xff)
+    	__optional_config_start = ABSOLUTE(.);
+    	
+
+    	KEEP(*(.optional_config))
+
+    	. = ALIGN(4);
+    	__optional_config_end = ABSOLUTE(.);
+    } >app_ram AT >app_flash =0xFF
+
+   	/*
+   	 * Place all of the code in flash
+   	 */
+	.text : ALIGN(4)
+	{
+		*(.text*)
+		*(.rodata .rodata.* .constdata .constdata.*)
+
+		. = ALIGN(4);
+	} > app_flash =0xFF
+
+	/*
+	 * Used for stack unwinding tables
+	 */
+	.ARM.edidx : ALIGN(4)
+	{
+		__exidx_start = .;
+		*(.ARM.exidx)
+		__exidx_end = .;
+
+		. = ALIGN(4);
+	} > app_flash =0xFF
+
+	/*
+	 * Include the application information block at the end of the image
+	 */
+	.block.appinfo : ALIGN(4)
+	{
+		KEEP(*(.block.appinfo))
+	} > app_info
+
+    /*
+     * RAM Sections
+     * 		.data contains all initialized variables that is copied to ram
+     *		.bss contains all unitialized variables that are cleared to 0
+     * 		.noinit contains all unitialized variables that should not be cleared
+     */
+
+	.data : ALIGN(4)
+	{
+		FILL(0xff)
+		
+		*(vtable)
+		*(.ramfunc*)
+		*(.data*)
+
+		. = ALIGN(4);
+
+		__used_flash = ABSOLUTE(.) - __flash_start;
+	} >app_ram AT >app_flash
+
+	.fill : ALIGN(4)
+	{
+		__fill_start = ABSOLUTE(.);
+
+		FILL(0xFF);
+
+		. = . + __flash_size - __fill_start - 1 - __info_size;
+
+		BYTE(0xFF);
+	} > app_flash
+
+	.bss : ALIGN(4)
+	{
+		*(.bss*)
+		*(COMMON)
+		. = ALIGN(4) ;
+	} > app_ram
+
+	.noinit (NOLOAD): ALIGN(4)
+	{
+		*(.noinit*)
+		*(.required_config*)
+		. = ALIGN(4);
+
+		__used_ram = ABSOLUTE(.) - __ram_start;
+	} > app_ram
+
+	
+
+	PROVIDE(_vStackTop = __ram_end);
+	PROVIDE(__code_checksum = 0 - 
+	(_vStackTop
+	+ Reset_Handler + 1
+	+ NMI_Handler + 1 
+	+ HardFault_Handler + 1
+	));
+
+	PROVIDE(__optional_config_size = __optional_config_end - __optional_config_start);
+	/* The location of the application info block if it exists */
+	PROVIDE(__app_info_start = __flash_end - __info_size);
+	PROVIDE(__application_start = __app_start);
+	PROVIDE(__application_end = __flash_end);
+
+	/* The location of the executive api block */
+	PROVIDE(__exec_api = __api_start);
+}

--- a/iotilebuild/test/test_iotilebuild/arm_def_component/firmware/src/SConscript
+++ b/iotilebuild/test/test_iotilebuild/arm_def_component/firmware/src/SConscript
@@ -1,0 +1,12 @@
+Import('prog_env')
+
+#Return all of the object files generated so that we can build the progra.
+objs = []
+
+srcfiles =  Glob("*.c") + \
+            Glob("cdb/*.c")
+
+for src in srcfiles:
+    objs.append(prog_env.Object(src))
+
+Return("objs")

--- a/iotilebuild/test/test_iotilebuild/arm_def_component/firmware/src/cdb/handlers.c
+++ b/iotilebuild/test/test_iotilebuild/arm_def_component/firmware/src/cdb/handlers.c
@@ -1,0 +1,21 @@
+#include <stdint.h>
+
+uint8_t test_rpc_handler(uint8_t *buffer, unsigned int length, uint8_t *out_buffer, unsigned int *out_length)
+{
+    (void)buffer;
+    (void)length;
+    (void)out_buffer;
+    (void)out_length;
+
+    return 0;
+}
+
+uint8_t test_rpc_handler2(uint8_t *buffer, unsigned int length, uint8_t *out_buffer, unsigned int *out_length)
+{
+    (void)buffer;
+    (void)length;
+    (void)out_buffer;
+    (void)out_length;
+
+    return 0;
+}

--- a/iotilebuild/test/test_iotilebuild/arm_def_component/firmware/src/cdb/progtest.cdb
+++ b/iotilebuild/test/test_iotilebuild/arm_def_component/firmware/src/cdb/progtest.cdb
@@ -1,0 +1,15 @@
+ModuleName = "progts";
+ModuleVersion = "1.0.0";
+APIVersion = "1.2";
+
+0x8000: test_rpc_handler(0, no);
+0x5000: test_rpc_handler2(0, no);
+
+# Config Variables
+
+0x7000: optional config uint8_t     opt1[15] = {1, 2, 3, 4, 5};
+0x7001: optional config char        opt2[10] = "hello";
+0x7002: optional config uint16_t    opt3 = 0;
+
+0x8000: required config uint8_t     req1;
+0x8001: required config uint32_t    req2[2];

--- a/iotilebuild/test/test_iotilebuild/arm_def_component/firmware/src/cdb_application.h
+++ b/iotilebuild/test/test_iotilebuild/arm_def_component/firmware/src/cdb_application.h
@@ -1,0 +1,64 @@
+#ifndef __cdb_application_h__
+#define __cdb_application_h__
+
+#include <stdint.h>
+
+#define kCDBModuleNameLength    6
+#define kCDBMagicNumber         0xBAADDAAD
+#define kModuleHardwareType     1
+
+/* 
+ * Slave RPC Handler
+ */ 
+typedef uint8_t (*cdb_slave_handler)(uint8_t *buffer, unsigned int length, uint8_t *out_buffer, unsigned int *out_length);
+
+/*
+ * RPC handler table entry format
+ */
+typedef struct
+{
+    cdb_slave_handler   handler;
+    uint16_t            command;
+    uint16_t            reserved;
+} cdb_slave_entry;
+
+/*
+ * Entry for specifying a configuration variable
+ */
+typedef struct
+{
+    void                *variable;
+    uint16_t            id;
+    uint16_t            size: 15;
+    uint16_t            variable_size: 1;
+} cdb_config_entry;
+
+/*
+ * Information block about CDB compatile application firmware image
+ */
+typedef struct
+{
+    uint8_t                 hardware_type;
+    uint8_t                 api_major_version;
+    uint8_t                 api_minor_version;
+
+    char                    name[kCDBModuleNameLength];
+
+    uint8_t                 module_major_version;
+    uint8_t                 module_minor_version;        
+    uint8_t                 module_patch_version;
+
+    uint8_t                 num_slave_commands;
+    uint8_t                 num_required_configs;
+    uint8_t                 num_total_configs;
+    
+    uint8_t                 reserved;
+
+    const cdb_config_entry  *config_variables;
+    const cdb_slave_entry   *slave_handlers;        
+
+    uint32_t                magic_number;
+    uint32_t                firmware_checksum;
+} CDBApplicationInfoBlock;
+
+#endif

--- a/iotilebuild/test/test_iotilebuild/arm_def_component/firmware/src/file_1.c
+++ b/iotilebuild/test/test_iotilebuild/arm_def_component/firmware/src/file_1.c
@@ -1,0 +1,13 @@
+#ifdef kTestDefine
+#error kTestDefine is defined but should have been undefined by a subsequent architecture
+#endif
+
+int main(void)
+{
+    return 1;
+}
+
+void Reset_Handler()
+{
+    
+}

--- a/iotilebuild/test/test_iotilebuild/arm_def_component/module_settings.json
+++ b/iotilebuild/test/test_iotilebuild/arm_def_component/module_settings.json
@@ -1,0 +1,58 @@
+{
+	"module_name": "libprogram",
+	
+	"module_targets": 
+	{
+		"progtest": ["arm/override"]
+	},
+
+	"modules":
+	{
+		"progtest":
+		{
+			"version": "1.0.0",
+			
+			"depends": {},
+			"linker": "firmware/linker/linker.ld",
+
+			"products": 
+			{
+				"progtest_arm.elf": "firmware_image",
+				"python/arm_proxy.py": "proxy_module",
+				"python/lib_armtypes": "type_package",
+				"include_directories": [
+					".",
+					"cdb"
+				],
+
+				"tilebus_definitions": [
+					["cdb", "progtest.cdb"]
+				]
+			}
+		}
+	},
+
+	"architectures":
+	{
+		"arm":
+		{
+			"cflags": ["-mthumb", "-Wall", "-Wshadow", "-Os", "-g", "-fno-builtin", "-ffunction-sections", "-fdata-sections"],
+			"asflags": ["-Wall"],
+			"ldflags": ["-mthumb", "-Xlinker", "--gc-sections", "--specs=nano.specs", "-lc", "-lnosys", "-nostartfiles"],
+			"cpu": "cortex-m0plus",
+			"chip": "lpc824",
+			"defines":
+			{
+				"kTestDefine": "(64*1024)"
+			}
+		},
+
+		"override":
+		{
+			"defines":
+			{
+				"kTestDefine": null
+			}
+		}
+	}
+}

--- a/iotilebuild/test/test_iotilebuild/arm_def_component/python/arm_proxy.py
+++ b/iotilebuild/test/test_iotilebuild/arm_def_component/python/arm_proxy.py
@@ -1,0 +1,8 @@
+from iotile.core.hw.proxy.proxy import TileBusProxyObject
+
+class ARMProxy(TileBusProxyObject):
+    """Provide access to ARM tile functionality"""
+
+    @classmethod
+    def ModuleName(cls):
+        return 'progts'

--- a/iotilebuild/test/test_iotilebuild/arm_def_component/python/lib_armtypes/file1.py
+++ b/iotilebuild/test/test_iotilebuild/arm_def_component/python/lib_armtypes/file1.py
@@ -1,0 +1,1 @@
+import os

--- a/iotilebuild/test/test_iotilebuild/test_scons.py
+++ b/iotilebuild/test/test_iotilebuild/test_scons.py
@@ -219,6 +219,20 @@ def test_build_arm(tmpdir):
         os.chdir(olddir)
 
 
+def test_build_arm_defines(tmpdir):
+    """Make sure we can build a component that overrides a depends key."""
+
+    olddir = os.getcwd()
+    builddir = copy_folder('arm_def_component', tmpdir)
+
+    try:
+        os.chdir(builddir)
+        err = subprocess.call(["iotile", "build"])
+        assert err == 0
+    finally:
+        os.chdir(olddir)
+
+
 def test_build_python(tmpdir):
     """Make sure we can build a component with a full python distribution.
 

--- a/iotilebuild/version.py
+++ b/iotilebuild/version.py
@@ -1,1 +1,1 @@
-version = "3.0.4"
+version = "3.0.5"


### PR DESCRIPTION
This PR adds the ability to completely remove a `defines` entry from a previous architecture in a subsequent one.  Previously it was only possible redefine it's value, not `#undefine` it entirely.  Complete removal is important when the `#define` is used by third party code that checks for its presence using `#ifdef` rather than `#if`.

Closes #730
