### PR TITLE
Migrate the ServiceStatusClient to use asynchronous behavior.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,7 +42,8 @@ jobs:
   - script: |
       set PATH=%PATH%;c:\gcc\bin
       pip install six cmdln pytest
-      pip install pytest pytest-logging pytest-localserver requests-mock pycryptodome configparser iotile-support-lib-controller-3
+      pip install pytest pytest-logging pytest-localserver
+      pip install requests-mock pycryptodome configparser iotile-support-lib-controller-3
       pip install "tornado>=4.5.3,<5.0.0"
       pip install -e ./iotilecore/
       pip install -e ./iotilebuild/

--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -1,8 +1,8 @@
 tornado>=4.5.3
 ws4py>=0.5.1
+websockets
 msgpack>=0.6.1
 python-dateutil>=2.6.0
 typedargs>=1.0.0
 sortedcontainers~=2.1
 entrypoints>=0.3.0
-enum34

--- a/iotilecore/RELEASE.md
+++ b/iotilecore/RELEASE.md
@@ -2,6 +2,10 @@
 
 All major changes in each released version of `iotile-core` are listed here.
 
+## 4.0.4
+
+- Create async version of the ValidatingWSClient
+- Create an EventLoop utility for managing asynchronous loops
 
 ## 4.0.3
 

--- a/iotilecore/iotile/core/utilities/event_loop.py
+++ b/iotilecore/iotile/core/utilities/event_loop.py
@@ -1,0 +1,105 @@
+"""A class that lets you push tasks to a global event loop of the program, letting
+your objects create a reference to the asyncio event loop withotu having to
+pass a loop everywhere
+"""
+
+import asyncio
+import logging
+import threading
+
+
+class EventLoop:
+    """EventLoop
+
+    A container for the asyncio event loop in a background thread
+    """
+
+    loop = None
+    thread = None
+
+    _started = False
+
+    _logger = logging.getLogger(__name__)
+
+    @classmethod
+    def start(cls):
+        """Starts the loop instance if not already created and started"""
+        if not cls.loop:
+            cls._logger.debug("starting event loop")
+            cls.loop = asyncio.new_event_loop()
+            cls.thread = threading.Thread(target=cls._loop_thread_main, name="EventLoopThread", daemon=True)
+            cls.thread.start()
+            cls._started = True
+
+    @classmethod
+    def get_loop(cls):
+        """Loop getter for users of the event loop object"""
+        if not cls.loop:
+            cls.start()
+
+        return cls.loop
+
+    @classmethod
+    def get_thread(cls):
+        """Utility function to get the loop's thread ID for lower-level control/access"""
+        return cls.thread
+
+    @classmethod
+    def stop_loop_abrupt(cls):
+        """Utility function to stop without trying to clean up"""
+        if cls.loop and cls.loop.is_running():
+            cls.loop.stop()
+
+    @classmethod
+    def stop_loop_clean(cls):
+        """Proper way to close the event loop that attempts to clean up all tasks"""
+        if cls.loop and cls.loop.is_running():
+            tasks = asyncio.Task.all_tasks(loop=cls.loop)
+            cls.loop.call_soon_threadsafe(cls.loop.create_task, cls._clean_tasks(tasks))
+            cls.thread.join()
+            cls.loop.stop()
+
+    @classmethod
+    def close(cls):
+        """Convenience caller to look similar to loop closes"""
+        cls.stop_loop_clean()
+
+    @classmethod
+    async def _clean_tasks(cls, tasks):
+        """Task to clear all other tasks (because the stop_loop_clean
+        task errors when it closes itself with this logic)
+        """
+        remainder = []
+        for task in tasks:
+            cls._logger.info("Cancelling task %s" % task)
+            task.cancel()
+            remainder.append(task)
+        await asyncio.gather(*remainder, return_exceptions=True)
+        cls.loop.stop()
+
+    @classmethod
+    def _loop_thread_main(cls):
+        """This is the background thread that actually owns the single asyncio event loop that your
+        application should be running.
+        """
+        try:
+            cls.loop.run_forever()
+        except:
+            cls._logger.exception("Exception raised from event loop thread")
+        finally:
+            cls._logger.debug("stopping loop clean")
+            cls.stop_loop_clean()
+
+    @classmethod
+    def add_future(cls, fut):
+        """Main method by which modules can add futures to the event loop"""
+        fut = asyncio.ensure_future(fut, loop=cls.loop)
+        cls._logger.debug("future added")
+        return fut
+
+    @classmethod
+    def add_task(cls, cor):
+        """Method by which modules can add tasks to the event loop"""
+        tsk = cls.loop.call_soon_threadsafe(cls.loop.create_task, cor)
+        cls._logger.debug("task added")
+        return tsk

--- a/iotilecore/iotile/core/utilities/validating_wsclient.py
+++ b/iotilecore/iotile/core/utilities/validating_wsclient.py
@@ -2,13 +2,17 @@
 
 from ws4py.client.threadedclient import WebSocketClient
 import threading
+import asyncio
+import websockets
 import msgpack
 import datetime
 import logging
 import uuid
+
 from iotile.core.exceptions import IOTileException, InternalError, ValidationError, TimeoutExpiredError
 from iotile.core.utilities.schema_verify import Verifier, DictionaryVerifier, \
     StringVerifier, LiteralVerifier, OptionsVerifier
+from iotile.core.utilities.event_loop import EventLoop
 
 # The prescribed schema of command response messages
 # Messages with this format are automatically processed inside the ValidatingWSClient
@@ -23,6 +27,178 @@ FailureResponseSchema.add_required('success', LiteralVerifier(False))
 FailureResponseSchema.add_required('reason', StringVerifier())
 
 ResponseSchema = OptionsVerifier(SuccessfulResponseSchema, FailureResponseSchema)
+
+
+class AsyncValidatingWSClient:
+    """An asynchronous websocket client that validates messages received.
+
+    Messages are assumed to be packed using msgpack in a binary format
+    and are decoded and validated against message type schema.  Matching
+    messages are dispatched to the appropriate handler and messages that
+    match no attached schema are logged and dropped.
+    """
+
+    def __init__(self, url, logger_name=__name__):
+        """Constructor.
+
+        Args:
+        url (string): The URL of the websocket server that we want
+            to connect to.
+        logger_name (string): An optional name that errors are logged to
+        """
+        self.con = None
+        self.url = url
+        self.loop = EventLoop.get_loop()
+        self._logger = logging.getLogger(logger_name)
+        self.validators = [(ResponseSchema, self._on_response_received)]
+        self.command_lock = asyncio.Lock(loop=self.loop)
+        self.response_queue = asyncio.Queue(1, loop=self.loop)
+
+        asyncio.ensure_future(self.connection_object(), loop=self.loop)
+        asyncio.ensure_future(self.handle_message(), loop=self.loop)
+
+    async def connection_object(self):
+        """Async object that contains the websocket connection (and keeps it open for us)"""
+        self.con = await websockets.connect(self.url)
+
+    async def send_command(self, command, args, timeout=10.0):
+        """Send a command and synchronously wait for a single response.
+
+        Args:
+            command (string): The command name
+            args (dict): Optional arguments
+            timeout (float): The maximum time to wait for a response
+        """
+        while not self.con:
+            await asyncio.sleep(1)
+        msg = {x: y for x, y in args.items()}
+        msg['type'] = 'command'
+        msg['operation'] = command
+        msg['no_response'] = False
+        packed = msgpack.packb(msg, use_bin_type=True)
+        async with self.command_lock:
+            await self.con.send(packed)
+            try:
+                results = await asyncio.wait_for(self.response_queue.get(), timeout=timeout, loop=self.loop)
+            except asyncio.TimeoutError:
+                results = {'success': False, 'reason': 'timeout'}
+            return results
+
+    async def handle_message(self):
+        """Listener for when a message is received from the ws server.
+
+        (This replaces the message_received callback from the threaded version)
+
+        The message must be encoded using message_pack
+        """
+
+        while not self.con:
+            await asyncio.sleep(1)
+
+        try:
+            while True:
+                message = await self.con.recv()
+                try:
+                    unpacked = self._unpack(message)
+                except Exception as exc:
+                    self._logger.error("Corrupt message received, parse exception = %s", str(exc))
+                    continue
+                # We need to delegate the callback to a processor to keep our callback exceptions
+                # Without blocking the websocket message handler with an await
+                asyncio.ensure_future(self.process_message(unpacked), loop=self.loop)
+        finally:
+            await self.con.close()
+
+    async def process_message(self, unpacked):
+        """Process a message asynchronously from the websocket message handler"""
+
+        handler_found = False
+        # We have to break instead of return to keep the coroutine alive
+        for validator, callback in self.validators:
+            # Look for the first callback that can handle this message
+            # if no one can handle it, log an error and discard the message.
+            try:
+                validator.verify(unpacked)
+            except ValidationError:
+                continue
+            try:
+                await callback(unpacked)
+                handler_found = True
+            except IOTileException as exc:
+                self._logger.error("Exception handling websocket message, exception = %s", str(exc))
+                break
+            except Exception as exc:
+                self._logger.error("Non-IOTile exception handling websocket message, exception = %s", str(exc))
+                break
+        if not handler_found:
+            self._logger.warning("No handler found for received message, message=%s", str(unpacked))
+
+    def add_message_type(self, validator, callback):
+        """Add a message type that should trigger a callback.
+
+        Each validator must be unique, in that a message will
+        be dispatched to the first callback whose validator
+        matches the message.
+
+        Args:
+            validator (Verifier): A schema verifier that will
+                validate a received message uniquely
+            callback (callable): The function that should be called
+                when a message that matches validator is received.
+        """
+
+        self.validators.append((validator, callback))
+
+    async def send_ping(self, timeout=10.0):
+        """Send a ping message to keep connection alive and to verify
+        if the server is still there
+        """
+
+        await self.con.ping(self.control_data, timeout=timeout)
+        await self.con.pong()
+
+    async def post_command(self, command, args):
+        """Post a command asynchronously and don't wait for a response.
+
+        Args:
+            command (string): The command name
+            args (dict): Optional arguments
+        """
+        while not self.con:
+            await asyncio.sleep(1)
+
+        msg = {x: y for x, y in args.items()}
+        msg['type'] = 'command'
+        msg['operation'] = command
+        msg['no_response'] = True
+        packed = msgpack.packb(msg, use_bin_type=True)
+        await self.con.send(packed)
+
+    def _unpack(self, msg):
+        """Unpack a binary msgpacked message."""
+
+        return msgpack.unpackb(msg, raw=False, object_hook=self.decode_datetime)
+
+    @classmethod
+    def decode_datetime(cls, obj):
+        """Decode a msgpack'ed datetime."""
+
+        if b'__datetime__' in obj:
+            obj = datetime.datetime.strptime(obj[b'as_str'].decode(), "%Y%m%dT%H:%M:%S.%f")
+        return obj
+
+    @classmethod
+    def encode_datetime(cls, obj):
+        """Encode a msgpck'ed datetime."""
+
+        if isinstance(obj, datetime.datetime):
+            obj = {'__datetime__': True, 'as_str': obj.strftime("%Y%m%dT%H:%M:%S.%f").encode()}
+        return obj
+
+    async def _on_response_received(self, resp):
+        """Put messages of "response" type on to the asyncio.Queue object"""
+
+        await self.response_queue.put(resp)
 
 
 class ValidatingWSClient(WebSocketClient):

--- a/iotilecore/version.py
+++ b/iotilecore/version.py
@@ -1,1 +1,1 @@
-version = "4.0.3"
+version = "4.0.4"

--- a/iotilegateway/RELEASE.md
+++ b/iotilegateway/RELEASE.md
@@ -2,6 +2,10 @@
 
 All major changes in each released version of IOTileGateway are listed here.
 
+## 2.1.0
+
+- Create an asyncio ServiceStatusClient
+
 ## 2.0.2
 
 - Remove past/future/monotonic, pylint cleanup

--- a/iotilegateway/iotilegateway/main.py
+++ b/iotilegateway/iotilegateway/main.py
@@ -35,7 +35,7 @@ def main():
             return 1
 
         try:
-            with open(config_file, "rb") as conf:
+            with open(config_file, "r") as conf:
                 args = json.load(conf)
         except IOError as exc:
             raise ArgumentError("Could not open required config file", path=config_file, error=str(exc))

--- a/iotilegateway/iotilegateway/supervisor/__init__.py
+++ b/iotilegateway/iotilegateway/supervisor/__init__.py
@@ -1,4 +1,4 @@
-from .status_client import ServiceStatusClient
+from .status_client import ServiceStatusClient, AsyncServiceStatusClient
 from .supervisor import IOTileSupervisor
 
-__all__ = ['ServiceStatusClient', 'IOTileSupervisor']
+__all__ = ['ServiceStatusClient', 'AsyncServiceStatusClient', 'IOTileSupervisor']

--- a/iotilegateway/iotilegateway/supervisor/service_tile.py
+++ b/iotilegateway/iotilegateway/supervisor/service_tile.py
@@ -65,6 +65,7 @@ class ServiceDelegateTile(VirtualTile):
         # run time of RPCs that could be long running.  The caller of the RPC
         # through the tile will know what an appropriate timeout is for the
         # RPC that they are trying to call.
+
         resp = self._client.send_rpc(self._service, rpc_id, payload, timeout=120.0)
         result = resp['result']
 

--- a/iotilegateway/iotilegateway/supervisor/status_client.py
+++ b/iotilegateway/iotilegateway/supervisor/status_client.py
@@ -4,11 +4,490 @@ from threading import Lock, Event
 from copy import copy
 import logging
 from time import monotonic
+import asyncio
+
 from iotile.core.hw.virtual import RPCInvalidArgumentsError, RPCInvalidReturnValueError
-from iotile.core.utilities.validating_wsclient import ValidatingWSClient
+from iotile.core.utilities.validating_wsclient import ValidatingWSClient, AsyncValidatingWSClient
+from iotile.core.utilities.event_loop import EventLoop
 from iotile.core.exceptions import ArgumentError
 from . import command_formats
 from . import states
+
+
+class AsyncServiceStatusClient(AsyncValidatingWSClient):
+    """A async websocket client that syncs the state of all known services.
+
+    On creation it connects to the supervisor service and gets the
+    current status of each known service.  Then it listens for
+    change notifications and updates it internal map of service states.
+
+    Each service is assigned a unique number based on the order in
+    which it was registered.
+
+    Other clients can dispatch RPCs to this service if it registers
+    as an RPC agent, and they are handled by forwarding them on to
+    callbacks on the passed dispatcher object which should be a subclass
+    of RPCQueue.
+
+    You can automatically register as a service agent by passing the
+    agent parameters.
+
+    Args:
+            url (string): The URL of the websocket server that we want
+                to connect to.
+            dispatcher (RPCDispatcher): Optional, the object that contains all of the
+                RPCs that we implement.
+            agent (string): Optional, automatically register as the RPC agent of
+                a given service by specifying its short_name
+            logger_name (string): An optional name that errors are logged to
+    """
+
+    def __init__(self, url, dispatcher=None, agent=None, logger_name=__name__):
+        super(AsyncServiceStatusClient, self).__init__(url)
+
+        loop = EventLoop.get_loop()
+
+        self._state_lock = asyncio.Lock(loop=loop)
+        self._rpc_lock = asyncio.Lock()
+        self._rpc_dispatcher = dispatcher
+        self._queued_rpcs = []
+
+        self._logger = logging.getLogger(logger_name)
+        self.services = {}
+        self._name_map = {}
+        self._on_change_callback = None
+
+        self.q = asyncio.Queue(loop=loop)
+
+        # Register callbacks for all of the status notifications
+
+        self.add_message_type(command_formats.ServiceStatusChanged, self._on_status_change)
+        self.add_message_type(command_formats.ServiceAdded, self._on_service_added)
+        self.add_message_type(command_formats.HeartbeatReceived, self._on_heartbeat)
+        self.add_message_type(command_formats.NewMessage, self._on_message)
+        self.add_message_type(command_formats.NewHeadline, self._on_headline)
+        self.add_message_type(command_formats.RPCCommand, self._on_rpc_command)
+        self.add_message_type(command_formats.RPCResponse, self._on_rpc_response)
+
+        asyncio.ensure_future(self.populate_name_map(), loop=loop)
+        if agent is not None:
+            asyncio.ensure_future(self.register_agent(agent), loop=loop)
+
+    async def populate_name_map(self):
+        """Populate the name map of services as reported by the supervisor"""
+        async with self._state_lock:
+            self.services = await self.sync_services()
+            for i, name in enumerate(self.services.keys()):
+                self._name_map[i] = name
+
+    def notify_changes(self, callback):
+        """Register to receive a callback when a service changes state.
+
+        Args:
+            callback (callable): A function to be called with signature
+                callback(short_name, id, state, is_new, new_headline)
+        """
+
+        self._on_change_callback = callback
+
+    async def local_service(self, name_or_id):
+        """Get the locally synced information for a service.
+
+        Args:
+            name_or_id (string or int): Either a short name for the service or
+                a numeric id.
+
+        Returns:
+            ServiceState: the current state of the service synced locally
+                at the time of the call.
+        """
+
+        async with self._state_lock:
+            if isinstance(name_or_id, int):
+                if name_or_id not in self._name_map:
+                    raise ArgumentError("Unknown ID used to look up service", id=name_or_id)
+                name = self._name_map[name_or_id]
+            else:
+                name = name_or_id
+            if name not in self.services:
+                raise ArgumentError("Unknown service name", name=name)
+            service = self.services[name]
+            return copy(service)
+
+    async def local_services(self):
+        """Get a list of id, name pairs for all of the known synced services.
+
+        Returns:
+            list (id, name): A list of tuples with id and service name sorted by id
+                from low to high
+        """
+
+
+        async with self._state_lock:
+            return sorted([(index, name) for index, name in self._name_map.items()], key=lambda element: element[0])
+
+    async def sync_services(self):
+        """Poll the current state of all services.
+
+        Returns:
+            dict: A dictionary mapping service name to service status
+        """
+
+        services = {}
+        servs = await self.list_services()
+        for i, serv in enumerate(servs):
+            info = await self.service_info(serv)
+            status = await self.service_status(serv)
+            messages = await self.get_messages(serv)
+            headline = await self.get_headline(serv)
+            services[serv] = states.ServiceState(info['short_name'], info['long_name'], info['preregistered'], i)
+            services[serv].state = status['numeric_status']
+
+            for message in messages:
+                services[serv].post_message(message.level, message.message, message.count, message.created)
+            if headline is not None:
+                services[serv].set_headline(headline.level, headline.message, headline.created)
+
+        return services
+
+    async def get_messages(self, name):
+        """Get stored messages for a service.
+
+        Args:
+            name (string): The name of the service to get messages from.
+
+        Returns:
+            list(ServiceMessage): A list of the messages stored for this service
+        """
+
+        resp = await self.send_command('query_messages', {'name': name}, timeout=5.0)
+        return [states.ServiceMessage.FromDictionary(x) for x in resp['payload']]
+
+    async def get_headline(self, name):
+        """Get stored messages for a service.
+
+        Args:
+            name (string): The name of the service to get messages from.
+
+        Returns:
+            ServiceMessage: the headline or None if no headline has been set
+        """
+
+        resp = await self.send_command('query_headline', {'name': name}, timeout=5.0)
+        if 'payload' not in resp:
+            return None
+
+        msg = resp['payload']
+        return states.ServiceMessage.FromDictionary(msg)
+
+    async def list_services(self):
+        """Get the current list of services from the server.
+
+        Returns:
+            list(string): A list of the short service names known
+                to the supervisor
+        """
+
+        resp = await self.send_command('list_services', {}, timeout=5.0)
+        return resp['payload']['services']
+
+    async def send_heartbeat(self, name):
+        """Send a heartbeat for a service.
+
+        Args:
+            name (string): The name of the service to send a heartbeat for
+        """
+
+        resp = await self.send_command('heartbeat', {'name': name}, timeout=5.0)
+        if resp['success'] is not True:
+            raise ArgumentError("Unknown service name", name=name)
+
+    async def service_info(self, name):
+        """Pull descriptive info of a service by name.
+
+        Information returned includes the service's user friendly
+        name and whether it was preregistered or added dynamically.
+
+        Returns:
+            dict: A dictionary of service information with the following keys
+                set:
+                long_name (string): The user friendly name of the service
+                preregistered (bool): Whether the service was explicitly
+                    called out as a preregistered service.
+        """
+        resp = await self.send_command('query_info', {'name': name}, timeout=5.0)
+        if resp['success'] is not True:
+            raise ArgumentError("Unknown service name", name=name)
+
+        return resp['payload']
+
+    async def update_state(self, name, state):
+        """Update the state for a service.
+
+        Args:
+            name (string): The name of the service
+            state (int): The new state of the service
+        """
+        resp = await self.send_command('update_state', {'name': name, 'new_status': state}, timeout=5.0)
+        if resp['success'] is not True:
+            raise ArgumentError("Error updating service state", reason=resp['reason'])
+
+    async def post_headline(self, name, level, message):
+        """Asynchronously update the sticky headline for a service.
+
+        Args:
+            name (string): The name of the service
+            level (int): A message level in states.*_LEVEL
+            message (string): The user facing error message that will be stored
+                for the service and can be queried later.
+        """
+
+        now = monotonic()
+        await self.post_command(
+            'set_headline',
+            {'name': name, 'level': level, 'message': message, 'created_time': now, 'now_time': now}
+        )
+
+    async def post_state(self, name, state):
+        """Asynchronously try to update the state for a service.
+
+        If the update fails, nothing is reported because we don't wait for a
+        response from the server.  This function will return immmediately and not block.
+
+        Args:
+            name (string): The name of the service
+            state (int): The new state of the service
+        """
+
+        await self.post_command('update_state', {'name': name, 'new_status': state})
+
+    async def post_error(self, name, message):
+        """Asynchronously post a user facing error message about a service.
+
+        Args:
+            name (string): The name of the service
+            message (string): The user facing error message that will be stored
+                for the service and can be queried later.
+        """
+
+        await self.post_command('post_message', {'name': name, 'level': states.ERROR_LEVEL, 'message': message})
+
+    async def post_warning(self, name, message):
+        """Asynchronously post a user facing warning message about a service.
+
+        Args:
+            name (string): The name of the service
+            message (string): The user facing warning message that will be stored
+                for the service and can be queried later.
+        """
+
+        await self.post_command('post_message', {'name': name, 'level': states.WARNING_LEVEL, 'message': message})
+
+    async def post_info(self, name, message):
+        """Asynchronously post a user facing info message about a service.
+
+        Args:
+            name (string): The name of the service
+            message (string): The user facing info message that will be stored
+                for the service and can be queried later.
+        """
+        await self.post_command('post_message', {'name': name, 'level': states.INFO_LEVEL, 'message': message})
+
+    async def service_status(self, name):
+        """Pull the current status of a service by name.
+
+        Returns:
+            dict: A dictionary of service status
+        """
+
+        resp = await self.send_command('query_status', {'name': name}, timeout=5.0)
+
+        if resp['success'] is not True:
+            raise ArgumentError("Unknown service name", name=name)
+
+        return resp['payload']
+
+    async def send_rpc(self, name, rpc_id, payload, timeout=1.0):
+        """Send an RPC to a service and synchronously wait for the response.
+
+        Args:
+            name (str): The short name of the service to send the RPC to
+            rpc_id (int): The id of the RPC we want to call
+            payload (bytes): Any binary arguments that we want to send
+            timeout (float): The number of seconds to wait for the RPC to finish
+                before timing out and returning
+
+        Returns:
+            dict: A response dictionary with 1 or 2 keys set
+                'result': one of 'success', 'service_not_found',
+                    or 'rpc_not_found', 'timeout'
+                'response': the binary response object if the RPC was successful
+        """
+
+        async with self._rpc_lock:
+            resp = await self.send_command(
+                'send_rpc',
+                {'name': name, 'rpc_id': rpc_id, 'payload': payload, 'timeout': timeout}
+            )
+
+            result = resp['payload']['result']
+
+            if result == 'service_not_found':
+                return {'result': 'service_not_found'}
+
+            try:
+                data = await asyncio.wait_for(self.q.get(), timeout=timeout, loop=self.loop)
+            except asyncio.TimeoutError:
+                return {'result': 'timeout'}
+
+            result = data[0]
+            if result != 'success':
+                return {'result': result}
+            return {'result': 'success', 'response': data[1]}
+
+    async def register_service(self, short_name, long_name, allow_duplicate=True):
+        """Register a new service with the service manager.
+
+        Args:
+            short_name (string): A unique short name for this service that functions
+                as an id
+            long_name (string): A user facing name for this service
+            allow_duplicate (boolean): Don't throw an error if this service is already
+                registered.  This is important if the service is preregistered for example.
+        Raises:
+            ArgumentError: if the short_name is already taken
+        """
+
+        async with self._state_lock:
+            resp = await self.send_command('register_service', {'name': short_name, 'long_name': long_name})
+
+            if resp['success'] is not True and not allow_duplicate:
+                raise ArgumentError("Service name already registered", short_name=short_name)
+
+    async def register_agent(self, short_name):
+        """Register to act as the RPC agent for this service.
+
+        After this call succeeds, all requests to send RPCs to this service will be routed
+        through this agent.
+
+        Args:
+            short_name (str): A unique short name for this service that functions
+                as an id
+        """
+
+        resp = await self.send_command('set_agent', {'name': short_name})
+        if resp['success'] is not True:
+            raise ArgumentError("Could not register as agent", short_name=short_name, reason=resp['reason'])
+
+    async def _on_status_change(self, update):
+        """Update a service that has its status updated."""
+
+        info = update['payload']
+        new_number = info['new_status']
+        name = update['name']
+
+        async with self._state_lock:
+            if name not in self.services:
+                return
+
+            is_changed = self.services[name].state != new_number
+
+            self.services[name].state = new_number
+
+        # Notify about this service state change if anyone is listening
+        if self._on_change_callback and is_changed:
+            await self._on_change_callback(name, self.services[name].id, new_number, False, False)
+
+    async def _on_service_added(self, update):
+        """Add a new service."""
+
+        info = update['payload']
+        name = info['short_name']
+
+        async with self._state_lock:
+            if name in self.services:
+                return
+
+            new_id = len(self.services)
+            serv = states.ServiceState(name, info['long_name'], info['preregistered'], new_id)
+            self.services[name] = serv
+            self._name_map[new_id] = name
+
+        # Notify about this new service if anyone is listening
+        if self._on_change_callback:
+            self._on_change_callback(name, new_id, serv.state, True, False)
+
+    async def _on_heartbeat(self, update):
+        """Receive a new heartbeat for a service."""
+
+        name = update['name']
+        async with self._state_lock:
+            if name not in self.services:
+                return
+            self.services[name].heartbeat()
+
+    async def _on_message(self, update):
+        """Receive a message from a service."""
+
+        name = update['name']
+        message_obj = update['payload']
+
+        async with self._state_lock:
+            if name not in self.services:
+                return
+            self.services[name].post_message(message_obj['level'], message_obj['message'])
+
+    async def _on_headline(self, update):
+        """Receive a headline from a service."""
+
+        name = update['name']
+        message_obj = update['payload']
+        new_headline = False
+
+        async with self._state_lock:
+            if name not in self.services:
+                return
+
+            self.services[name].set_headline(message_obj['level'], message_obj['message'])
+
+            if self.services[name].headline.count == 1:
+                new_headline = True
+        # Notify about this service state change if anyone is listening
+        # headline changes are only reported if they are not duplicates
+        if self._on_change_callback and new_headline:
+            self._on_change_callback(name, self.services[name].id, self.services[name].state, False, True)
+
+    async def _on_rpc_response(self, resp):
+        """Receive an RPC response for a command that we previously sent."""
+
+        payload = resp['payload']
+        data = [payload['result'], payload['payload']]
+        await self.q.put(data)
+
+    async def _on_rpc_command(self, cmd):
+        """Received an RPC command that we should execute."""
+
+        payload = cmd['payload']
+        rpc_id = payload['rpc_id']
+        tag = payload['response_uuid']
+        args = payload['payload']
+
+        if self._rpc_dispatcher is None or not self._rpc_dispatcher.has_rpc(rpc_id):
+            # Fixme: include proper things here
+            await self.post_command('rpc_response', {'response_uuid': tag, 'result': 'rpc_not_found', 'response': b''})
+            return
+
+        try:
+            response = self._rpc_dispatcher.call_rpc(rpc_id, args)
+            await self.post_command('rpc_response', {'response_uuid': tag, 'result': 'success', 'response': response})
+            return
+        except RPCInvalidArgumentsError:
+            await self.post_command('rpc_response', {'response_uuid': tag, 'result': 'invalid_arguments', 'response': b''})
+        except RPCInvalidReturnValueError:
+            await self.post_command('rpc_response', {'response_uuid': tag, 'result': 'invalid_response', 'response': b''})
+        except Exception as exc: #pylint:disable=bare-exception
+            self._logger.exception("Exception handling RPC 0x%X : %s", rpc_id, str(exc))
+            await self.post_command('rpc_response', {'response_uuid': tag, 'result': 'execution_exception', 'response': b''})
 
 
 class ServiceStatusClient(ValidatingWSClient):

--- a/iotilegateway/setup.py
+++ b/iotilegateway/setup.py
@@ -24,7 +24,8 @@ setup(
         "tornado>=4.5.0,<5.0.0",
         "iotile-core>=4.0.0",
         "msgpack>=0.6.1",
-        "ws4py>=0.5.1"
+        "ws4py>=0.5.1",
+        "websockets"
     ],
     python_requires=">=3.5,<4",
     entry_points={

--- a/iotilegateway/test/test_async_supervisor.py
+++ b/iotilegateway/test/test_async_supervisor.py
@@ -1,0 +1,235 @@
+"""Unit tests for async supervisor server and client."""
+
+import pytest
+import logging
+from iotilegateway.supervisor import IOTileSupervisor
+from iotilegateway.supervisor.status_client import AsyncServiceStatusClient
+import iotilegateway.supervisor.states as states
+import tornado.gen
+import tornado.testing
+from util_async import AsyncWebSocketsTestCase
+from iotile.core.exceptions import ArgumentError
+
+
+import asyncio
+
+from iotile.core.utilities.event_loop import EventLoop
+
+
+@pytest.fixture(scope="function")
+def supervisor():
+    """A running supervisor with two connected status clients."""
+
+    print("setting up supervisor")
+
+    info = {
+        'expected_services':
+        [
+            {
+                "short_name": "service1",
+                "long_name": "Service 1"
+            },
+
+            {
+                "short_name": "service2",
+                "long_name": "Service 2"
+            }
+        ],
+        'port': 'unused'  # Bind an unused port for testing, the value
+                          # will appear on visor.port after visor.loaded is set
+    }
+
+    visor = IOTileSupervisor(info)
+
+    visor.start()
+    signaled = visor.loaded.wait(2.0)
+    if not signaled:
+        raise ValueError("Could not start supervisor service")
+
+    port = visor.port
+    client1 = AsyncServiceStatusClient('ws://127.0.0.1:%d/services' % port)
+
+    yield visor, client1
+
+    #client1.stop()
+    visor.stop()
+
+
+def test_list_services(supervisor):
+    """Make sure we can pull a service list from the supervisor."""
+
+    print("test list services")
+    _visor, client = supervisor
+
+    servs = asyncio.run_coroutine_threadsafe(client.list_services(), loop=EventLoop.get_loop()).result()
+    print("THE SERVES are", servs)
+
+    assert len(servs) == 2
+    assert 'service1' in servs
+    assert 'service2' in servs
+
+
+def test_query_service(supervisor):
+    """Make sure we can query a service's status."""
+
+    _visor, client = supervisor
+
+    status = asyncio.run_coroutine_threadsafe(client.service_status('service2'), loop=EventLoop.get_loop()).result()
+
+    assert status['numeric_status'] == states.UNKNOWN
+
+    with pytest.raises(ArgumentError):
+        asyncio.run_coroutine_threadsafe(client.service_status('service3'), loop=EventLoop.get_loop()).result()
+
+
+def test_register_service(supervisor):
+    """Make sure we can register a new service."""
+
+    _visor, client = supervisor
+    asyncio.run_coroutine_threadsafe(client.register_service('service3', 'A nice service'),
+                                     loop=EventLoop.get_loop()).result()
+
+    servs = asyncio.run_coroutine_threadsafe(client.list_services(), loop=EventLoop.get_loop()).result()
+    assert len(servs) == 3
+    assert 'service3' in servs
+
+
+def test_service_syncing(supervisor):
+    """Make sure we get updates on service changes."""
+
+    _visor, client = supervisor
+    asyncio.run_coroutine_threadsafe(client.register_service('service3', 'A nice service'),
+                                     loop=EventLoop.get_loop()).result()
+
+    # Make sure the update got synced
+    asyncio.run_coroutine_threadsafe(client.service_info('service3'), loop=EventLoop.get_loop()).result()
+
+    assert len(client.services) == 3
+    assert 'service3' in client.services
+
+    serv = client.services['service3']
+    assert serv.long_name == 'A nice service'
+    assert serv.preregistered is False
+    assert serv.id == 2
+
+    # Update the state of a service and make sure it gets synced
+    asyncio.run_coroutine_threadsafe(client.update_state('service3', states.RUNNING),
+                                     loop=EventLoop.get_loop()).result()
+    asyncio.run_coroutine_threadsafe(client.service_info('service3'), loop=EventLoop.get_loop()).result()
+
+    assert client.services['service3'].state == states.RUNNING
+    assert client.services['service3'].string_state == states.KNOWN_STATES[states.RUNNING]
+
+
+def test_service_info(supervisor):
+    """Make sure we can register a new service."""
+
+    _visor, client = supervisor
+    status = asyncio.run_coroutine_threadsafe(client.service_info('service2'), loop=EventLoop.get_loop()).result()
+    assert status['long_name'] == 'Service 2'
+    assert status['preregistered'] is True
+
+    asyncio.run_coroutine_threadsafe(client.register_service('service3', 'A nice service'),
+                                     loop=EventLoop.get_loop()).result()
+    status = asyncio.run_coroutine_threadsafe(client.service_info('service3'), loop=EventLoop.get_loop()).result()
+    assert status['long_name'] == 'A nice service'
+    assert status['preregistered'] is False
+
+
+def test_service_heartbeat(supervisor):
+    """Make sure we get updates on service heartbeats."""
+
+    _visor, client = supervisor
+
+    status = asyncio.run_coroutine_threadsafe(client.service_info('service1'), loop=EventLoop.get_loop()).result()
+
+    # Need to wait until the services are populated for the dict to have updated keys
+    # Would be better to find an awaitable that actually monitors this dict key
+    asyncio.run_coroutine_threadsafe( asyncio.sleep(0.5), loop=EventLoop.get_loop()).result()
+
+    assert client.services['service1'].num_heartbeats == 0
+
+    asyncio.run_coroutine_threadsafe(client.send_heartbeat('service1'), loop=EventLoop.get_loop()).result()
+    asyncio.run_coroutine_threadsafe(client.service_info('service1'), loop=EventLoop.get_loop()).result()
+    assert client.services['service1'].num_heartbeats == 1
+
+    asyncio.run_coroutine_threadsafe(client.send_heartbeat('service1'), loop=EventLoop.get_loop()).result()
+    asyncio.run_coroutine_threadsafe(client.service_info('service1'), loop=EventLoop.get_loop()).result()
+    assert client.services['service1'].num_heartbeats == 2
+
+
+def test_query_messages(supervisor):
+    """Make sure we can set, sync and query messages from the supervisor."""
+
+    _visor, client = supervisor
+    msgs = asyncio.run_coroutine_threadsafe(client.get_messages('service1'), loop=EventLoop.get_loop()).result()
+    assert len(msgs) == 0
+
+    asyncio.run_coroutine_threadsafe(asyncio.sleep(0.5), loop=EventLoop.get_loop()).result()
+    asyncio.run_coroutine_threadsafe(client.post_error('service1', 'test 1'), loop=EventLoop.get_loop()).result()
+    asyncio.run_coroutine_threadsafe(client.post_error('service1', 'test 1'), loop=EventLoop.get_loop()).result()
+    asyncio.run_coroutine_threadsafe(client.post_error('service1', 'test 2'), loop=EventLoop.get_loop()).result()
+    asyncio.run_coroutine_threadsafe(client.post_error('service1', 'test 3'), loop=EventLoop.get_loop()).result()
+    asyncio.run_coroutine_threadsafe(client.post_error('service1', 'test 2'), loop=EventLoop.get_loop()).result()
+
+    asyncio.run_coroutine_threadsafe(asyncio.sleep(0.5), loop=EventLoop.get_loop()).result()
+    msgs = asyncio.run_coroutine_threadsafe(client.get_messages('service1'), loop=EventLoop.get_loop()).result()
+
+    for msg in msgs:
+        print(msg.count, ": ", msg.message)
+    assert len(msgs) == 4
+    assert msgs[0].count == 2
+    assert msgs[0].message == 'test 1'
+    assert msgs[1].count == 1
+    assert msgs[1].message == 'test 2'
+    assert msgs[2].count == 1
+    assert msgs[2].message == 'test 3'
+    assert msgs[3].count == 1
+    assert msgs[3].message == 'test 2'
+
+    # Now make sure the messages got properly synced locally as well
+    asyncio.run_coroutine_threadsafe(asyncio.sleep(0.5), loop=EventLoop.get_loop()).result()
+    local = asyncio.run_coroutine_threadsafe(client.local_service('service1'), loop=EventLoop.get_loop()).result()
+    msgs = local.messages
+
+    assert len(msgs) == 4
+    assert msgs[0].count == 2
+    assert msgs[0].message == 'test 1'
+    assert msgs[1].count == 1
+    assert msgs[1].message == 'test 2'
+    assert msgs[2].count == 1
+    assert msgs[2].message == 'test 3'
+    assert msgs[3].count == 1
+    assert msgs[3].message == 'test 2'
+
+
+def test_service_headline(supervisor):
+    """Make sure we can set, sync and query headlines."""
+
+    _visor, client = supervisor
+
+    msg = asyncio.run_coroutine_threadsafe(client.get_headline('service1'), loop=EventLoop.get_loop()).result()
+    assert msg is None
+
+    asyncio.run_coroutine_threadsafe(client.post_headline('service1', states.ERROR_LEVEL, 'test message'),
+                                     loop=EventLoop.get_loop()).result()
+    msg = asyncio.run_coroutine_threadsafe(client.get_headline('service1'), loop=EventLoop.get_loop()).result()
+
+    assert msg.level == states.ERROR_LEVEL
+    assert msg.message == 'test message'
+    assert msg.count == 1
+
+    local = asyncio.run_coroutine_threadsafe(client.local_service('service1'), loop=EventLoop.get_loop()).result()
+    assert local.headline is not None
+    assert local.headline.message == 'test message'
+
+    # Make sure we can change the headline
+    asyncio.run_coroutine_threadsafe(client.post_headline('service1', states.INFO_LEVEL, 'info message'),
+                                     loop=EventLoop.get_loop()).result()
+    msg = asyncio.run_coroutine_threadsafe(client.get_headline('service1'), loop=EventLoop.get_loop()).result()
+    assert msg.level == states.INFO_LEVEL
+    assert msg.message == 'info message'
+
+    local = asyncio.run_coroutine_threadsafe(client.local_service('service1'), loop=EventLoop.get_loop()).result()
+    assert local.headline is not None
+    assert local.headline.message == 'info message'

--- a/iotilegateway/test/test_async_supervisor_commands.py
+++ b/iotilegateway/test/test_async_supervisor_commands.py
@@ -1,0 +1,279 @@
+"""Tests to make sure IOTileSupervisor and RPC dispatching work with an asyncio ServiceStatusClient."""
+
+import struct
+import json
+import pytest
+from iotile.core.dev import ComponentRegistry
+from iotile.core.hw.virtual import RPCDispatcher, tile_rpc
+from iotile.core.hw.hwmanager import HardwareManager
+from iotile.core.hw.proxy.proxy import TileBusProxyObject
+from iotilegateway.supervisor import IOTileSupervisor, AsyncServiceStatusClient
+
+import asyncio
+
+from iotile.core.utilities.event_loop import EventLoop
+
+
+class BasicRPCDispatcher(RPCDispatcher):
+    @tile_rpc(0x8000, "LL", "L")
+    def add(self, arg1, arg2):
+        return [arg1 + arg2]
+
+    @tile_rpc(0x8001, "", "")
+    def throw_exception(self):
+        raise ValueError("Random error")
+
+    @tile_rpc(0x8002, "", "L")
+    def invalid_return(self):
+        return [1, 2]
+
+
+class BasicRPCDispatcherProxy(TileBusProxyObject):
+    """A very basic proxy object for interacting with out BasicRPCDispatcher."""
+
+    @classmethod
+    def ModuleName(cls):
+        return 'bsctst'
+
+    def add(self, arg1, arg2):
+        """Invoke the add function on the BasicRPCDispatcher."""
+
+        res, = self.rpc(0x80, 0x00, arg1, arg2, arg_format="LL", result_format="L")
+        return res
+
+
+@pytest.fixture(scope="function")
+def supervisor():
+    """A running supervisor with two connected status clients."""
+
+    info = {
+        'expected_services':
+        [
+            {
+                "short_name": "service_1",
+                "long_name": "A test service"
+            },
+
+            {
+                "short_name": "service_2",
+                "long_name": "A second test service"
+            }
+        ],
+        'port': 'unused'  # Bind an unused port for testing,
+                          # the value will appear on visor.port after visor.loaded is set
+    }
+
+    visor = IOTileSupervisor(info)
+
+    visor.start()
+    signaled = visor.loaded.wait(2.0)
+    if not signaled:
+        raise ValueError("Could not start supervisor service")
+
+    port = visor.port
+
+    client1 = AsyncServiceStatusClient('ws://127.0.0.1:%d/services' % port)
+    client2 = AsyncServiceStatusClient('ws://127.0.0.1:%d/services' % port)
+
+    yield visor, client1, client2
+
+    #client1.stop()
+    #client2.stop()
+    visor.stop()
+
+
+@pytest.fixture(scope="function")
+def rpc_agent(supervisor):
+    """Register an RPC agent on one of the clients."""
+
+    visor, _client1, client2 = supervisor
+
+    port = visor.port
+    client1 = AsyncServiceStatusClient('ws://127.0.0.1:%d/services' % port, dispatcher=BasicRPCDispatcher(),
+                                       agent='service_1')
+
+    yield visor, client1, client2
+
+    #client1.stop()
+
+
+@pytest.fixture(scope="function")
+def linked_tile(rpc_agent, tmpdir):
+    """Create a connected HardwareManager instance with a proxy pointed at an RPCDispatcher."""
+
+    visor, _client1, _client2 = rpc_agent
+
+    # Create a config file that we can use to initialize a virtual device that will point at our
+    # BasicRPCDispatch via a running IOTileSupervisor.  Currently, HardwareManager can only
+    # load configurations for virtual devices from actual files, so we need to save this to a
+    # temp file.
+    config = {
+        "device": {
+            "iotile_id": 1,
+            "tiles": [
+                {
+                    "name": "service_delegate",
+                    "address": 11,
+                    "args": {
+                        "url": "ws://127.0.0.1:%d/services" % visor.port, # This has to match the port of the supervisor instance that we want to connect to
+                        "service": "service_1",      # This has to match the service name that the RPCDispatcher is registered as an agent for
+                        "name": "bsctst"             # This is the 6 character string that must match the ModuleName() of the proxy and is used to find the right proxy
+                    }
+                }
+            ]
+        }
+    }
+
+    # This is a special py.path.local object from pytest
+    # https://docs.pytest.org/en/latest/tmpdir.html
+    config_path_obj = tmpdir.join('config.json')
+    config_path_obj.write(json.dumps(config))
+
+    config_path = str(config_path_obj)
+
+    reg = ComponentRegistry()
+    reg.register_extension('iotile.proxy', 'test_proxy', BasicRPCDispatcherProxy)
+
+    # This will create a HardwareManager pointed at a virtual tile based device
+    # where the tiles that are added to the virtual device are found using the config
+    # file specified after the @ symbol.
+    hw = HardwareManager(port="virtual:tile_based@%s" % config_path)  # pylint:disable=invalid-name; We use hw throughout CoreTools to denote a HardwareManager instance
+
+    # We specified that the virtual device should be at uuid 1 (using iotile_id above)
+    # so we know how to connect to it.  We also know that we specified a single tile
+    # at address 11 inside that virtual device so we will be able to get its proxy
+    # object by calling hw.get(11) once we are connected.
+    hw.connect(1)
+    yield hw
+
+    hw.disconnect()
+    reg.clear_extensions('iotile.proxy')
+
+
+def test_service_delegate_tile(linked_tile):
+    """Make sure our service delegate tile works correctly."""
+
+    hw = linked_tile  # pylint:disable=invalid-name; We use hw throughout CoreTools to denote a HardwareManager instance
+
+    # Normally this is not required but since we are conecting to a
+    # virtual tile that doesn't have a known proxy ('bsctst'), we need
+    # to temporarily register the proxy that we would like to use othweise
+    # we will get a:
+    #  HardwareError: HardwareError: Could not find proxy object for tile
+    #    Additional Information:
+    #     - known_names: ['Simple', 'NO APP']
+    #     - name: 'bsctst'
+
+    # When we call get(address) the HardwareManager will ask the tile at that address,
+    # in this case the ServiceDelegateTile what it's 6 character name is.  It will
+    # return, in this case 'bsctst' because that's what we put in the config.json
+    # file we created in the linked_tile fixture.  The HardwareManager will then
+    # look up in its dictionary of known proxies for one whose ModuleName() exactly
+    # matches and return that object.
+    asyncio.run_coroutine_threadsafe(asyncio.sleep(1.5), loop=EventLoop.get_loop()).result()
+
+    proxy = hw.get(11)
+
+    result = proxy.add(5, 1)
+    assert result == 5 + 1
+
+
+def test_send_rpc_unknown(supervisor):
+    """Make sure we can send an RPC at a basic level."""
+
+    _visor, client1, _client2 = supervisor
+
+    resp = asyncio.run_coroutine_threadsafe(client1.send_rpc('service_1', 0x8000, b""), loop=EventLoop.get_loop())
+    resp = resp.result()
+    assert resp['result'] == 'service_not_found'
+
+
+def test_register_agent(supervisor):
+    """Make sure we can register as an agent."""
+
+    visor, client1, _client2 = supervisor
+
+    assert len(visor.service_manager.agents) == 0
+    asyncio.run_coroutine_threadsafe(client1.register_agent('service_1'), loop=EventLoop.get_loop()).result()
+
+    assert len(visor.service_manager.agents) == 1
+    assert 'service_1' in visor.service_manager.agents
+
+
+def test_send_rpc_not_found(supervisor):
+    """Make sure we RPCs get forwarded and timeout when not answered."""
+
+    _visor, client1, client2 = supervisor
+
+    asyncio.run_coroutine_threadsafe(client1.register_agent('service_1'), loop=EventLoop.get_loop()).result()
+    resp = asyncio.run_coroutine_threadsafe(client2.send_rpc('service_1', 0x8000, b""), loop=EventLoop.get_loop())
+    resp = resp.result()
+    assert resp['result'] == 'rpc_not_found'
+
+
+def test_send_rpc_success(rpc_agent):
+    """Make sure we can send RPCs that are implemented."""
+
+    _visor, client1, client2 = rpc_agent
+
+    asyncio.run_coroutine_threadsafe(asyncio.sleep(1.5), loop=EventLoop.get_loop()).result()
+
+    resp = asyncio.run_coroutine_threadsafe(client2.send_rpc('service_1', 0x8000, b'\x00'*8), loop=EventLoop.get_loop())
+    resp = resp.result()
+    assert resp['result'] == 'success'
+    assert resp['response'] == b'\x00'*4
+
+
+def test_send_rpc_execution(rpc_agent):
+    """Make sure we can send RPCs that are implemented."""
+
+    _visor, client1, client2 = rpc_agent
+
+    args = struct.pack("<LL", 1, 2)
+
+    asyncio.run_coroutine_threadsafe(asyncio.sleep(1.5), loop=EventLoop.get_loop()).result()
+
+    resp = asyncio.run_coroutine_threadsafe(client2.send_rpc('service_1', 0x8000, args), loop=EventLoop.get_loop())
+    resp = resp.result()
+    assert resp['result'] == 'success'
+
+    arg_sum, = struct.unpack("<L", resp['response'])
+    assert arg_sum == 3
+
+
+def test_send_rpc_invalid_args(rpc_agent):
+    """Make sure an exception gets thrown when an RPC has invalid args."""
+
+    _visor, client1, client2 = rpc_agent
+
+    args = struct.pack("<LLL", 1, 2, 3)
+
+    asyncio.run_coroutine_threadsafe(asyncio.sleep(1.5), loop=EventLoop.get_loop()).result()
+
+    resp = asyncio.run_coroutine_threadsafe(client2.send_rpc('service_1', 0x8000, args), loop=EventLoop.get_loop())
+    resp = resp.result()
+    assert resp['result'] == 'invalid_arguments'
+
+
+def test_send_rpc_exception(rpc_agent):
+    """Make sure an exception gets thrown when an RPC has an error processing."""
+
+    _visor, client1, client2 = rpc_agent
+
+    asyncio.run_coroutine_threadsafe(asyncio.sleep(1.5), loop=EventLoop.get_loop()).result()
+
+    resp = asyncio.run_coroutine_threadsafe(client2.send_rpc('service_1', 0x8001, b''), loop=EventLoop.get_loop())
+    resp = resp.result()
+    assert resp['result'] == 'execution_exception'
+
+
+def test_send_rpc_invalid_response(rpc_agent):
+    """Make sure an exception gets thrown when an RPC returns a nonconforming response."""
+
+    _visor, client1, client2 = rpc_agent
+
+    asyncio.run_coroutine_threadsafe(asyncio.sleep(1.5), loop=EventLoop.get_loop()).result()
+
+    resp = asyncio.run_coroutine_threadsafe(client2.send_rpc('service_1', 0x8002, b''), loop=EventLoop.get_loop())
+    resp = resp.result()
+    assert resp['result'] == 'invalid_response'

--- a/iotilegateway/tox.ini
+++ b/iotilegateway/tox.ini
@@ -9,6 +9,5 @@ deps=
     ../iotilecore
     ../iotiletest
     tornado>=4.5.3,<5.0.0
-    futures
 commands=
 	py.test {posargs}

--- a/iotilegateway/version.py
+++ b/iotilegateway/version.py
@@ -1,1 +1,1 @@
-version = "2.0.2"
+version = "2.1.0"


### PR DESCRIPTION
Since there aren't users of this function outside of the gateway, this change is self contained and avoids prematurely infecting the larger code base with asyncio. However, there is still another dependence on the ServiceStatusClient, so the new functionality has been implemented with a separate Async* naming convention. The long term goal is to deprecate the non-async code paths. 

## Overview

This is a cleaner version of the other WIP PR that cuts out the dev work that explored how deep asyncio might go in the code.

## Major Changes

- An AsyncServiceStatusClient
- An AsyncValidatingWSClient
- An EventLoop utility that enables modules to unify coroutines in a singular event loop that exists in an EventLoopThread for a given program runtime.
- Modification to the virtual_tile to wrap a coroutine-enabled ServiceStatusClient's RPC method for a non-async virtual device.

### Additional Notes

- There are two new test modules that exercise this functionality in parallel to the old tests. Note that it leverages `concurrent.Futures` to schedule coroutines, but since the EventLoop doesn't guarantee ordering of submitted tasks, sometimes there are enforced sleeps to ensure that the async objects have had time to initialize fully. 

