### PR TITLE
Feat event loop

### DIFF
--- a/iotilecore/iotile/core/utilities/__init__.py
+++ b/iotilecore/iotile/core/utilities/__init__.py
@@ -2,5 +2,6 @@
 
 from .validating_dispatcher import ValidatingDispatcher
 from .workqueue_thread import WorkQueueThread
+from .event_loop import EventLoop, BackgroundEventLoop
 
-__all__ = ['ValidatingDispatcher', 'WorkQueueThread']
+__all__ = ['ValidatingDispatcher', 'WorkQueueThread', 'BackgroundEventLoop', 'EventLoop']

--- a/iotilecore/iotile/core/utilities/event_loop.py
+++ b/iotilecore/iotile/core/utilities/event_loop.py
@@ -159,7 +159,7 @@ class BackgroundTask:
 
         try:
             await asyncio.wait_for(finished, timeout=self._stop_timeout)
-        except asyncio.TimeoutError:
+        except asyncio.TimeoutError as err:
             # See discussion here: https://github.com/python/asyncio/issues/253#issuecomment-120138132
             # This prevents a nuisance log error message, finished is guaranteed
             # to be cancelled but not awaited when wait_for() has a timeout.
@@ -168,7 +168,9 @@ class BackgroundTask:
             except asyncio.CancelledError:
                 pass
 
-            raise
+            # See https://mail.python.org/pipermail/python-3000/2008-May/013740.html
+            # for why we need to explictly name the error here
+            raise err
         finally:
             self.stopped = True
 

--- a/iotilecore/iotile/core/utilities/event_loop.py
+++ b/iotilecore/iotile/core/utilities/event_loop.py
@@ -1,105 +1,432 @@
-"""A class that lets you push tasks to a global event loop of the program, letting
-your objects create a reference to the asyncio event loop withotu having to
-pass a loop everywhere
+"""A global background asyncio event loop for CoreTools.
+
+This class is the base primitive used by all of CoreTools to interact with the
+asyncio framework.  There should be a single EventLoop per process using
+CoreTools in an asynchronous fashion.
+
+Various subsystems add tasks to this background event loop which runs until
+the process shuts down or until you explicitly stop it using EventLoop.stop().
+
+The primary mode of interaction with the event loop is by scheduling long
+running tasks using EventLoop.add_task().  You get a BackgroundTask object
+back that you can stop at any time from any thread using BackgroundTask.stop().
+
+If you have complex tasks that must be stopped in a specific order, you can
+register then as subtasks and their parent task is in charge of stopping
+them cleanly in the correct order.
 """
 
 import asyncio
+import inspect
 import logging
 import threading
+from iotile.core.exceptions import TimeoutExpiredError, ArgumentError, InternalError
 
+class BackgroundTask:
+    """A background coroutine task running in a BackgroundEventLoop.
 
-class EventLoop:
-    """EventLoop
+    This class is a wrapper around asyncio.Task that allows tasks to have
+    subtasks.  A subtask is just a regular task but the parent task is in
+    charge of stopping it when required.  This distinction allows you to
+    create hierarchies of tasks that can be cleanly stopped in a known
+    order when the EventLoop is stopped.
 
-    A container for the asyncio event loop in a background thread
+    Tasks can also be given names that will be logged for debugging purposes.
+
+    This class should never be created directly but will be returned
+    by BackgroundEventLoop.add_task()
+
+    Args:
+        cor (coroutine or asyncio.Task): An asyncio Task or the coroutine
+            that we should execute as a task.  If a coroutine is given
+            it is scheduled as a task in threadsafe manner automatically.
+        name (str): The name of the task for pretty printing and debug
+            purposes.  If not specified, it defaults to the underlying
+            asyncio task object instance name.
+        finalizer (callable): An optional callable that should be
+            invoked to cancel the task.  If specified it will be called
+            with a single argument, this BackgroundTask instance.
+
+            If not specified, calling stop() will result in cancel()
+            being called on the underlying task.
+
+            The finalizer (or task.cancel()) is always invokved inside
+            the event loop.  If finalizer is a coroutine it is awaited.
+        loop (BackgroundEventLoop): The background event loop this task
+            should run in.  If not specified, it defaults to the global
+            EventLoop instance.
+        stop_timeout (float): The maximum amount of time to wait for this
+            task to stop when stop() is called in seconds.  None indicates
+            an unlimited amount of time.  Default is 1 second.
     """
 
-    loop = None
-    thread = None
+    #pylint:disable=too-many-arguments;This class is not meant to be directly constructed by the user
+    def __init__(self, cor, name=None, finalizer=None, stop_timeout=1.0, loop=None):
+        self._name = name
+        self._finalizer = finalizer
+        self._stop_timeout = stop_timeout
+        self._logger = logging.getLogger(__name__)
+        self.stopped = False
 
-    _started = False
+        if loop is None:
+            loop = EventLoop
 
-    _logger = logging.getLogger(__name__)
+        if not isinstance(loop, BackgroundEventLoop):
+            raise ArgumentError("A BackgroundTask must be created with a BackgroundEventLoop, loop={}".format(loop))
 
-    @classmethod
-    def start(cls):
-        """Starts the loop instance if not already created and started"""
-        if not cls.loop:
-            cls._logger.debug("starting event loop")
-            cls.loop = asyncio.new_event_loop()
-            cls.thread = threading.Thread(target=cls._loop_thread_main, name="EventLoopThread", daemon=True)
-            cls.thread.start()
-            cls._started = True
+        self._loop = loop
 
-    @classmethod
-    def get_loop(cls):
-        """Loop getter for users of the event loop object"""
-        if not cls.loop:
-            cls.start()
+        self.subtasks = []
+        if inspect.iscoroutine(cor):
+            self.task = _create_task_threadsafe(cor, self._loop)
+        elif inspect.iscoroutinefunction(cor):
+            self.task = _create_task_threadsafe(cor(), self._loop)
+        elif isinstance(cor, asyncio.Task):
+            self.task = cor
+        else:
+            raise ArgumentError("Unknown object passed to Background task: {}".format(cor))
 
-        return cls.loop
+    @property
+    def name(self):
+        """A descriptive name for this task."""
 
-    @classmethod
-    def get_thread(cls):
-        """Utility function to get the loop's thread ID for lower-level control/access"""
-        return cls.thread
+        if self._name is not None:
+            return self._name
 
-    @classmethod
-    def stop_loop_abrupt(cls):
-        """Utility function to stop without trying to clean up"""
-        if cls.loop and cls.loop.is_running():
-            cls.loop.stop()
+        return str(self.task)
 
-    @classmethod
-    def stop_loop_clean(cls):
-        """Proper way to close the event loop that attempts to clean up all tasks"""
-        if cls.loop and cls.loop.is_running():
-            tasks = asyncio.Task.all_tasks(loop=cls.loop)
-            cls.loop.call_soon_threadsafe(cls.loop.create_task, cls._clean_tasks(tasks))
-            cls.thread.join()
-            cls.loop.stop()
+    def add_subtask(self, subtask):
+        """Link a subtask to this parent task.
 
-    @classmethod
-    def close(cls):
-        """Convenience caller to look similar to loop closes"""
-        cls.stop_loop_clean()
+        This will cause stop() to block until the subtask has also
+        finished.  Calling stop will not directly cancel the subtask.
+        It is expected that your finalizer for this parent task will
+        cancel or otherwise stop the subtask.
 
-    @classmethod
-    async def _clean_tasks(cls, tasks):
-        """Task to clear all other tasks (because the stop_loop_clean
-        task errors when it closes itself with this logic)
+        Args:
+            subtask (BackgroundTask): Another task that will be stopped
+                when this task is stopped.
         """
-        remainder = []
-        for task in tasks:
-            cls._logger.info("Cancelling task %s" % task)
-            task.cancel()
-            remainder.append(task)
-        await asyncio.gather(*remainder, return_exceptions=True)
-        cls.loop.stop()
 
-    @classmethod
-    def _loop_thread_main(cls):
-        """This is the background thread that actually owns the single asyncio event loop that your
-        application should be running.
+        if self.stopped:
+            raise InternalError("Cannot add a subtask to a parent that is already stopped")
+
+        if not isinstance(subtask, BackgroundTask):
+            raise ArgumentError("Subtasks must inherit from BackgroundTask, task={}".format(subtask))
+
+        #pylint:disable=protected-access;It is the same class as us so is equivalent to self access.
+        if subtask._loop != self._loop:
+            raise ArgumentError("Subtasks must run in the same BackgroundEventLoop as their parent",
+                                subtask=subtask, parent=self)
+
+        self.subtasks.append(subtask)
+
+    async def stop(self):
+        """Stop this task and wait until it and all its subtasks end.
+
+        This function will finalize this task either by using the finalizer
+        function passed during creation or by calling task.cancel() if no
+        finalizer was passed.
+
+        It will then call join() on this task and any registered subtasks
+        with the given maximum timeout, raising asyncio.TimeoutError if
+        the tasks did not exit within the given timeout.
+
+        This method should only be called once.
+
+        After this method returns, the task is finished and no more subtasks
+        can be added.
         """
+
+        if self.stopped:
+            return
+
+        self._logger.debug("Stopping task %s", self.name)
+
+        if self._finalizer is not None:
+            try:
+                result = self._finalizer(self)
+                if inspect.isawaitable(result):
+                    await result
+            except:  #pylint:disable=bare-except;We need to make sure we always wait for the task
+                self._logger.exception("Error running finalizer for task %s",
+                                       self.name)
+        else:
+            self.task.cancel()
+
+        tasks = [self.task] + [x.task for x in self.subtasks]
+        finished = asyncio.gather(*tasks, return_exceptions=True)
+
         try:
-            cls.loop.run_forever()
-        except:
-            cls._logger.exception("Exception raised from event loop thread")
+            await asyncio.wait_for(finished, timeout=self._stop_timeout)
+        except asyncio.TimeoutError:
+            # See discussion here: https://github.com/python/asyncio/issues/253#issuecomment-120138132
+            # This prevents a nuisance log error message, finished is guaranteed
+            # to be cancelled but not awaited when wait_for() has a timeout.
+            try:
+                await finished
+            except asyncio.CancelledError:
+                pass
+
+            raise
         finally:
-            cls._logger.debug("stopping loop clean")
-            cls.stop_loop_clean()
+            self.stopped = True
 
-    @classmethod
-    def add_future(cls, fut):
-        """Main method by which modules can add futures to the event loop"""
-        fut = asyncio.ensure_future(fut, loop=cls.loop)
-        cls._logger.debug("future added")
-        return fut
+    def stop_threadsafe(self):
+        """Stop this task from another thread and wait for it to finish.
 
-    @classmethod
-    def add_task(cls, cor):
-        """Method by which modules can add tasks to the event loop"""
-        tsk = cls.loop.call_soon_threadsafe(cls.loop.create_task, cor)
-        cls._logger.debug("task added")
-        return tsk
+        This method must not be called from within the BackgroundEventLoop but
+        will inject self.stop() into the event loop and block until it
+        returns.
+
+        Raises:
+            TimeoutExpiredError: If the task does not stop in the given
+                timeout specified in __init__()
+        """
+
+        if self.stopped:
+            return
+
+        try:
+            self._loop.run_coroutine(self.stop())
+        except asyncio.TimeoutError:
+            raise TimeoutExpiredError("Timeout stopping task {} with {} subtasks".format(self.name, len(self.subtasks)))
+
+
+class BackgroundEventLoop:
+    """A shared asyncio event loop running in a background thread.
+
+    This class represents a single background event loop.
+
+    The background thread is created the first time a request is made that
+    requires a loop to present so it is cheap to create a BackgroundEventLoop
+    and not use it in any way.
+
+    There is also a global instance of BackgroundEventLoop called EventLoop
+    that can be used when you just want to add tasks to a single shared loop.
+    Creating your own BackgroundEventLoop should not be generally done unless
+    you are unit testing.
+    """
+
+    def __init__(self):
+        self.loop = None
+        self.thread = None
+        self.tasks = set()
+
+        self._logger = logging.getLogger(__name__)
+        self._loop_check = threading.local()
+
+    def start(self):
+        """Ensure the background loop is running.
+
+        This method is safe to call multiple times.  If the loop is already
+        running, it will not do anything.
+        """
+
+        if not self.loop:
+            self._logger.debug("starting event loop")
+            self.loop = asyncio.new_event_loop()
+            self.thread = threading.Thread(target=self._loop_thread_main, name="EventLoopThread", daemon=True)
+            self.thread.start()
+
+    def stop(self):
+        """Synchronously stop the background loop from outside.
+
+        This method will block until the background loop is completely stopped
+        so it cannot be called from inside the loop itself.
+
+        This method is safe to call multiple times.  If the loop is not
+        currently running it will return without doing anything.
+        """
+
+        if not self.loop:
+            return
+
+        if self.inside_loop():
+            raise InternalError("EventLoop.stop() called from inside event loop; "
+                                "would have deadlocked.")
+
+        try:
+            self.run_coroutine(self._stop_internal())
+            self.thread.join()
+        except:
+            self._logger.exception("Error stopping EventLoop")
+            raise
+        finally:
+            self.thread = None
+            self.loop = None
+            self.tasks = set()
+
+    def get_loop(self):
+        """Get the current loop instance.
+
+        If there is no current loop, a new loop is created and started before
+        returning.
+
+        Returns:
+            asyncio.Loop: The loop.
+        """
+
+        if not self.loop:
+            self.start()
+
+        return self.loop
+
+    def inside_loop(self):
+        """Check if we are running inside the event loop.
+
+        This can be used to decide whether we need to use a threadsafe method
+        to interact with the loop or whether we can just interact with it
+        directly. It is used inside EventLoop to check for situations that
+        would deadlock and raise an Exception instead.
+
+        Returns:
+            bool: True if we are running inside the loop thread.
+        """
+
+        return self._loop_check.__dict__.get('inside_loop', False)
+
+    async def _stop_internal(self):
+        """Cleanly stop the event loop after shutting down all tasks."""
+
+        awaitables = [task.stop() for task in self.tasks]
+
+        results = await asyncio.gather(*awaitables, return_exceptions=True)
+        for task, result in zip(self.tasks, results):
+            if isinstance(result, Exception):
+                self._logger.error("Error stopping task %s: %s", task.name, repr(result))
+
+        # It is important to defer this call by one loop cycle so
+        # that this coroutine is finalized and anyone blocking on it
+        # resumes execution.
+        self.loop.call_soon(self.loop.stop)
+
+    def _loop_thread_main(self):
+        """Main background thread running the event loop."""
+
+        asyncio.set_event_loop(self.loop)
+        self._loop_check.inside_loop = True
+
+        try:
+            self._logger.debug("Starting loop in background thread")
+            self.loop.run_forever()
+            self._logger.debug("Finished loop in background thread")
+        except:  #pylint:disable=bare-except;This is a background worker thread.
+            self._logger.exception("Exception raised from event loop thread")
+        finally:
+            self.loop.close()
+
+    #pylint:disable=too-many-arguments;These all have sane defaults that should not be changed often.
+    def add_task(self, cor, name=None, finalizer=None, stop_timeout=1.0, parent=None):
+        """Schedule a task to run on the background event loop.
+
+        This method will start the given coroutine as a task and  keep track
+        of it so that it can be properly shutdown which the event loop is
+        stopped.
+
+        If parent is None, the task will be stopped by calling finalizer()
+        inside the event loop and then awaiting the task.  If finalizer is
+        None then task.cancel() will be called to stop the task.  If finalizer
+        is specified, it is called with a single argument (self, this
+        BackgroundTask).  Finalizer can be a simple function, or any
+        awaitable.  If it is an awaitable it will be awaited.
+
+        If parent is not None, it must be a BackgroundTask object previously
+        created by a call to EventLoop.add_task() and this task will be
+        registered as a subtask of that task.  It is that task's job then to
+        cancel this task or otherwise stop it when it is stopped.
+
+        This method is safe to call either from inside the event loop itself
+        or from any other thread without fear of deadlock or race.
+
+        Args:
+            cor (coroutine or asyncio.Task): An asyncio Task or the coroutine
+                that we should execute as a task.  If a coroutine is given
+                it is scheduled as a task in threadsafe manner automatically.
+            name (str): The name of the task for pretty printing and debug
+                purposes.  If not specified, it defaults to the underlying
+                asyncio task object instance name.
+            finalizer (callable): An optional callable that should be
+                invoked to cancel the task.  If not specified, calling stop()
+                will result in cancel() being called on the underlying task.
+
+
+            stop_timeout (float): The maximum amount of time to wait for this
+                task to stop when stop() is called in seconds.  None indicates
+                an unlimited amount of time.  Default is 1.
+
+                This is ignored if parent is not None.
+            parent (BackgroundTask): A previously created task that will take
+                responsibility for stopping this task when it is stopped.
+
+        Returns:
+            BackgroundTask: The BackgroundTask representing this task.
+        """
+
+        # Ensure the loop exists and is started
+        self.start()
+
+        if parent is not None and parent not in self.tasks:
+            raise ArgumentError("Designated parent task {} is not registered".format(parent))
+
+        task = BackgroundTask(cor, name, finalizer, stop_timeout, loop=self)
+        if parent is None:
+            self.tasks.add(task)
+            self._logger.debug("Added primary task %s", task.name)
+        else:
+            parent.add_subtask(task)
+            self._logger.debug("Added subtask %s to parent %s", task.name, parent.name)
+
+        return task
+
+    def run_coroutine(self, cor):
+        """Run a coroutine to completion and return its result.
+
+        This method may only be called outside of the event loop.
+        Attempting to call it from inside the event loop would deadlock
+        and will raise InternalError instead.
+
+        Args:
+            cor (coroutine): The coroutine that we wish to run in the
+                background and wait until it finishes.
+
+        Returns:
+            object: Whatever the coroutine cor returns.
+        """
+
+        # Ensure the loop exists and is started
+        self.start()
+
+        if self.inside_loop():
+            raise InternalError("EventLoop.run_coroutine called from inside event loop, "
+                                "would have deadlocked.")
+
+        future = asyncio.run_coroutine_threadsafe(cor, loop=self.loop)
+        return future.result()
+
+    def create_event(self):
+        """Attach an Event to the background loop.
+
+        Returns:
+            asyncio.Event
+        """
+
+        self.start()
+        return asyncio.Event(loop=self.loop)
+
+
+def _create_task_threadsafe(cor, loop):
+    asyncio_loop = loop.get_loop()
+
+    if loop.inside_loop():
+        return asyncio_loop.create_task(cor)
+
+    async def _task_creator():
+        return asyncio_loop.create_task(cor)
+
+    future = asyncio.run_coroutine_threadsafe(_task_creator(), loop=asyncio_loop)
+    return future.result()
+
+
+# Create a single global event loop that anyone can add tasks to.
+EventLoop = BackgroundEventLoop()  # pylint:disable=invalid-name;This is for backwards compatibility.

--- a/iotilecore/iotile/core/utilities/event_loop.py
+++ b/iotilecore/iotile/core/utilities/event_loop.py
@@ -414,6 +414,16 @@ class BackgroundEventLoop:
         self.start()
         return asyncio.Event(loop=self.loop)
 
+    def create_queue(self):
+        """Attach a Queue to the background loop.
+
+        Returns:
+            asyncio.Queue
+        """
+
+        self.start()
+        return asyncio.Queue(loop=self.loop)
+
 
 def _create_task_threadsafe(cor, loop):
     asyncio_loop = loop.get_loop()

--- a/iotilecore/test/test_utilities/test_eventloop.py
+++ b/iotilecore/test/test_utilities/test_eventloop.py
@@ -1,0 +1,134 @@
+"""Tests for the shared background EventLoop."""
+
+import asyncio
+import pytest
+from iotile.core.utilities.event_loop import BackgroundEventLoop
+from iotile.core.exceptions import TimeoutExpiredError
+
+
+@pytest.fixture(scope="function")
+def clean_loop():
+    """Create and cleanly stop a background loop."""
+
+    loop = BackgroundEventLoop()
+    loop.start()
+
+    yield loop
+
+    loop.stop()
+
+
+def test_basic_functionality():
+    """Ensure that EventLoops works at a basic level."""
+
+
+    loop = BackgroundEventLoop()
+    loop.start()
+
+    try:
+        async def _loop_task():
+            return loop.inside_loop()
+
+        assert loop.run_coroutine(_loop_task()) is True
+
+        async def _failing_task():
+            raise ValueError("hello")
+
+        with pytest.raises(ValueError):
+            loop.run_coroutine(_failing_task())
+    finally:
+        loop.stop()
+
+
+def test_primary_task_cleanup():
+    """Make sure tasks are properly cleaned up."""
+
+    loop = BackgroundEventLoop()
+    loop.start()
+
+    try:
+        async def _cor():
+            await asyncio.sleep(15)
+
+        primary = loop.add_task(_cor, "test_task")
+        assert primary.name == 'test_task'
+    finally:
+        loop.stop()
+
+    assert primary.task.cancelled() is True
+    assert primary.task.done() is True
+
+
+def test_task_cleanup_failure(clean_loop):
+    """Make sure we don't deadlock if a task's cleanup routine doesn't work."""
+
+    async def _cor():
+        await asyncio.sleep(15)
+
+    primary = clean_loop.add_task(_cor(), "test_task", finalizer=lambda x: None, stop_timeout=0.01)
+    with pytest.raises(TimeoutExpiredError):
+        primary.stop_threadsafe()
+
+    # If there's a timeout, the task is cancelled
+    assert primary.stopped
+    assert primary.task.done()
+    assert primary.task.cancelled()
+
+
+def test_subtasks(clean_loop):
+    """Make sure we don't deadlock if a task's cleanup routine doesn't work."""
+
+    event = clean_loop.create_event()
+
+    async def _primary():
+        try:
+            await asyncio.sleep(15)
+        except asyncio.CancelledError:
+            event.set()
+
+    async def _sub():
+        await event.wait()
+
+    primary = clean_loop.add_task(_primary(), "test_task")
+    subtask = clean_loop.add_task(_sub(), "sub_task", parent=primary)
+
+    assert len(primary.subtasks) == 1
+
+    primary.stop_threadsafe()
+
+    assert primary.stopped
+    assert primary.task.done()
+    assert not primary.task.cancelled()
+
+    assert subtask.task.done()
+    assert not subtask.task.cancelled()
+
+
+def test_subtasks_nocleanup(clean_loop):
+    """Make sure we cancel subtasks if the parent doesn't clean them up."""
+
+    event = clean_loop.create_event()
+
+    async def _primary():
+        try:
+            await asyncio.sleep(15)
+        except asyncio.CancelledError:
+            pass
+
+    async def _sub():
+        await event.wait()
+
+    primary = clean_loop.add_task(_primary(), "test_task", stop_timeout=0.01)
+    subtask = clean_loop.add_task(_sub(), "sub_task", parent=primary)
+
+    assert len(primary.subtasks) == 1
+
+    with pytest.raises(TimeoutExpiredError):
+        primary.stop_threadsafe()
+
+    assert primary.stopped
+    assert primary.task.done()
+    assert not primary.task.cancelled()
+
+    assert subtask.task.done()
+    assert subtask.task.cancelled()


### PR DESCRIPTION
## Overview

This PR refactors EventLoop to add support for stopping background tasks in an orderly fashion and adds basic test coverage of the task creation and shutdown process.  For increased testability, `EventLoop` is moved from class methods onto to a normal class (`BackgroundEventLoop`) and a single global instance is created named `EventLoop` for backwards compatibility.

We should probably rename `EventLoop` to something like `SharedLoop` or `GlobalLoop` to better distinguish it from the `BackgroundEventLoop` class.

## Notes

- This PR is to merge into the long-running branch `extended-asyncio-upgrade` that can accumulate asyncio-related changes until we are at a point where we want to merge into `master` and declare that we're going to start maintaining backwards compatibility and release the new functionality.