### PR TITLE
Add generic device server implementation and refactor progress notifications

### DIFF
--- a/iotilecore/iotile/core/hw/exceptions.py
+++ b/iotilecore/iotile/core/hw/exceptions.py
@@ -12,13 +12,61 @@ import iotile.core.exceptions
 
 
 class DeviceAdapterError(iotile.core.exceptions.HardwareError):
+    """A protocol or communication error occurred during an operation.
+
+    This exception indicates that a DeviceAdapter was not able to perform
+    the desired operation because of a communication-type error.
+
+    Args:
+        conn_id (int): The connection id that the error occurred on.  If the
+            error was not associated with a connection then this will be None.
+        operation (str): A descriptive name of the operation that was being
+            performed.
+        reason (str): A helpful string about what the issue was.
+    """
+
     def __init__(self, conn_id, operation, reason):
         super(DeviceAdapterError, self).__init__("Operation {} on conn {} failed because {}".
-                                                 format(conn_id, operation, reason),
+                                                 format(operation, conn_id, reason),
                                                  reason=reason, operation=operation,
                                                  conn_id=conn_id)
 
         self.reason = reason
+
+
+class DeviceServerError(iotile.core.exceptions.HardwareError):
+    """The device server rejected your request because it was invalid.
+
+    This exception indicates that the request was never forwarded to the
+    underlying device adapter but rather reject by the DeviceServer
+    implementation itself because it was disallowed or invalid.
+
+    For example, if you are trying to access a device for which you
+    do not have an active connection.  Or disconnecting a device that
+    you did not connect.
+
+    The client_id, reason and connection_string are available as
+    properties on the exception instance to assist with converting
+    the error into a message to send back to the client.
+
+    Args:
+        client_id (str): The client id that requested the invalid
+            operation.
+        conn_str (str): The connection string for the device in question.
+        operation (str): A descriptive name of the operation that was
+            requested.
+        reason (str): A helpful string about what the issue was.
+    """
+
+    def __init__(self, client_id, conn_str, operation, reason):
+        super(DeviceServerError, self).__init__("Operation {} for client {} on device {} failed because {}".
+                                                format(operation, client_id, conn_str, reason),
+                                                reason=reason, operation=operation,
+                                                conn_string=conn_str, client_id=client_id)
+
+        self.reason = reason
+        self.client_id = client_id
+        self.connection_string = conn_str
 
 
 class RPCError(iotile.core.exceptions.HardwareError):

--- a/iotilecore/iotile/core/hw/transport/__init__.py
+++ b/iotilecore/iotile/core/hw/transport/__init__.py
@@ -7,5 +7,9 @@
 # are copyright Arch Systems Inc.
 
 from .cmdstream import CMDStream
+from .adapter import AbstractDeviceAdapter, StandardDeviceAdapter
+from .server import AbstractDeviceServer, StandardDeviceServer
+from .virtualadapter import VirtualDeviceAdapter
 
-__all__ = ['CMDStream']
+__all__ = ['CMDStream', 'AbstractDeviceAdapter', 'AbstractDeviceServer',
+           'StandardDeviceAdapter', 'StandardDeviceServer', 'VirtualDeviceAdapter']

--- a/iotilecore/iotile/core/hw/transport/adapter/abstract.py
+++ b/iotilecore/iotile/core/hw/transport/adapter/abstract.py
@@ -506,7 +506,7 @@ class AbstractDeviceAdapter(abc.ABC):
             RPCErrorCode: The RPC implementation wishes to fail with a
                 non-zero status code.
             RPCInvalidIDError: The rpc_id is too large to fit in 16-bits.
-            TileBusSerror: The tile was busy and could not respond to the RPC.
+            TileBusyError: The tile was busy and could not respond to the RPC.
             Exception: The rpc raised an exception during processing.
             DeviceAdapterError: If there is a hardware or communication issue
                 invoking the RPC.

--- a/iotilecore/iotile/core/hw/transport/adapter/abstract.py
+++ b/iotilecore/iotile/core/hw/transport/adapter/abstract.py
@@ -26,6 +26,89 @@ DeviceAdapter.
 Previous DeviceAdapter implementations used multithreading and callback based
 interfaces that worked but proved difficult to implement, raising the barrier
 to creating new DeviceAdapters to support additional communication protocols.
+
+
+Events
+======
+
+Communication with a device through an AbstractDeviceAdapter is bidrectional
+in that commands can flow from the user to the device and events can flow
+back from the devie to the user without being the direct result of a command.
+
+The way to receive events is to register an event monitor using
+:meth:`AbstractDeviceAdapter.register_monitor`.  There are different kinds of
+events that you can receive and your monitor includes filters based on the
+event name and the source device.
+
+Every event notification contains a tuple with three things: the connection
+string of the device that sent the event, the name of the event and an event
+object whose contents vary depending on the event name.  The supported events
+are:
+
+    report
+        A report has been received from the device.
+
+        The event object will be a subclass of
+        :class:`iotile.core.hw.reports.IOTileReport`.
+        This event is used to send reports from a device to the user via the
+        streaming interface.  It can only be received if the streaming
+        interface is open.
+
+    connection
+        Someone has connected to a device.
+
+        The event object for this event will be ``None`` since there is not
+        additional information available.
+
+    trace
+        Tracing data has been received from a device.
+
+        The event object will be a ``bytes`` object containing a blob of
+        tracing data.  Since tracing data may be fragmented as it travels from
+        the device to you, there is no guarantee that you will receive it in
+        the same atomic chunk sizes that the device sent.  In particular,
+        trace data may be temporarily buffered inside some device adapters for
+        performance reasons.
+
+    device_seen
+        A scan event has been received for a device.
+
+        The event object will be a dictionary with certain mandatory keys and
+        perhaps some additional keys whose meaning is determined by the device
+        adapter itself.
+
+    disconnection
+        Someone has disconnected from a device.
+
+        The event object will be a dictionary with at least a single key
+        ``reason`` set that will be a string that describes why the disconnect
+        occurred.  There will additionally be an ``expected`` key, which will
+        be a boolean and set to True if the disconnetion event is expected
+        because it was the result of a call to the
+        :meth:`AbstractDeviceAdapter.disconnect`` method.
+
+    broadcast
+        A broadcast report has been received from a device.
+
+        The event object will be a subclass of
+        :class:`iotile.core.hw.reports.BroadcastReport`
+
+    progress
+        A progress update has been received from a device.
+
+        Progress events help update the user on the sate of a long-running
+        task.  This may be received either from a debug operation or a sending
+        a script.
+
+        The event object will be a dict with three keys set:
+
+            operation
+                The string name of the operation in progress: either ``script`` or
+                ``debug``
+            finished
+                An integer specifying how many operation steps have finished.
+            total
+                An integer specifying how many total operation steps there are.
 """
 
 import abc
@@ -50,14 +133,15 @@ class AbstractDeviceAdapter(abc.ABC):
         """Return whether this device adapter can accept another connection.
 
         Depending on the underlying hardware and transport protocols in use, a
-        given DeviceAdapter may be able to maintain more than one simultaneous
-        connection to a device.  In simple cases, this method is not necessary
-        because a user can just try to connect to a device and have it fail if
-        the adapter cannot accomodate another connection.  However, in more
-        complicated scenarios where there are multiple DeviceAdapters that
-        could be used to connect to a device, it is useful to be able to
-        filter them and find the best adapter that has a free connection
-        slot available.
+        given DeviceAdapter may be able to maintain simultaneous connections
+        to more than one device at a time.  In simple cases, this method is
+        not necessary because a user can just try to connect to a device and
+        have it fail if the adapter cannot accomodate another connection.
+
+        However, in more complicated scenarios where there are multiple
+        DeviceAdapters that could be used to connect to a device, it is useful
+        to be able to filter them and find the best adapter that has a free
+        connection slot available.
 
         Returns:
             bool: Whether one additional connection is possible
@@ -126,6 +210,10 @@ class AbstractDeviceAdapter(abc.ABC):
                 Someone has disconnected from a device.
             broadcast
                 A broadcast report has been received from a device.
+            progress
+                A progress update has been received from a device
+                performing a long-running task.  This may be received
+                either from a debug operation or a sending a script.
 
         The ``devices`` are a set of connection_string objects containing
         which devices you want to install this filter on.  All events are tied
@@ -183,7 +271,7 @@ class AbstractDeviceAdapter(abc.ABC):
 
         If you remove a device or event that was not previously registered, no
         error is raised.  Similarly, if you add an event that was already
-        registerd, no error is raised.  The ``adjust_monitor`` method is
+        registered, no error is raised.  The ``adjust_monitor`` method is
         idempotent.
 
         Args:
@@ -206,7 +294,6 @@ class AbstractDeviceAdapter(abc.ABC):
         Args:
             handle (object): The handle to a previously registered monitor.
         """
-
 
     @abc.abstractmethod
     async def probe(self):
@@ -419,18 +506,19 @@ class AbstractDeviceAdapter(abc.ABC):
             RPCErrorCode: The RPC implementation wishes to fail with a
                 non-zero status code.
             RPCInvalidIDError: The rpc_id is too large to fit in 16-bits.
+            TileBusSerror: The tile was busy and could not respond to the RPC.
             Exception: The rpc raised an exception during processing.
             DeviceAdapterError: If there is a hardware or communication issue
                 invoking the RPC.
         """
 
     @abc.abstractmethod
-    async def debug(self, conn_id, name, cmd_args, progress_callback):
+    async def debug(self, conn_id, name, cmd_args):
         """Send a debug command to a device.
 
         The command name and arguments are passed to the underlying device
         adapter and interpreted there.  If the command is long running,
-        progress_callback may be used to provide status updates.
+        you may receive progress events (if you have a registered event monitor).
 
         Most DeviceAdapter classes do not support this command or the debug
         interface since it typically requires a special hardware connection to
@@ -441,14 +529,10 @@ class AbstractDeviceAdapter(abc.ABC):
             conn_id (int): A unique identifier that will refer to this connection
             name (str): The name of the debug command we want to invoke
             cmd_args (dict): Any arguments that we want to send with this command.
-            progress_callback (callable): A function to be called with status on our
-                progress, called as: ``progress_callback(done_count, total_count)``.
-                This may be a coroutine, in which case it will be awaited each time
-                it is called.
         """
 
     @abc.abstractmethod
-    async def send_script(self, conn_id, data, progress_callback):
+    async def send_script(self, conn_id, data):
         """Send a a script to a device.
 
         Scripts are like binary files transferred to a device.  They are
@@ -457,14 +541,11 @@ class AbstractDeviceAdapter(abc.ABC):
         The device must have previously been connected to and you must have
         opened the script interface.  This method will robustly transfer a binary
         script blob to the device via its script interface and may inform you
-        of its progress using ``progress_callback``.
+        of its progress using progress events.
 
         Args:
-            conn_id (int): A unique identifier that will refer to this connection
-            data (bytes): the script to send to the device
-            progress_callback (callable): A function to be called with status on our progress,
-                called as: progress_callback(done_count, total_count).  If this is
-                a coroutine, it will be awaited after each call.
+            conn_id (int): A unique identifier specifying the connection
+            data (bytes): The script to send to the device
         """
 
     @abc.abstractmethod

--- a/iotilecore/iotile/core/hw/transport/adapter/mixin_notifications.py
+++ b/iotilecore/iotile/core/hw/transport/adapter/mixin_notifications.py
@@ -199,16 +199,16 @@ class BasicNotificationMixin:
     def notify_event(self, conn_string, name, event):
         """Notify an event.
 
-        This will move the notification to the background event loop and
-        return immediately.  It is useful for situations where you cannot
-        await notify_event but keep in mind that it prevents back-pressure
-        when you are notifying too fast so should be used sparingly.
+        This method will launch a coroutine that runs all callbacks (and
+        awaits all coroutines) attached to the given event that was just
+        raised.  Internally it uses
+        :meth:`BackgroundEventLoop.launch_coroutine` which retains an
+        awaitable object when called from within an event loop and a
+        concurrent Future object when called outside of the event loop.
 
-        Note that calling this method will push the notification to a
-        background task so it can be difficult to reason about when it will
-        precisely occur.  For that reason, :meth:`notify_event` should be
-        preferred when possible since that method guarantees that all
-        callbacks will be called synchronously before it finishes.
+        Calling this method from outside of the BackgroundEventLoop is
+        considered experimental and not stable behavior that can be depended
+        on.
 
         Args:
             conn_string (str): The connection string for the device that the

--- a/iotilecore/iotile/core/hw/transport/adapter/standard.py
+++ b/iotilecore/iotile/core/hw/transport/adapter/standard.py
@@ -186,7 +186,7 @@ class StandardDeviceAdapter(PerConnectionDataMixin,
 
         raise DeviceAdapterError(conn_id, 'send rpc', 'not supported')
 
-    async def debug(self, conn_id, name, cmd_args, progress_callback):
+    async def debug(self, conn_id, name, cmd_args):
         """Send a debug command to a device.
 
         See :meth:`AbstractDeviceAdapter.debug`.
@@ -194,7 +194,7 @@ class StandardDeviceAdapter(PerConnectionDataMixin,
 
         raise DeviceAdapterError(conn_id, 'debug', 'not supported')
 
-    async def send_script(self, conn_id, data, progress_callback):
+    async def send_script(self, conn_id, data):
         """Send a a script to a device.
 
         See :meth:`AbstractDeviceAdapter.send_script`.

--- a/iotilecore/iotile/core/hw/transport/adapter/sync_wrapper.py
+++ b/iotilecore/iotile/core/hw/transport/adapter/sync_wrapper.py
@@ -10,46 +10,33 @@ from iotile.core.exceptions import ArgumentError
 from iotile.core.utilities import SharedLoop
 
 from .abstract import AbstractDeviceAdapter
+from .legacy import DeviceAdapter
 from ...exceptions import DeviceAdapterError
 from ...virtual import (RPCInvalidIDError, TileNotFoundError, RPCNotFoundError,
-                        RPCErrorCode, pack_rpc_response)
+                        RPCErrorCode, BusyRPCResponse, pack_rpc_response)
 
 _MISSING = object()
 
 
-class SynchronousLegacyWrapper:
+class SynchronousLegacyWrapper(DeviceAdapter):
     """Provide a legacy synchronous API on top of an AbstractDeviceAdapter."""
 
     MAX_ADAPTER_STARTUP_TIME = 10.0
 
     def __init__(self, adapter: AbstractDeviceAdapter, loop=SharedLoop):
+        super(SynchronousLegacyWrapper, self).__init__()
+
         if not isinstance(adapter, AbstractDeviceAdapter):
             raise ArgumentError("DeviceAdapterLegacyWrapper created from object "
                                 "not a subclass of AbstractDeviceAdapter", adapter=adapter)
 
         self._adapter = adapter
-        self._id = -1
         self._loop = loop
         self._logger = logging.getLogger(__name__)
 
         # Synchronously start the adapter and block until it is started
         future = self._loop.launch_coroutine(self._adapter.start())
         future.result(SynchronousLegacyWrapper.MAX_ADAPTER_STARTUP_TIME)
-
-    @property
-    def id(self):
-        """The unique id of this adapter."""
-
-        return self._id
-
-    def set_id(self, adapter_id):
-        """Set an ID that this adapter uses to identify itself when making callbacks.
-
-        Args:
-            adapter_id (int): The adapter id that will be included in all callbacks.
-        """
-
-        self._id = adapter_id
 
     def set_config(self, name, value):
         """Set a config value for this adapter by name
@@ -92,7 +79,7 @@ class SynchronousLegacyWrapper:
         if name == 'on_scan':
             events = ['device_seen']
             def callback(_conn_string, _conn_id, _name, event):
-                func(self._id, event, event.get('validity_period', 60))
+                func(self.id, event, event.get('validity_period', 60))
         elif name == 'on_report':
             events = ['report', 'broadcast']
             def callback(_conn_string, conn_id, _name, event):
@@ -104,7 +91,7 @@ class SynchronousLegacyWrapper:
         elif name == 'on_disconnect':
             events = ['disconnection']
             def callback(_conn_string, conn_id, _name, _event):
-                func(self._id, conn_id)
+                func(self.id, conn_id)
         else:
             raise ArgumentError("Unknown callback type {}".format(name))
 
@@ -124,43 +111,11 @@ class SynchronousLegacyWrapper:
         future = self._loop.launch_coroutine(self._adapter.stop())
         return self._format_future(future)
 
-    def connect_sync(self, conn_id, connection_string):
-        """Synchronously connect to a device
-
-        Args:
-            conn_id (int): A unique identifier that will refer to this connection
-            connection_string (string): A DeviceAdapter specific string that can be used to connect to
-                a device using this DeviceAdapter.
-
-        Returns:
-            dict: A dictionary with two elements
-                'success': a bool with the result of the connection attempt
-                'failure_reason': a string with the reason for the failure if we failed
-        """
-
-        future = self._loop.launch_coroutine(self._adapter.connect(conn_id, connection_string))
-        return self._format_future(future)
-
     def connect_async(self, conn_id, connection_string, callback):
         """Asynchronously connect to a device."""
 
         future = self._loop.launch_coroutine(self._adapter.connect(conn_id, connection_string))
         future.add_done_callback(lambda x: self._callback_future(conn_id, x, callback))
-
-    def disconnect_sync(self, conn_id):
-        """Synchronously disconnect from a connected device
-
-        Args:
-            conn_id (int): A unique identifier that will refer to this connection
-
-        Returns:
-            dict: A dictionary with two elements
-                'success': a bool with the result of the connection attempt
-                'failure_reason': a string with the reason for the failure if we failed
-        """
-
-        future = self._loop.launch_coroutine(self._adapter.disconnect(conn_id))
-        return self._format_future(future)
 
     def disconnect_async(self, conn_id, callback):
         """Asynchronously disconnect from a device."""
@@ -168,84 +123,17 @@ class SynchronousLegacyWrapper:
         future = self._loop.launch_coroutine(self._adapter.disconnect(conn_id))
         future.add_done_callback(lambda x: self._callback_future(conn_id, x, callback))
 
-    def open_interface_sync(self, conn_id, interface, connection_string=None):
-        """Asynchronously open an interface to this IOTile device
-
-        interface must be one of (rpc, script, streaming, tracing, debug)
-
-        Args:
-            interface (string): The interface to open
-            conn_id (int): A unique identifier that will refer to this connection
-            connection_string (string): An optional DeviceAdapter specific string that can
-                be used to connect to a device using this DeviceAdapter.
-        Returns:
-            dict: A dictionary with two elements
-                'success': a bool with the result of the connection attempt
-                'failure_reason': a string with the reason for the failure if we failed
-        """
-
-        future = self._loop.launch_coroutine(self._adapter.open_interface(conn_id, interface, connection_string))
-        return self._format_future(future)
-
     def open_interface_async(self, conn_id, interface, callback, connection_string=None):
         """Asynchronously connect to a device."""
 
         future = self._loop.launch_coroutine(self._adapter.open_interface(conn_id, interface))
         future.add_done_callback(lambda x: self._callback_future(conn_id, x, callback))
 
-    def probe_sync(self):
-        """Synchronously probe for devices on this adapter."""
-
-        future = self._loop.launch_coroutine(self._adapter.probe())
-
-        if future.exception():
-            try:
-                future.result()
-            except:
-                self._logger.exception("Error probing")
-
-        return self._format_future(future)
-
     def probe_async(self, callback):
         """Asynchronously connect to a device."""
 
         future = self._loop.launch_coroutine(self._adapter.probe())
         future.add_done_callback(lambda x: self._callback_future(None, x, callback))
-
-    def send_rpc_sync(self, conn_id, address, rpc_id, payload, timeout):
-        """Synchronously send an RPC to this IOTile device
-
-        Args:
-            conn_id (int): A unique identifier that will refer to this connection
-            address (int): the address of the tile that we wish to send the RPC to
-            rpc_id (int): the 16-bit id of the RPC we want to call
-            payload (bytearray): the payload of the command
-            timeout (float): the number of seconds to wait for the RPC to execute
-
-        Returns:
-            dict: A dictionary with four elements
-                'success': a bool indicating whether we received a response to our attempted RPC
-                'failure_reason': a string with the reason for the failure if success == False
-                'status': the one byte status code returned for the RPC if success == True else None
-                'payload': a bytearray with the payload returned by RPC if success == True else None
-        """
-
-        future = self._loop.launch_coroutine(self._adapter.send_rpc(conn_id, address, rpc_id, payload, timeout))
-
-        payload = None
-        exception = future.exception()
-        if exception is None:
-            payload = future.result()
-
-
-        rpc_status, rpc_response = pack_rpc_response(payload, exception)
-
-        return {
-            'success': True,
-            'failure_reason': None,
-            'status': rpc_status,
-            'payload': rpc_response
-        }
 
     def send_rpc_async(self, conn_id, address, rpc_id, payload, timeout, callback):
         """Asynchronously send an RPC to this IOTile device."""
@@ -255,15 +143,26 @@ class SynchronousLegacyWrapper:
         def format_response(future):
             payload = None
             exception = future.exception()
+            rpc_status = None
+            rpc_response = b''
+            failure = None
+            success = True
+
             if exception is None:
                 payload = future.result()
+                rpc_status, rpc_response = pack_rpc_response(payload, exception)
+            elif isinstance(exception, (RPCInvalidIDError, TileNotFoundError, RPCNotFoundError,
+                                        RPCErrorCode, BusyRPCResponse)):
+                rpc_status, rpc_response = pack_rpc_response(payload, exception)
+            else:
+                success = False
+                failure = str(exception)
 
-            rpc_status, rpc_response = pack_rpc_response(payload, exception)
-            callback(conn_id, self.id, True, None, rpc_status, rpc_response)
+            callback(conn_id, self.id, success, failure, rpc_status, rpc_response)
 
         future.add_done_callback(format_response)
 
-    def debug_sync(self, conn_id, cmd_name, cmd_args, progress_callback):
+    def debug_async(self, conn_id, cmd_name, cmd_args, progress_callback, callback):
         """Asynchronously complete a named debug command.
 
         The command name and arguments are passed to the underlying device adapter
@@ -277,41 +176,69 @@ class SynchronousLegacyWrapper:
             cmd_args (dict): any arguments that we want to send with this command.
             progress_callback (callable): A function to be called with status on our progress, called as:
                 progress_callback(done_count, total_count)
+            callback (callable): The callback that should be called when finished.
         """
 
-        future = self._loop.launch_coroutine(self._adapter.debug(conn_id, cmd_name, cmd_args, progress_callback))
-        if future.exception() is not None:
-            return self._format_exception(future.exception())
+        def monitor_callback(_conn_string, _conn_id, _event_name, event):
+            if event.get('operation') != 'debug':
+                return
 
-        return {
-            'success': True,
-            'failure_reason': None,
-            'return_value': future.result()
-        }
+            progress_callback(event.get('finished'), event.get('total'))
 
-    def send_script_sync(self, conn_id, data, progress_callback):
-        """Asynchronously send a a script to this IOTile device
+        async def _install_monitor():
+            try:
+                conn_string = self._adapter._get_property(conn_id, 'connection_string')
+                return self._adapter.register_monitor([conn_string], ['progress'], monitor_callback)
+            except:  #pylint:disable=bare-except;This is a legacy shim that must always ensure it doesn't raise.
+                self._logger.exception("Error installing debug progress monitor")
+                return None
 
-        Args:
-            conn_id (int): A unique identifier that will refer to this connection
-            data (string): the script to send to the device
-            progress_callback (callable): A function to be called with status on our progress, called as:
-                progress_callback(done_count, total_count)
+        monitor_id = self._loop.run_coroutine(_install_monitor())
+        if monitor_id is None:
+            callback(conn_id, self.id, False, 'could not install progress monitor', None)
+            return
 
-        Returns:
-            dict: a dict with the following two entries set
-                'success': a bool indicating whether we received a response to our attempted RPC
-                'failure_reason': a string with the reason for the failure if success == False
-        """
+        future = self._loop.launch_coroutine(self._adapter.debug(conn_id, cmd_name, cmd_args))
 
-        future = self._loop.launch_coroutine(self._adapter.send_script(conn_id, data, progress_callback))
-        return self._format_future(future)
+        def format_response(future):
+            ret_val = None
+            success = True
+            failure = None
+            if future.exception() is None:
+                ret_val = future.result()
+            else:
+                success = False
+                failure = str(future.exception())
+
+            self._adapter.remove_monitor(monitor_id)
+            callback(conn_id, self.id, success, ret_val, failure)
+
+        future.add_done_callback(format_response)
 
     def send_script_async(self, conn_id, data, progress_callback, callback):
         """Asynchronously send a script to the device."""
 
-        future = self._loop.launch_coroutine(self._adapter.send_script(conn_id, data, progress_callback))
-        future.add_done_callback(lambda x: self._callback_future(conn_id, x, callback))
+        def monitor_callback(_conn_string, _conn_id, _event_name, event):
+            if event.get('operation') != 'script':
+                return
+
+            progress_callback(event.get('finished'), event.get('total'))
+
+        async def _install_monitor():
+            try:
+                conn_string = self._adapter._get_property(conn_id, 'connection_string')
+                return self._adapter.register_monitor([conn_string], ['progress'], monitor_callback)
+            except:  #pylint:disable=bare-except;This is a legacy shim that must always ensure it doesn't raise.
+                self._logger.exception("Error installing script progress monitor")
+                return None
+
+        monitor_id = self._loop.run_coroutine(_install_monitor())
+        if monitor_id is None:
+            callback(conn_id, self.id, False, 'could not install progress monitor')
+            return
+
+        future = self._loop.launch_coroutine(self._adapter.send_script(conn_id, data))
+        future.add_done_callback(lambda x: self._callback_future(conn_id, x, callback, monitors=[monitor_id]))
 
     def _format_exception(self, exception):
         if isinstance(exception, DeviceAdapterError):
@@ -337,8 +264,12 @@ class SynchronousLegacyWrapper:
             'failure_reason': None
         }
 
-    def _callback_future(self, conn_id, future, callback):
+    def _callback_future(self, conn_id, future, callback, monitors=None):
         info = self._format_future(future)
+
+        if monitors is not None:
+            for monitor in monitors:
+                self._adapter.remove_monitor(monitor)
 
         if conn_id is not None:
             callback(conn_id, self.id, info.get('success'), info.get('failure_reason'))

--- a/iotilecore/iotile/core/hw/transport/server/__init__.py
+++ b/iotilecore/iotile/core/hw/transport/server/__init__.py
@@ -1,0 +1,4 @@
+from .abstract import AbstractDeviceServer
+from .standard import StandardDeviceServer
+
+__all__ = ['AbstractDeviceServer', 'StandardDeviceServer']

--- a/iotilecore/iotile/core/hw/transport/server/abstract.py
+++ b/iotilecore/iotile/core/hw/transport/server/abstract.py
@@ -1,0 +1,109 @@
+"""Abstract interface for a class that serves access to IOTile devices.
+
+This class can be thought of as a generic server that could be accessed
+by an :class:`AbstractDeviceAdapter`.  This base class does not specify
+anything about how the actual server works since that will vary widely.
+
+The goal of declaring this base class is to standardize how such servers
+are configured and started so that a generic "server container" such as
+``iotile-gateway`` is capable of running any number of servers regardless
+of their implementations.
+
+It is, by design, entirely unspecified how a given device server chooses
+to "make available" devices.  The only agreement needs to be between
+a device server and the corresponding device adapter.
+
+As a concrete example, consider the BLED112 DeviceAdapter.  This adapter acts
+as a BLE central device, finding iotile devices by scanning for bluetooth low
+energy (BLE) perihperal advertisements within range.  It sends rpcs by writing
+to the iotile device's GATT server on specific characteristics.
+
+A device server for BLED112 then would be a BLE peripheral that implements the
+same GATT server as a phyiscal IOTile device and dispatches RPCs to its
+internal adapter as they are received via writes to the agreed-upon
+characterstics.
+
+Given the highly normalized nature of IOTile interactions, they are easy to
+proxy between communications modalities and form bridges connecting, e.g.
+bluetooth and websockets or TCP and usb.
+"""
+
+import abc
+from iotile.core.utilities import SharedLoop
+
+class AbstractDeviceServer(abc.ABC):
+    """A generic class that serves access to an IOTile compliant device.
+
+    This class is the server side of a :class:`AbstractDeviceAdapter`.
+    It is expected that there could be an AbstractDeviceServer for
+    every AbstractDeviceAdapter implementation.
+
+    In an analogy to HTTP, the DeviceAdapter is the HTTP client like
+    Chrome or curl.  The DeviceServer is the HTTP server like nginx
+    or apache.
+
+    Note that there is very little specified here in terms of required
+    interface except that arguments must be passed as an argument dictionary
+    and the device server must take a single adapter argument that will
+    be an AbstractDeviceAdapter.  The device server should use that device
+    adapter to find, connect to and perform operations on devices.
+
+    .. important:
+
+        It is not the role of AbstractDeviceServer to ``start()`` or ``stop()``
+        its device adapter.  It should assume that the adapter is already
+        started by the time :meth:`start` is called and will be stopped
+        after :meth:`stop` is called.
+
+        This is important because there may well be multiple device servers
+        attached to the same underlying device adapter.
+
+    Args:
+        adapter (AbstractDeviceAdapter): The device adapter that this
+            device server should use to find and connect to devices.
+        args (dict): Any arguments to the device adapter must be passed
+            in as a dictionary so that they can be passed in a generic
+            fashion.
+        loop (BackgroundEventLoop): The event loop that the device server
+            should use for blocking coroutine operations.  If not specified,
+            this defaults to the global SharedLoop.
+    """
+
+    @abc.abstractmethod
+    def __init__(self, adapter, args=None, *, loop=SharedLoop):
+        """Required constructor signature."""
+
+    @abc.abstractmethod
+    async def start(self):
+        """Start serving access to devices.
+
+        This method must not return until the devices are accessible over the
+        implementations chosen server protocol.  It must be possible to
+        immediately attach an AbstractDevice adapter to this server and use it
+        without any race conditions.
+
+        For example, if the server is configured to use a TCP port to serve
+        devices, the TCP port must be bound and listening for connections when
+        this coroutine returns.
+        """
+
+    @abc.abstractmethod
+    async def stop(self):
+        """Stop serving access to devices.
+
+        Subclass **must not** return until the devices are no longer accessible
+        over the implementation's chosen server protocol.  There should be no
+        race condition where a client is still able to invoke a function on
+        this server after stop has returned.  This is important because server
+        container running this AbstractDeviceServer may no longer be in a
+        state to respond allow for client connections safely.
+
+        Subclasses **must** cleanly disconnect from any devices accessed via
+        ``adapter`` before stopping.  It is the job of the ``AbstractDeviceServer``
+        to release all of its internal resources.  It is not the job of ``adapter``
+        to somehow know that a particular DeviceServer has stopped and free the
+        resources associated with that server.
+
+        Subclasses **should** cleanly disconnect any clients when stopped if
+        possible, rather than just breaking all sockets, for example.
+        """

--- a/iotilecore/iotile/core/hw/transport/server/standard.py
+++ b/iotilecore/iotile/core/hw/transport/server/standard.py
@@ -1,0 +1,492 @@
+"""A reference implementation of AbstractDeviceServer designed to be subclassed.
+
+:class:`StandardDeviceServer` is a full-featured implementation of the
+:class:`AbstractDeviceServer` interface.  See the class docstring for
+more information but all that is required to build a concrete device
+server on top of StandardDeviceServer is to just handle receiving messages
+from clients and calling the appropriate method.  Allocating and freeing
+per-client resources is handled internally to make sure that nothing
+leaks if clients unexpectedly disconnect.
+
+In particular there is no need to manually keep track of client connections
+or manage notifications on behalf of a client.  That is all done internally
+inside of StandardDeviceServer.
+
+"""
+import logging
+import uuid
+import inspect
+from iotile.core.utilities import SharedLoop
+from iotile.core.exceptions import ArgumentError
+from ...exceptions import DeviceServerError
+from .abstract import AbstractDeviceServer
+
+
+class StandardDeviceServer(AbstractDeviceServer):
+    """A standard reference implementation of AbstractDeviceServer.
+
+    This class is designed to provide the basic set of features that
+    any normal AbstractDeviceServer needs.  In particular, it handles
+    the three critical aspects of being a device server:
+
+    - managing per-client data and cleaning up after a client is gone
+    - managing per-connection data and cleaning up any lingering connections
+      after a client is gone.
+    - keeping track of which events should be forwarded to which clients.
+
+    It does this by wrapping the underlying methods of the
+    AbstractDeviceAdapter that it is given with versions that contain hooks to
+    keep track of which client is connected to which device.
+
+    These hooks automatically configure monitors on the underlying adapters
+    and take care of removing those monitors when the client connection is
+    destroyed for any reason.  Similarly any existing device connections are
+    disconnected when a client goes away.
+
+    This standard device server is completely functional on its own with
+    no subclassing but developers will typically want to override the
+    :meth:`start` and :meth:`stop` routines to actually start and stop their
+    particular server (tcp, websockets, mqtt, etc).
+
+    The interface that StandardDeviceServer presents is identical to
+    AbstractDeviceAdapter but with the following modifications that make
+    it suitable for use in a multi-client server:
+
+    - All methods take a `client_id` parameter so that there is an explicit
+      association of all operations with a single client.
+
+    - All methods that previously took a `connection_id` now take a
+      `connection_id`.  This is because we cannot guarantee that multiple
+      clients would not choose the same connection_id and confuse the
+      device adapter.  StandardDeviceServer handles assigning unique connection
+      ids to all connections internally.  The connection ids are never exposed
+      externally to the clients.
+
+    .. important:
+
+        If you override stop() make sure to call the super() implementation to
+        ensure that client resources are properly released when the server
+        stops.
+
+    Args:
+        adapter (AbstractDeviceAdapter): The underlying device adapter to use
+            to find and connect to devices.
+        args (dict): Any arguments that you wish to pass to the device server.
+        loop (BackgroundEventLoop): The background loop that should be used
+            to manage tasks.
+    """
+
+    def __init__(self, adapter, args=None, *, loop=SharedLoop):
+        super(StandardDeviceServer, self).__init__(adapter, args, loop=loop)
+
+        self.adapter = adapter
+        self._clients = {}
+        self._loop = loop
+        self._next_conn_id = 0
+        self._logger = logging.getLogger(__name__)
+
+    #pylint:disable=unused-argument;This method is designed to be overridden
+    async def client_event_handler(self, client_id, event_tuple, user_data):
+        """Method called to actually send an event to a client.
+
+        Users of this class should override this method to actually forward
+        device events to their clients.  It is called with the client_id
+        passed to (or returned from) :meth:`setup_client` as well as the
+        user_data object that was included there.
+
+        The event tuple is a 3-tuple of:
+
+        - connection string
+        - event name
+        - event object
+
+        If you override this to be acoroutine, it will be awaited.  The
+        default implementation just logs the event.
+
+        Args:
+            client_id (str): The client_id that this event should be forwarded
+                to.
+            event_tuple (tuple): The connection_string, event_name and event_object
+                that should be forwarded.
+            user_data (object): Any user data that was passed to setup_client.
+        """
+
+        conn_string, event_name, _event = event_tuple
+        self._logger.debug("Ignoring event %s from device %s forwarded for client %s",
+                           event_name, conn_string, client_id)
+
+        return None
+
+    def setup_client(self, client_id=None, user_data=None, scan=True, broadcast=False):
+        """Setup a newly connected client.
+
+        ``client_id`` must be unique among all connected clients.  If it is
+        passed as None, a random client_id will be generated as a string and
+        returned.
+
+        This method reserves internal resources for tracking what devices this
+        client has connected to and installs a monitor into the adapter on
+        behalf of the client.
+
+        It should be called whenever a new client connects to the device server
+        before any other activities by that client are allowed.  By default,
+        all clients start receiving ``device_seen`` events but if you want
+        your client to also receive broadcast events, you can pass broadcast=True.
+
+        Args:
+            client_id (str): A unique identifier for this client that will be
+                used to refer to it in all future interactions.  If this is
+                None, then a random string will be generated for the client_id.
+            user_data (object): An arbitrary object that you would like to store
+                with this client and will be pased to your event handler when
+                events are forwarded to this client.
+            scan (bool): Whether to install a monitor to listen for device_found
+                events.
+            broadcast (bool): Whether to install a monitor to list for broadcast
+                events.
+
+        Returns:
+            str: The client_id.
+
+            If a client id was passed in, it will be the same as what was passed
+            in.  If no client id was passed in then it will be a random unique
+            string.
+        """
+
+        if client_id is None:
+            client_id = str(uuid.uuid4())
+
+        if client_id in self._clients:
+            raise  ArgumentError("Duplicate client_id: {}".format(client_id))
+
+        async def _client_callback(conn_string, _, event_name, event):
+            event_tuple = (conn_string, event_name, event)
+            await self._forward_client_event(client_id, event_tuple)
+
+        client_monitor = self.adapter.register_monitor([], [], _client_callback)
+
+        self._clients[client_id] = dict(user_data=user_data, connections={},
+                                        monitor=client_monitor)
+
+        self._adjust_global_events(client_id, scan, broadcast)
+        return client_id
+
+    async def start(self):
+        """Start the server.
+
+        See :meth:`AbstractDeviceServer.start`.
+        """
+
+    async def stop(self):
+        """Stop the server and teardown any remaining clients.
+
+        If your subclass overrides this method, make sure to call
+        super().stop() to ensure that all devices with open connections from
+        thie server are properly closed.
+
+        See :meth:`AbstractDeviceServer.stop`.
+        """
+
+        clients = list(self._clients)
+
+        for client in clients:
+            self._logger.info("Tearing down client %s at server stop()", client)
+            await self.teardown_client(client)
+
+    async def teardown_client(self, client_id):
+        """Release all resources held by a client.
+
+        This method must be called and awaited whenever a client is
+        disconnected.  It ensures that all of the client's resources are
+        properly released and any devices they have connected to are
+        disconnected cleanly.
+
+        Args:
+            client_id (str): The client that we should tear down.
+
+        Raises:
+            ArgumentError: The client_id is unknown.
+        """
+
+        client_info = self._client_info(client_id)
+
+        self.adapter.remove_monitor(client_info['monitor'])
+        conns = client_info['connections']
+
+        for conn_string, conn_id in conns.items():
+            try:
+                await self.adapter.disconnect(conn_id)
+            except:  #pylint:disable=bare-except; This is a finalization method that should not raise unexpectedly
+                self._logger.exception("Error disconnecting device during teardown_client: conn_string=%s", conn_string)
+
+        del self._clients[client_id]
+
+    async def probe(self, client_id):
+        """Probe for devices on behalf of a client.
+
+        See :meth:`AbstractDeviceAdapter.probe`.
+
+        Args:
+            client_id (str): The client we are probing for.
+
+        Raises:
+            DeviceServerError: There is an issue with your client_id.
+            DeviceAdapterError: The adapter had an issue probing.
+        """
+
+        self._client_info(client_id)
+
+        await self.adapter.probe()
+
+    async def connect(self, client_id, conn_string):
+        """Connect to a device on behalf of a client.
+
+        See :meth:`AbstractDeviceAdapter.connect`.
+
+        Args:
+            client_id (str): The client we are working for.
+            conn_string (str): A connection string that will be
+                passed to the underlying device adapter to connect.
+
+        Raises:
+            DeviceServerError: There is an issue with your client_id.
+            DeviceAdapterError: The adapter had an issue connecting.
+        """
+        conn_id = self._next_conn_id
+        self._next_conn_id += 1
+
+        self._client_info(client_id)
+
+        await self.adapter.connect(conn_id, conn_string)
+        self._hook_connect(conn_string, conn_id, client_id)
+
+    async def disconnect(self, client_id, conn_string):
+        """Disconnect from a device on behalf of a client.
+
+        See :meth:`AbstractDeviceAdapter.disconnect`.
+
+        Args:
+            client_id (str): The client we are working for.
+            conn_string (str): A connection string that will be
+                passed to the underlying device adapter to connect.
+
+        Raises:
+            DeviceServerError: There is an issue with your client_id such
+                as not being connected to the device.
+            DeviceAdapterError: The adapter had an issue disconnecting.
+        """
+
+        conn_id = self._client_connection(client_id, conn_string)
+
+        try:
+            await self.adapter.disconnect(conn_id)
+        finally:
+            self._hook_disconnect(conn_string, client_id)
+
+    async def open_interface(self, client_id, conn_string, interface):
+        """Open a device interface on behalf of a client.
+
+        See :meth:`AbstractDeviceAdapter.open_interface`.
+
+        Args:
+            client_id (str): The client we are working for.
+            conn_string (str): A connection string that will be
+                passed to the underlying device adapter.
+            interface (str): The name of the interface to open.
+
+        Raises:
+            DeviceServerError: There is an issue with your client_id such
+                as not being connected to the device.
+            DeviceAdapterError: The adapter had an issue opening the interface.
+        """
+
+        conn_id = self._client_connection(client_id, conn_string)
+
+        # Hook first so there is no race on getting the first event
+        self._hook_open_interface(conn_string, interface, client_id)
+        await self.adapter.open_interface(conn_id, interface)
+
+    async def close_interface(self, client_id, conn_string, interface):
+        """Close a device interface on behalf of a client.
+
+        See :meth:`AbstractDeviceAdapter.close_interface`.
+
+        Args:
+            client_id (str): The client we are working for.
+            conn_string (str): A connection string that will be
+                passed to the underlying device adapter.
+            interface (str): The name of the interface to close.
+
+        Raises:
+            DeviceServerError: There is an issue with your client_id such
+                as not being connected to the device.
+            DeviceAdapterError: The adapter had an issue closing the interface.
+        """
+
+        conn_id = self._client_connection(client_id, conn_string)
+
+        await self.adapter.close_interface(conn_id, interface)
+        self._hook_close_interface(conn_string, interface, client_id)
+
+    #pylint:disable=too-many-arguments;This is a legacy method signature.
+    async def send_rpc(self, client_id, conn_string, address, rpc_id, payload, timeout):
+        """Send an RPC on behalf of a client.
+
+        See :meth:`AbstractDeviceAdapter.send_rpc`.
+
+        Args:
+            client_id (str): The client we are working for.
+            conn_string (str): A connection string that will be
+                passed to the underlying device adapter to connect.
+            address (int): The RPC address.
+            rpc_id (int): The ID number of the RPC
+            payload (bytes): The RPC argument payload
+            timeout (float): The RPC's expected timeout to hand to the underlying
+                device adapter.
+
+        Returns:
+            bytes: The RPC response.
+
+        Raises:
+            DeviceServerError: There is an issue with your client_id such
+                as not being connected to the device.
+            TileNotFoundError: The destination tile address does not exist
+            RPCNotFoundError: The rpc_id does not exist on the given tile
+            RPCErrorCode: The RPC was invoked successfully and wishes to fail
+                with a non-zero status code.
+            RPCInvalidIDError: The rpc_id is too large to fit in 16-bits.
+            TileBusSerror: The tile was busy and could not respond to the RPC.
+            Exception: The rpc raised an exception during processing.
+            DeviceAdapterError: If there is a hardware or communication issue
+                invoking the RPC.
+        """
+
+        conn_id = self._client_connection(client_id, conn_string)
+        return await self.adapter.send_rpc(conn_id, address, rpc_id, payload, timeout)
+
+    async def send_script(self, client_id, conn_string, script):
+        """Send a script to a device on behalf of a client.
+
+        See :meth:`AbstractDeviceAdapter.send_script`.
+
+        Args:
+            client_id (str): The client we are working for.
+            conn_string (str): A connection string that will be
+                passed to the underlying device adapter.
+            script (bytes): The script that we wish to send.
+
+        Raises:
+            DeviceServerError: There is an issue with your client_id such
+                as not being connected to the device.
+            DeviceAdapterError: The adapter had a protocol issue sending the script.
+        """
+
+        conn_id = self._client_connection(client_id, conn_string)
+        await self.adapter.send_script(conn_id, script)
+
+    async def debug(self, client_id, conn_string, command, args):
+        """Send a debug command to a device on behalf of a client.
+
+        See :meth:`AbstractDeviceAdapter.send_script`.
+
+        Args:
+            client_id (str): The client we are working for.
+            conn_string (str): A connection string that will be
+                passed to the underlying device adapter.
+            command (str): The name of the debug command to run.
+            args (dict): Any command arguments.
+
+        Returns:
+            object: The response to the debug command.
+
+        Raises:
+            DeviceServerError: There is an issue with your client_id such
+                as not being connected to the device.
+            DeviceAdapterError: The adapter had a protocol issue sending the debug
+                command.
+        """
+
+        conn_id = self._client_info(client_id, 'connections')[conn_string]
+        return await self.adapter.debug(conn_id, command, args)
+
+    def _adjust_global_events(self, client_id, scan=None, broadcast=None):
+        monitor = self._client_info(client_id, 'monitor')
+
+        action = {False: "remove", True: "add"}
+
+        if scan is not None:
+            self.adapter.adjust_monitor(monitor, action.get(scan), [None], ['device_seen'])
+
+        if broadcast is not None:
+            self.adapter.adjust_monitor(monitor, action.get(broadcast), [None], ['broadcast'])
+
+    #pylint:disable=too-many-arguments;This is an internal utility method
+    def _adjust_device_events(self, client_id, conn_string, report=None, trace=None, disconnect=None, progress=None):
+        monitor = self._client_info(client_id, 'monitor')
+
+        action = {False: "remove", True: "add"}
+
+        if report is not None:
+            self.adapter.adjust_monitor(monitor, action.get(report), [conn_string], ['report'])
+
+        if trace is not None:
+            self.adapter.adjust_monitor(monitor, action.get(trace), [conn_string], ['trace'])
+
+        if disconnect is not None:
+            self.adapter.adjust_monitor(monitor, action.get(disconnect), [conn_string], ['disconnection'])
+
+        if progress is not None:
+            self.adapter.adjust_monitor(monitor, action.get(disconnect), [conn_string], ['progress'])
+
+    def _client_connection(self, client_id, conn_string):
+        conns = self._client_info(client_id, 'connections')
+
+        conn_id = conns.get(conn_string)
+        if conn_id is None:
+            raise DeviceServerError(client_id, conn_string, 'get_connection', 'client does not have connection')
+
+        return conn_id
+
+    def _client_info(self, client_id, key=None):
+        client_info = self._clients.get(client_id)
+
+        if client_info is None:
+            raise DeviceServerError(client_id, None, 'get_client_info', "unknown client id")
+
+        if key is None:
+            return client_info
+
+        return client_info[key]
+
+    def _hook_connect(self, conn_string, conn_id, client_id):
+        self._client_info(client_id, 'connections')[conn_string] = conn_id
+        self._adjust_device_events(client_id, conn_string, disconnect=True, progress=True)
+
+    def _hook_disconnect(self, conn_string, client_id):
+        self._adjust_device_events(client_id, conn_string,
+                                   disconnect=False, report=False, trace=False, progress=False)
+        del self._client_info(client_id, 'connections')[conn_string]
+
+    def _hook_open_interface(self, conn_string, interface, client_id):
+        if interface == 'streaming':
+            self._adjust_device_events(client_id, conn_string, report=True)
+        elif interface == 'tracing':
+            self._adjust_device_events(client_id, conn_string, trace=True)
+
+    def _hook_close_interface(self, conn_string, interface, client_id):
+        if interface == 'streaming':
+            self._adjust_device_events(client_id, conn_string, report=False)
+        elif interface == 'tracing':
+            self._adjust_device_events(client_id, conn_string, trace=False)
+
+    async def _forward_client_event(self, client_id, event_tuple):
+        conn_string, name, _ = event_tuple
+        user_data = self._client_info(client_id, 'user_data')
+
+        if name == 'disconnect':
+            self._hook_disconnect(conn_string, client_id)
+
+        if self.client_event_handler is not None:
+            result = self.client_event_handler(client_id, event_tuple, user_data=user_data)  #pylint:disable=assignment-from-none;This is an overridable method
+            if inspect.isawaitable(result):
+                await result

--- a/iotilecore/iotile/core/hw/virtual/__init__.py
+++ b/iotilecore/iotile/core/hw/virtual/__init__.py
@@ -6,12 +6,12 @@ from .virtualdevice import VirtualIOTileDevice
 from .common_types import (tile_rpc, RPCDispatcher, RPCInvalidIDError,
                            RPCNotFoundError, RPCInvalidArgumentsError,
                            RPCInvalidReturnValueError, TileNotFoundError,
-                           RPCErrorCode, unpack_rpc_payload, pack_rpc_payload,
+                           RPCErrorCode, BusyRPCResponse, unpack_rpc_payload, pack_rpc_payload,
                            pack_rpc_response)
 from .virtualinterface import VirtualIOTileInterface
 
 __all__ = ['VirtualTile', 'VirtualIOTileDevice', 'tile_rpc',
            'RPCDispatcher', 'RPCInvalidIDError', 'TileNotFoundError',
-           'RPCNotFoundError', 'RPCInvalidArgumentsError',
+           'RPCNotFoundError', 'RPCInvalidArgumentsError', 'BusyRPCResponse',
            'RPCInvalidReturnValueError', 'RPCErrorCode', 'VirtualIOTileInterface',
            'unpack_rpc_payload', 'pack_rpc_payload', 'pack_rpc_response']

--- a/iotilecore/setup.py
+++ b/iotilecore/setup.py
@@ -45,7 +45,7 @@ setup(
             'ws = iotile.core.hw.transport.websocketstream:WebSocketStream'
         ],
         'iotile.device_adapter': [
-            'virtual = iotile.core.hw.transport.virtualadapter:AsyncVirtualDeviceAdapter'
+            'virtual = iotile.core.hw.transport:VirtualDeviceAdapter'
         ],
         'iotile.report_format': [
             'individual = iotile.core.hw.reports:IndividualReadingReport',

--- a/iotilecore/test/test_hw/test_standard_adapter.py
+++ b/iotilecore/test/test_hw/test_standard_adapter.py
@@ -33,6 +33,8 @@ def test_register_monitors(adapter_loop):
     assert len(pairs) == 1
     assert pairs[0] == (None, 'device_seen', handle)
 
-    loop.run_coroutine(adapter.notify_event('abc', 'device_seen', {}))
+    # Returns a Future since it was called outside of event loop
+    future = adapter.notify_event('abc', 'device_seen', {})
+    future.result()
 
     assert len(events) == 1

--- a/iotilecore/test/test_hw/test_standard_server.py
+++ b/iotilecore/test/test_hw/test_standard_server.py
@@ -1,0 +1,232 @@
+"""Test the StandardDeviceServer class."""
+
+import pytest
+from iotile.core.utilities import BackgroundEventLoop
+from iotile.core.hw.transport import StandardDeviceServer, VirtualDeviceAdapter
+from iotile.core.hw.exceptions import DeviceAdapterError, DeviceServerError
+from iotile.core.hw.virtual import TileNotFoundError
+from iotile.mock.devices import ReportTestDevice, TracingTestDevice
+
+class BasicDeviceServer(StandardDeviceServer):
+    """Minimal subclass of device server for testing."""
+
+    async def start(self):
+        pass
+
+
+@pytest.fixture(scope="function")
+def server():
+    """A clean device server."""
+    shared_events = []
+
+    async def _event_callback(client_id, event_tuple, user_data):
+        shared_events.append((client_id, event_tuple))
+
+    loop = BackgroundEventLoop()
+
+    report_dev = ReportTestDevice({
+        'iotile_id': 1
+    })
+
+    tracing_dev = TracingTestDevice({
+        'iotile_id': 2
+    })
+
+    adapter = VirtualDeviceAdapter(None, devices=[report_dev, tracing_dev], loop=loop)
+    server = BasicDeviceServer(adapter, loop=loop)
+    server.client_event_handler = _event_callback
+
+    loop.start()
+    loop.run_coroutine(adapter.start())
+    loop.run_coroutine(server.start())
+
+    yield loop, shared_events, server, adapter
+
+    try:
+        loop.run_coroutine(server.stop())
+        loop.run_coroutine(adapter.stop())
+    finally:
+        loop.stop()
+
+
+def test_basic_probe(server):
+    """Make sure we can scan through a DeviceServer."""
+
+    loop, events, server, _ = server
+
+    client_id = server.setup_client()
+
+    assert len(events) == 0
+    assert isinstance(client_id, str)
+
+    loop.run_coroutine(server.probe(client_id))
+    assert len(events) == 2
+
+    event_client, (_, name, event) = events[0]
+    assert event_client == client_id
+    assert name == "device_seen"
+    assert isinstance(event, dict)
+
+    with pytest.raises(DeviceServerError):
+        loop.run_coroutine(server.probe("random client id"))
+
+    # Make sure it works repeatedly
+    loop.run_coroutine(server.probe(client_id))
+    assert len(events) == 4
+
+
+def test_multiclient_probe(server):
+    """Make sure multiple clients can probe separately."""
+
+    loop, events, server, _ = server
+
+    client1 = server.setup_client()
+    client2 = server.setup_client()
+
+    loop.run_coroutine(server.probe(client1))
+    loop.run_coroutine(server.probe(client2))
+
+    assert len(events) == 8
+
+
+def test_connect(server):
+    """Make sure we can connect to a device."""
+
+    loop, _, server, _ = server
+
+    client1 = server.setup_client()
+    client2 = server.setup_client()
+
+    loop.run_coroutine(server.connect(client1, '1'))
+
+    with pytest.raises(DeviceAdapterError):
+        loop.run_coroutine(server.connect(client2, '1'))
+
+    with pytest.raises(DeviceServerError):
+        loop.run_coroutine(server.disconnect(client2, '1'))
+
+    loop.run_coroutine(server.disconnect(client1, '1'))
+    loop.run_coroutine(server.connect(client2, '1'))
+
+
+def test_multiclient_connect(server):
+    """Make sure multiple clients can connect to multiple devices."""
+
+    loop, events, server, _ = server
+
+    client1 = server.setup_client()
+    client2 = server.setup_client()
+
+    loop.run_coroutine(server.connect(client1, '1'))
+    loop.run_coroutine(server.connect(client2, '2'))
+
+    loop.run_coroutine(server.open_interface(client1, '1', 'streaming'))
+    loop.run_coroutine(server.open_interface(client2, '2', 'tracing'))
+
+    assert any(x[0] == client1 for x in events)
+    assert any(x[0] == client2 for x in events)
+
+    with pytest.raises(DeviceServerError):
+        loop.run_coroutine(server.open_interface(client1, '2', 'streaming'))
+
+    with pytest.raises(DeviceServerError):
+        loop.run_coroutine(server.open_interface(client2, '1', 'tracing'))
+
+
+def test_send_rpc(server):
+    """Make sure we can send RPCs."""
+
+    loop, _, server, _ = server
+
+    client1 = server.setup_client()
+
+    with pytest.raises(DeviceServerError):
+        loop.run_coroutine(server.send_rpc(client1, '1', 1, 0xabcd, b'', timeout=0.1))
+
+    loop.run_coroutine(server.connect(client1, '1'))
+
+    with pytest.raises(TileNotFoundError):
+        loop.run_coroutine(server.send_rpc(client1, '1', 1, 0xabcd, b'', timeout=0.1))
+
+
+def test_send_script(server):
+    """Make sure we can send scripts."""
+
+    loop, events, server, _ = server
+
+    client1 = server.setup_client()
+
+    with pytest.raises(DeviceServerError):
+        loop.run_coroutine(server.send_script(client1, '1', bytes(100)))
+
+    loop.run_coroutine(server.connect(client1, '1'))
+    loop.run_coroutine(server.send_script(client1, '1', bytes(100)))
+
+    assert len(events) > 0
+    assert all(x[1][1] == 'progress' for x in events)
+
+
+def test_all_interfaces(server):
+    """Make sure we can open and close all interfaces."""
+
+    loop, _, server, _ = server
+
+    client1 = server.setup_client()
+
+    loop.run_coroutine(server.connect(client1, '1'))
+
+    loop.run_coroutine(server.open_interface(client1, '1', 'streaming'))
+    loop.run_coroutine(server.close_interface(client1, '1', 'streaming'))
+
+    loop.run_coroutine(server.open_interface(client1, '1', 'tracing'))
+    loop.run_coroutine(server.close_interface(client1, '1', 'tracing'))
+
+    loop.run_coroutine(server.open_interface(client1, '1', 'rpc'))
+    loop.run_coroutine(server.close_interface(client1, '1', 'rpc'))
+
+    loop.run_coroutine(server.open_interface(client1, '1', 'script'))
+    loop.run_coroutine(server.close_interface(client1, '1', 'script'))
+
+    loop.run_coroutine(server.open_interface(client1, '1', 'debug'))
+    loop.run_coroutine(server.close_interface(client1, '1', 'debug'))
+
+
+def test_receive_reports(server):
+    """Make sure we get report events."""
+
+    loop, events, server, _ = server
+
+    client1 = server.setup_client()
+    _client2 = server.setup_client()
+
+    loop.run_coroutine(server.connect(client1, '1'))
+    loop.run_coroutine(server.open_interface(client1, '1', 'streaming'))
+
+    # Make sure client1 and only client1 gets reports
+    assert len(events) > 0
+    assert all(x[1][1] == 'report' for x in events)
+    assert all(x[0] == client1 for x in events)
+
+    len_1 = len(events)
+
+    loop.run_coroutine(server.close_interface(client1, '1', 'streaming'))
+    loop.run_coroutine(server.open_interface(client1, '1', 'streaming'))
+
+    # Make sure we got more events the second time.
+    assert len(events) > len_1
+
+def test_receive_traces(server):
+    """Make sure we get trace events."""
+
+    loop, events, server, _ = server
+
+    client1 = server.setup_client()
+    _client2 = server.setup_client()
+
+    loop.run_coroutine(server.connect(client1, '2'))
+    loop.run_coroutine(server.open_interface(client1, '2', 'tracing'))
+
+    # Make sure client1 and only client1 gets reports
+    assert len(events) > 0
+    assert all(x[1][1] == 'trace' for x in events)
+    assert all(x[0] == client1 for x in events)

--- a/iotileemulate/iotile/emulate/transport/emulatedadapter.py
+++ b/iotileemulate/iotile/emulate/transport/emulatedadapter.py
@@ -6,12 +6,12 @@ into the emulated devices.
 """
 
 import logging
-from iotile.core.hw.transport.virtualadapter import AsyncVirtualDeviceAdapter
+from iotile.core.hw.transport import VirtualDeviceAdapter
 from iotile.core.hw.exceptions import DeviceAdapterError
 from ..virtual import EmulatedDevice
 
 
-class EmulatedDeviceAdapter(AsyncVirtualDeviceAdapter):
+class EmulatedDeviceAdapter(VirtualDeviceAdapter):
     """DeviceAdapter for connecting to EmulatedDevices.
 
     This adapter is used the exact same way as VirtualDeviceAdapter, except
@@ -57,20 +57,16 @@ class EmulatedDeviceAdapter(AsyncVirtualDeviceAdapter):
             for dev in self.devices.values():
                 dev.wait_idle()
 
-    async def debug(self, conn_id, name, cmd_args, progress_callback):
+    async def debug(self, conn_id, name, cmd_args):
         """Asynchronously complete a named debug command.
 
         The command name and arguments are passed to the underlying device adapter
-        and interpreted there.  If the command is long running, progress_callback
-        may be used to provide status updates.  Callback is called when the command
-        has finished.
+        and interpreted there.
 
         Args:
             conn_id (int): A unique identifer that will refer to this connection
             name (string): the name of the debug command we want to invoke
             cmd_args (dict): any arguments that we want to send with this command.
-            progress_callback (callable): A function to be called with status on our progress, called as:
-                progress_callback(done_count, total_count)
         """
 
 


### PR DESCRIPTION

## Overview

Adds  `AbstractDeviceServer` and `StandardDeviceServer` classes.  These classes are designed to unify and eventually replace `VirtualInterface` and `GatewayAgent`.  

`AbstractDeviceServer` is designed to let `iotile-gateway` load and run device servers without needing to know anything about how they serve devices.  It is intentionally left very minimal.

`StandardDeviceServer` is designed to be the reference implementation of device server functionality that most/all device servers inherit from.  As described in the documentation, it takes a single `AbstractDeviceAdapter` instance and serves multiple clients access to the devices that are reachable through that adapter.

`StandardDeviceServer` takes care of all of the tricky house-keeping around cleaning up after clients that unexpectedly go away and leave device connections hanging.  The goal is to have all that is required to implement a new DeviceServer be just listening for connections (over http, tcp, etc) and translating the messages received into calls on `StandardDeviceServer`.

## Major Changes

- Add `AbstractDeviceServer` class
- Add `StandardDeviceServer` class that implements `AbstractDeviceServer`
- Refactor how progress notifications are sent to not be callback based but to use the same notification system as other events.

### Additional Notes

- Slightly reorganizes the `transport` subpackage to be more logical.  
- Updates `SynchronousLegacyWrapper` to explicitly inherit from DeviceAdapter and provide both `_sync` and `_async` versions of all legacy functions.  It takes care of translating the new `progress` events back to the old progress callbacks.
- Slight refactor on `BackgroundEventLoop.launch_coroutine` to allow it to be called from within and without of the loop itself.  It now returns an `asyncio.Future` or `concurrent.futures.Future` based on the calling thread.  This lets us simplify the implementation of `notify_events`.
- Documents all of the events that can be notified by an AbstractDeviceAdapter.

Closes #756
Closes #754