### PR TITLE
Add support for using legacy DeviceAdapters in iotile-gateway

### DIFF
--- a/iotilecore/iotile/core/hw/debug/debug_manager.py
+++ b/iotilecore/iotile/core/hw/debug/debug_manager.py
@@ -30,6 +30,16 @@ class DebugManager:
     def __init__(self, stream):
         self._stream = stream
 
+    def send_command(self, name, cmd_args):
+        """Send an arbitrary debug command.
+
+        Args:
+            name (str): The name of the debug command to send.
+            cmd_args (dict): Any required arguments for the command.
+        """
+
+        return self._stream.debug_command(name, cmd_args)
+
     @docannotate
     def dump_ram(self, out_path, pause=False):
         """Dump all RAM to a binary file.

--- a/iotilecore/iotile/core/hw/transport/adapter/__init__.py
+++ b/iotilecore/iotile/core/hw/transport/adapter/__init__.py
@@ -4,6 +4,8 @@ from .standard import StandardDeviceAdapter
 from .mixin_conndata import PerConnectionDataMixin
 from .mixin_notifications import BasicNotificationMixin
 from .sync_wrapper import SynchronousLegacyWrapper
+from .async_wrapper import AsynchronousModernWrapper
 
 __all__ = ['DeviceAdapter', 'AbstractDeviceAdapter', 'StandardDeviceAdapter',
-           'PerConnectionDataMixin', 'BasicNotificationMixin', 'SynchronousLegacyWrapper']
+           'PerConnectionDataMixin', 'BasicNotificationMixin', 'SynchronousLegacyWrapper',
+           'AsynchronousModernWrapper']

--- a/iotilecore/iotile/core/hw/transport/adapter/async_wrapper.py
+++ b/iotilecore/iotile/core/hw/transport/adapter/async_wrapper.py
@@ -1,0 +1,261 @@
+"""A wrapper class that turns a legacy DeviceAdapter into an AbstractDeviceAdapter.
+
+The legacy adapter routines are run in a thread executor to provide a
+non-blocking coroutine based api.  All callbacks from the legacy adapter are
+translated to the corresponding event type appropriate and notified as events.
+
+The periodic callback from the legacy adapter is called in a loop once per second
+with the the periodic_callback itself running in an executor thread in case it
+contains blocking operations.
+"""
+
+import asyncio
+import logging
+import functools
+import concurrent.futures
+from iotile.core.exceptions import ArgumentError
+from iotile.core.utilities import SharedLoop
+from iotile.core.hw.reports import BroadcastReport
+from .standard import StandardDeviceAdapter
+from .legacy import DeviceAdapter
+from ...exceptions import DeviceAdapterError
+from ...virtual import unpack_rpc_response
+
+_MISSING = object()
+
+
+class AsynchronousModernWrapper(StandardDeviceAdapter):
+    """Provide a modern coroutine API on top of a legacy DeviceAdapter."""
+
+    def __init__(self, adapter, loop=SharedLoop):
+        super(AsynchronousModernWrapper, self).__init__(loop=loop)
+
+        if not isinstance(adapter, DeviceAdapter):
+            raise ArgumentError("AsynchronousModernWrapper created from object "
+                                "not a subclass of DeviceAdapter", adapter=adapter)
+
+        self._adapter = adapter
+        self._loop = loop
+        self._logger = logging.getLogger(__name__)
+        self._executor = concurrent.futures.ThreadPoolExecutor(max_workers=3)
+        self._task = loop.add_task(None, name="LegacyAdapter (%s)" % adapter.__class__.__name__,
+                                   finalizer=lambda _x: self.stop, stop_timeout=5.0)
+
+    def set_config(self, name, value):
+        """Set a config value for this adapter by name
+
+        Args:
+            name (string): The name of the config variable
+            value (object): The value of the config variable
+        """
+
+        self._adapter.set_config(name, value)
+
+    def get_config(self, name, default=_MISSING):
+        """Get a config value from this adapter by name
+
+        Args:
+            name (string): The name of the config variable
+            default (object): The default value to return if config is not found
+
+        Returns:
+            object: the value associated with the name
+
+        Raises:
+            ArgumentError: if the name is not found and no default is supplied
+        """
+
+        value = self._adapter.get_config(name, default)
+        if value is _MISSING:
+            raise ArgumentError("Config value did not exist", name=name)
+
+        return value
+
+    async def start(self):
+        """Start the device adapter.
+
+        See :meth:`AbstractDeviceAdapter.start`.
+        """
+
+        self._loop.add_task(self._periodic_loop, name="periodic task for %s" % self._adapter.__class__.__name__,
+                            parent=self._task)
+
+        self._adapter.add_callback('on_scan', functools.partial(_on_scan, self._loop, self))
+        self._adapter.add_callback('on_report', functools.partial(_on_report, self._loop, self))
+        self._adapter.add_callback('on_trace', functools.partial(_on_trace, self._loop, self))
+        #self._adapter.add_callback('on_disconnect', functools.partial(_on_disconnect, self._loop, self))
+
+    async def stop(self):
+        """Stop the device adapter.
+
+        See :meth:`AbstractDeviceAdapter.stop`.
+        """
+
+        self._logger.debug("Stopping async wrapper %s (before check)", self._adapter.__class__.__name__)
+
+        if self._task.stopped:
+            return
+
+        self._logger.debug("Stopping async wrapper %s", self._adapter.__class__.__name__)
+        for task in self._task.subtasks:
+            await task.stop()
+
+        self._logger.debug("Stopping underlying adapter %s", self._adapter.__class__.__name__)
+        await self._execute(self._adapter.stop_sync)
+
+    def _execute(self, func, *args):
+        return self._loop.get_loop().run_in_executor(self._executor, func, *args)
+
+    async def _periodic_loop(self):
+        while True:
+            try:
+                await self._execute(self._adapter.periodic_callback)
+                await asyncio.sleep(1)
+            except asyncio.CancelledError:
+                raise
+            except:  #pylint:disable=bare-except;This is a background worker task that logs the error
+                self._logger.exception("Error in periodic callback from device adapter")
+
+    def can_connect(self):
+        """Return whether this device adapter can accept another connection.
+
+        We just forward the request to the underlying adapter and ask.
+
+        See :meth:`AbstractDeviceAdapter.can_connect`.
+        """
+
+        return self._adapter.can_connect()
+
+    async def connect(self, conn_id, connection_string):
+        """Connect to a device.
+
+        See :meth:`AbstractDeviceAdapter.connect`.
+        """
+
+        resp = await self._execute(self._adapter.connect_sync, conn_id, connection_string)
+        _raise_error(conn_id, 'connect', resp)
+        self._setup_connection(conn_id, connection_string)
+
+    async def disconnect(self, conn_id):
+        """Disconnect from a connected device.
+
+        See :meth:`AbstractDeviceAdapter.disconnect`.
+        """
+
+        resp = await self._execute(self._adapter.disconnect_sync, conn_id)
+        _raise_error(conn_id, 'disconnect', resp)
+        self._teardown_connection(conn_id)
+
+    async def open_interface(self, conn_id, interface):
+        """Open an interface on an IOTile device.
+
+        See :meth:`AbstractDeviceAdapter.open_interface`.
+        """
+
+        resp = await self._execute(self._adapter.open_interface_sync, conn_id, interface)
+        _raise_error(conn_id, 'open_interface', resp)
+
+    async def close_interface(self, conn_id, interface):
+        """Close an interface on this IOTile device.
+
+        See :meth:`AbstractDeviceAdapter.close_interface`.
+        """
+
+        resp = await self._execute(self._adapter.close_interface_sync, conn_id, interface)
+        _raise_error(conn_id, 'close_interface', resp)
+
+    async def probe(self):
+        """Probe for devices connected to this adapter.
+
+        See :meth:`AbstractDeviceAdapter.probe`.
+        """
+
+        resp = await self._execute(self._adapter.probe_sync)
+        _raise_error(None, 'probe', resp)
+
+    async def send_rpc(self, conn_id, address, rpc_id, payload, timeout):
+        """Send an RPC to a device.
+
+        See :meth:`AbstractDeviceAdapter.send_rpc`.
+        """
+
+        resp = await self._execute(self._adapter.send_rpc_sync, conn_id, address, rpc_id, payload, timeout)
+        _raise_error(conn_id, 'send_rpc', resp)
+
+        status = resp.get('status')
+        payload = resp.get('payload')
+
+        # This will raise an exception if needed based on status
+        return unpack_rpc_response(status, payload, rpc_id, address)
+
+    async def debug(self, conn_id, name, cmd_args):
+        """Send a debug command to a device.
+
+        See :meth:`AbstractDeviceAdapter.debug`.
+        """
+
+        progress_callback = functools.partial(_on_progress, self, 'debug', conn_id)
+
+        resp = await self._execute(self._adapter.debug_sync, conn_id, name, cmd_args, progress_callback)
+        _raise_error(conn_id, 'send_rpc', resp)
+
+        return resp.get('return_value')
+
+    async def send_script(self, conn_id, data):
+        """Send a a script to a device.
+
+        See :meth:`AbstractDeviceAdapter.send_script`.
+        """
+
+        progress_callback = functools.partial(_on_progress, self, 'script', conn_id)
+
+        resp = await self._execute(self._adapter.send_script_sync, conn_id, data, progress_callback)
+        _raise_error(conn_id, 'send_rpc', resp)
+
+
+def _raise_error(conn_id, operation, resp):
+    if resp['success'] is False:
+        raise DeviceAdapterError(conn_id, operation, resp.get('failure_reason', "unknown failure reason"))
+
+
+def _on_scan(_loop, adapter, _adapter_id, info, expiration_time):
+    """Callback when a new device is seen."""
+
+    info['validity_period'] = expiration_time
+    adapter.notify_event_nowait(info.get('connection_string'), 'device_seen', info)
+
+
+def _on_report(_loop, adapter, conn_id, report):
+    """Callback when a report is received."""
+
+    conn_string = None
+    if conn_id is not None:
+        conn_string = adapter._get_property(conn_id, 'connection_string')
+
+    if isinstance(report, BroadcastReport):
+        adapter.notify_event_nowait(conn_string, 'broadcast', report)
+    elif conn_string is not None:
+        adapter.notify_event_nowait(conn_string, 'report', report)
+    else:
+        adapter._logger.debug("Dropping report with unknown conn_id=%s", conn_id)
+
+
+def _on_trace(_loop, adapter, conn_id, trace):
+    """Callback when tracing data is received."""
+
+    conn_string = adapter._get_property(conn_id, 'connection_string')
+    if conn_string is None:
+        adapter._logger.debug("Dropping trace daata with unknown conn_id=%s", conn_id)
+        return
+
+    adapter.notify_event_nowait(conn_string, 'trace', trace)
+
+
+def _on_progress(adapter, operation, conn_id, done, total):
+    """Callback when progress is reported."""
+
+    conn_string = adapter._get_property(conn_id, 'connection_string')
+    if conn_string is None:
+        return
+
+    adapter.notify_progress(conn_string, operation, done, total)

--- a/iotilecore/iotile/core/hw/transport/adapter/async_wrapper.py
+++ b/iotilecore/iotile/core/hw/transport/adapter/async_wrapper.py
@@ -91,12 +91,10 @@ class AsynchronousModernWrapper(StandardDeviceAdapter):
         See :meth:`AbstractDeviceAdapter.stop`.
         """
 
-        self._logger.debug("Stopping async wrapper %s (before check)", self._adapter.__class__.__name__)
 
         if self._task.stopped:
             return
 
-        self._logger.debug("Stopping async wrapper %s", self._adapter.__class__.__name__)
         for task in self._task.subtasks:
             await task.stop()
 

--- a/iotilecore/iotile/core/hw/transport/server/standard.py
+++ b/iotilecore/iotile/core/hw/transport/server/standard.py
@@ -217,6 +217,7 @@ class StandardDeviceServer(AbstractDeviceServer):
 
         for conn_string, conn_id in conns.items():
             try:
+                self._logger.debug("Disconnecting client %d from conn %s at teardown", client_id, conn_string)
                 await self.adapter.disconnect(conn_id)
             except:  #pylint:disable=bare-except; This is a finalization method that should not raise unexpectedly
                 self._logger.exception("Error disconnecting device during teardown_client: conn_string=%s", conn_string)

--- a/iotilecore/test/test_hw/test_standard_server.py
+++ b/iotilecore/test/test_hw/test_standard_server.py
@@ -166,6 +166,30 @@ def test_send_script(server):
     assert all(x[1][1] == 'progress' for x in events)
 
 
+def test_debug(server):
+    """Make sure we can send debug commands."""
+
+    loop, events, server, _ = server
+
+    client1 = server.setup_client()
+
+    with pytest.raises(DeviceServerError):
+        loop.run_coroutine(server.send_script(client1, '1', bytes(100)))
+
+    loop.run_coroutine(server.connect(client1, '1'))
+    result = loop.run_coroutine(server.debug(client1, '1', 'inspect_property',
+                                             dict(properties=['connected'])))
+
+    assert len(result) == 1
+    assert result.get('connected') is True
+
+    assert len(events) == 1
+    assert all(x[1][1] == 'progress' for x in events)
+
+    with pytest.raises(DeviceAdapterError):
+        loop.run_coroutine(server.debug(client1, '1', 'random_command', {}))
+
+
 def test_all_interfaces(server):
     """Make sure we can open and close all interfaces."""
 

--- a/iotilecore/test/test_hw/test_virtualadapter.py
+++ b/iotilecore/test/test_hw/test_virtualadapter.py
@@ -244,6 +244,22 @@ def test_tilebased_device(tile_based):
     tile1.count()
 
 
+def test_debug(realtime_scan_hw):
+    """Make sure we can send debug commands."""
+
+    hw = realtime_scan_hw
+
+    hw.connect('1')
+    debug_man = hw.debug()
+    result = debug_man.send_command('inspect_property', dict(properties=['connected']))
+
+    assert len(result) == 1
+    assert result.get('connected') is True
+
+    with pytest.raises(HardwareError):
+        debug_man.send_command('random_command', dict())
+
+
 def test_recording_rpcs(tmpdir):
     """Make sure we can record RPCs."""
 

--- a/iotilegateway/iotilegateway/device.py
+++ b/iotilegateway/iotilegateway/device.py
@@ -12,9 +12,7 @@ formatted connection string if you don't want the automatic behavior.
 
 TODO:
 - [ ] Periodically expire devices from visible_devices
-- [ ] Set configs like probe_required, probe_supported
 - [ ] Add threadsafe mutex around visible_devices
-
 """
 
 import logging
@@ -23,7 +21,7 @@ from time import monotonic
 import functools
 from iotile.core.exceptions import ArgumentError, InternalError
 from iotile.core.utilities import SharedLoop
-from iotile.core.hw.transport.adapter import AbstractDeviceAdapter, BasicNotificationMixin, PerConnectionDataMixin
+from iotile.core.hw.transport.adapter import AbstractDeviceAdapter, BasicNotificationMixin, PerConnectionDataMixin, DeviceAdapter, AsynchronousModernWrapper
 from iotile.core.hw.exceptions import DeviceAdapterError
 
 
@@ -82,6 +80,10 @@ class AggregatingDeviceAdapter(BasicNotificationMixin,
 
         if self._started:
             raise InternalError("New adapters cannot be added after start() is called")
+
+        if isinstance(adapter, DeviceAdapter):
+            self._logger.warning("Wrapping legacy device adapter %s in async wrapper", adapter)
+            adapter = AsynchronousModernWrapper(adapter, loop=self._loop)
 
         self.adapters.append(adapter)
 

--- a/iotilegateway/iotilegateway/main.py
+++ b/iotilegateway/iotilegateway/main.py
@@ -101,7 +101,7 @@ def main(argv=None, loop=SharedLoop, max_time=None):
         if should_raise:
             raise exc
 
-        logger.exception("Fatal error running supervisor")
+        logger.exception("Fatal error running gateway")
         return 1
 
     return 0

--- a/transport_plugins/websocket/iotile_transport_websocket/device_server.py
+++ b/transport_plugins/websocket/iotile_transport_websocket/device_server.py
@@ -269,6 +269,7 @@ class WebSocketDeviceServer(StandardDeviceServer):
             return
 
         try:
+            self._logger.debug("Sending event %s: %s", msg_name, msg_payload)
             await self.server.send_event(user_data, msg_name, msg_payload)
         except websockets.exceptions.ConnectionClosed:
             self._logger.debug("Could not send notification because connection was closed for client %s", client_id)


### PR DESCRIPTION
## Overview

This PR adds a wrapper class that takes a legacy instance of `DeviceAdapter` and wraps it with a modern coroutine based api that inherits from `StandardDeviceAdapter`.  This allows `iotile-gateway` to automatically support `jlink` and `bled112` transport plugins via this legacy shim.

This is step one to migrating `AdapterStream` to natively work with `AbstractDeviceAdapter` and support legacy device adapters via this shim.  Currently we natively support the legacy DeviceAdapters and work with the modern ones using a `LegacySynchronousWrapper` class.

## Major Changes

- Add `AsynchronousModernWrapper` class that takes a legacy DeviceAdapter and turns it into something that inherits from `StandardDeviceAdapter`.  Legacy callbacks are translated to modern events and all of the legacy adapters functions are run inside an executor thread to ensure they are non-blocking.
- Adds support for `debug` commands in the `VirtualAdapter` to make it easier to test debug interface support in AbstractDeviceServer implementations.
- Adds a few more debug logs that make it easier to inspect what is going on inside of device servers.

### Additional Notes

- Support for unexpected disconnect event propagation is not yet supported in `AsynchronousModernWrapper`.  I wanted to refactor `AdapterStream` before adding that and make sure we have good test coverage to test automatic reconnections.
- Fixes an error in how `BackgroudEventLoop.wait_for_interrupt()` works.  It should not automatically stop() itself so that the user is able to cleanly close their functionality in their desired order.