### PR TITLE
Fix open mode from 'rb' to 'r' for yaml files

### DIFF
--- a/iotileship/RELEASE.md
+++ b/iotileship/RELEASE.md
@@ -2,6 +2,10 @@
 
 All major changes in each released version of IOTileShip are listed here.
 
+## 1.0.4
+
+- Change open mode from 'rb' to 'r'. 
+
 ## 1.0.3
 
 - Remove remaining builtins/__future__

--- a/iotileship/iotile/ship/recipe.py
+++ b/iotileship/iotile/ship/recipe.py
@@ -351,7 +351,7 @@ class RecipeObject:
     @classmethod
     def _process_yaml(cls, yamlfile):
         import yaml
-        with open(yamlfile, 'rb') as infile:
+        with open(yamlfile, 'r') as infile:
             info = yaml.load(infile)
             return info
 

--- a/iotileship/iotile/ship/scripts/iotile_ship.py
+++ b/iotileship/iotile/ship/scripts/iotile_ship.py
@@ -38,7 +38,7 @@ def load_variables(defines, config_file):
     """
 
     if config_file is not None:
-        with open(config_file, "rb") as conf_file:
+        with open(config_file, "r") as conf_file:
             variables = yaml.load(conf_file)
     else:
         variables = {}

--- a/iotileship/version.py
+++ b/iotileship/version.py
@@ -1,1 +1,1 @@
-version = "1.0.3"
+version = "1.0.4"


### PR DESCRIPTION
Bug fix to remove the binary mode from reading the yaml files. 

