### PR TITLE
asyncio / websockets small fixes

### DIFF
--- a/iotilegateway/iotilegateway/supervisor/service_manager.py
+++ b/iotilegateway/iotilegateway/supervisor/service_manager.py
@@ -117,7 +117,7 @@ class ServiceManager:
         """
 
         if name in self.services:
-            raise ArgumentError("Could not add service because the short_name is taken", short_name=short_name)
+            raise ArgumentError("Could not add service because the long_name is taken", long_name=long_name)
 
         serv_state = states.ServiceState(name, long_name, preregistered)
 

--- a/transport_plugins/websocket/iotile_transport_websocket/generic/packing.py
+++ b/transport_plugins/websocket/iotile_transport_websocket/generic/packing.py
@@ -19,8 +19,8 @@ def pack(message):
 def _decode_datetime(obj):
     """Decode a msgpack'ed datetime."""
 
-    if b'__datetime__' in obj:
-        obj = datetime.datetime.strptime(obj[b'as_str'].decode(), "%Y%m%dT%H:%M:%S.%f")
+    if '__datetime__' in obj:
+        obj = datetime.datetime.strptime(obj['as_str'].decode(), "%Y%m%dT%H:%M:%S.%f")
     return obj
 
 


### PR DESCRIPTION
In the EventLoop:
 - Add outcome exception printouts for when cancelled tasks have an exception other than CancelledError to help debug
 - Some minor style changes

In websockets:
 - Switched the datetime decoder to not use bytes, similar to what we'd done in the past for the other websockets datetime things for py3

In gateway:
 - short_name was used when long_name was the variable present and (I believe) intended to be used.
