### PR TITLE
Modify the VirtualDevice to be compliant with coroutine RPCs

### DIFF
--- a/iotilecore/iotile/core/hw/transport/adapterstream.py
+++ b/iotilecore/iotile/core/hw/transport/adapterstream.py
@@ -276,7 +276,7 @@ class AdapterStream:
         exceptions that can be raised here.
 
         Args:
-            address (int): The tile address containin the RPC
+            address (int): The tile address containing the RPC
             rpc_id (int): The ID of the RPC that we wish to call.
             call_payload (bytes): The payload containing encoded arguments for the
                 RPC.

--- a/iotilecore/iotile/core/hw/transport/virtualadapter.py
+++ b/iotilecore/iotile/core/hw/transport/virtualadapter.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import inspect
 from iotile.core.exceptions import ArgumentError
 from iotile.core.dev import ComponentRegistry
 from iotile.core.hw.reports import BroadcastReport
@@ -295,7 +296,11 @@ class VirtualDeviceAdapter(StandardDeviceAdapter):
         dev = self._get_property(conn_id, 'device')
 
         try:
-            return dev.call_rpc(address, rpc_id, bytes(payload))
+            res = dev.call_rpc(address, rpc_id, bytes(payload))
+            if inspect.iscoroutine(res):
+                return await res
+            else:
+                return res
         except (RPCInvalidIDError, RPCNotFoundError, TileNotFoundError, RPCErrorCode, BusyRPCResponse):
             raise
         except Exception:

--- a/iotilecore/iotile/core/utilities/async_tools/event_loop.py
+++ b/iotilecore/iotile/core/utilities/async_tools/event_loop.py
@@ -278,7 +278,7 @@ class BackgroundEventLoop:
         self._logger = logging.getLogger(__name__)
         self._loop_check = threading.local()
 
-    def start(self):
+    def start(self, aug='EventLoopThread'):
         """Ensure the background loop is running.
 
         This method is safe to call multiple times.  If the loop is already
@@ -291,7 +291,7 @@ class BackgroundEventLoop:
         if not self.loop:
             self._logger.debug("Starting event loop")
             self.loop = asyncio.new_event_loop()
-            self.thread = threading.Thread(target=self._loop_thread_main, name="EventLoopThread", daemon=True)
+            self.thread = threading.Thread(target=self._loop_thread_main, name=aug, daemon=True)
             self.thread.start()
 
     def wait_for_interrupt(self, check_interval=1.0, max_time=None):

--- a/iotileemulate/iotile/emulate/virtual/emulated_tile.py
+++ b/iotileemulate/iotile/emulate/virtual/emulated_tile.py
@@ -376,7 +376,6 @@ class EmulatedTile(EmulationMixin, RPCDispatcher):
     @async_tile_rpc(*rpcs.RESET)
     async def reset_rpc(self):
         """Reset this tile."""
-
         await self.reset()
         raise TileNotFoundError("tile was reset via an RPC")
 

--- a/iotilegateway/iotilegateway/supervisor/client.py
+++ b/iotilegateway/iotilegateway/supervisor/client.py
@@ -3,8 +3,8 @@
 import threading
 from copy import copy
 import logging
-from time import monotonic
 import asyncio
+import inspect
 
 from iotile.core.hw.virtual import RPCInvalidArgumentsError, RPCInvalidReturnValueError
 from iotile.core.utilities import SharedLoop
@@ -503,6 +503,8 @@ class AsyncSupervisorClient(AsyncValidatingWSClient):
         else:
             try:
                 response = self._rpc_dispatcher.call_rpc(rpc_id, args)
+                if inspect.iscoroutine(response):
+                    response = await response
             except RPCInvalidArgumentsError:
                 result = 'invalid_arguments'
             except RPCInvalidReturnValueError:

--- a/iotiletest/iotile/mock/mock_adapter.py
+++ b/iotiletest/iotile/mock/mock_adapter.py
@@ -82,7 +82,6 @@ class MockDeviceAdapter(DeviceAdapter):
             return
 
         device = self.connections[connection_id]
-
         try:
             payload = device.call_rpc(address, rpc_id, payload)
         except (RPCInvalidIDError, RPCNotFoundError):


### PR DESCRIPTION
## Overview

Addresses #798 and #799

## Major Changes

- Added inspectors to support async functions to be called by RPC, both by decorator and by the status client. This duplicates the async_rpc decorators in the Emulator, which haven't been removed but could be at this point.
- The VirtualAdapter now properly allows for coroutine based calls from the SupervisorClient



