### PR TITLE
Cleanup minor issues in iotile-ext-cloud and iotile-build

### DIFF
--- a/iotile_ext_cloud/RELEASE.md
+++ b/iotile_ext_cloud/RELEASE.md
@@ -2,6 +2,12 @@
 
 All major changes in each released version of the iotile-ext-cloud plugin are listed here.
 
+## 1.0.5
+
+- Only request IOTileCloud credentials if we are actually uploading to IOTileCloud.
+  This allows people to use the cloud_uploader app to download reports from a POD
+  without needing to have/enter an IOTile.cloud password.
+
 ## 1.0.4
 
 - Implement proper dependency major version limits.

--- a/iotile_ext_cloud/iotile/cloud/apps/cloud_uploader.py
+++ b/iotile_ext_cloud/iotile/cloud/apps/cloud_uploader.py
@@ -37,8 +37,15 @@ class CloudUploader(IOTileApp):
     def __init__(self, hw, app_info, os_info, device_id):
         super(CloudUploader, self).__init__(hw, app_info, os_info, device_id)
 
-        self._cloud = IOTileCloud()
+        self._cloud_obj = None
         self._con = self._hw.get(8, basic=True)
+
+    @property
+    def _cloud(self):
+        if self._cloud_obj is None:
+            self._cloud_obj = IOTileCloud()
+
+        return self._cloud_obj
 
     @classmethod
     def AppName(cls):

--- a/iotile_ext_cloud/version.py
+++ b/iotile_ext_cloud/version.py
@@ -1,1 +1,1 @@
-version = "1.0.4"
+version = "1.0.5"

--- a/iotilebuild/RELEASE.md
+++ b/iotilebuild/RELEASE.md
@@ -2,6 +2,12 @@
 
 All major changes in each released version of IOTileBuild are listed here.
 
+## 3.0.7
+
+- Add support for `iotile depends python` command to get the python dependencies
+  of an iotile component.  This allows the creation of scripts that automatically
+  install required python dependencies in a CI setting.
+
 ## 3.0.6
 
 - Implement proper dependency major version limits.

--- a/iotilebuild/iotile/build/dev/depmanager.py
+++ b/iotilebuild/iotile/build/dev/depmanager.py
@@ -196,6 +196,24 @@ class DependencyManager (object):
         shutil.rmtree(depdir)
         os.makedirs(depdir)
 
+    @docannotate
+    def python(self, path='.'):
+        """Return all python dependencies in pip install compatible format.
+
+        This function can be used to easily ensure that all required python
+        dependencies are installed before building/testing.
+
+        Args:
+            path (str): Optional path to the iotile component to install dependencies
+                for.  Defaults to the cwd.
+
+        Returns:
+            str: A newline delimited list of python dependencies.
+        """
+
+        tile = IOTile(path)
+        return "\n".join('"{}"'.format(x) for x in tile.support_wheel_depends)
+
     @param("path", "path", "exists", desc="Path to IOTile to check")
     def ensure_compatible(self, path='.'):
         """Check that all of the version of dependency tiles are compatible

--- a/iotilebuild/version.py
+++ b/iotilebuild/version.py
@@ -1,1 +1,1 @@
-version = "3.0.6"
+version = "3.0.7"


### PR DESCRIPTION
- You can now get a list of all python dependencies of an iotile component.  This is needed to be able to make sure those dependencies are installed during firmware CI testing.  Previously we didn't test python parts of an iotile component so the fact that this never worked wasn't an issue, now it is and is blocking us moving firmware builds to python 3.

- You can now use the cloud_uploader app to download reports from a POD without needing to enter iotile.cloud credentials.  This improves the POD-1M `tracker_app` download process so that we can just download data locally without needing to enter an unused iotile.cloud credential.

