### PR TITLE
Fix asyncio jlink adapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ target/
 
 workspace
 .pytest_cache
+test.bin

--- a/transport_plugins/jlink/RELEASE.md
+++ b/transport_plugins/jlink/RELEASE.md
@@ -3,6 +3,10 @@
 All major changes in each released version of the jlink transport plugin are
 listed here.
 
+## 1.0.5
+
+- Fix `_try_connect` logic around already connected devices.
+
 ## 1.0.4
 
 - Implement proper dependency major version limits.

--- a/transport_plugins/jlink/iotile_transport_jlink/jlink.py
+++ b/transport_plugins/jlink/iotile_transport_jlink/jlink.py
@@ -137,8 +137,7 @@ class JLinkAdapter(DeviceAdapter):
             if self.connected is True:
                 self._trigger_callback('on_disconnect', self.id, self._connection_id)
                 self.connected = False
-
-            self.stop_sync()
+                self.stop_sync()
 
             if self._mux_func is not None:
                 self._mux_func(self._channel)

--- a/transport_plugins/jlink/iotile_transport_jlink/jlink.py
+++ b/transport_plugins/jlink/iotile_transport_jlink/jlink.py
@@ -40,6 +40,7 @@ class JLinkAdapter(DeviceAdapter):
         self._control_thread = None
         self._connection_id = None
         self.jlink = None
+        self.connected = False
 
         self._parse_port(port)
 
@@ -133,7 +134,9 @@ class JLinkAdapter(DeviceAdapter):
     def _try_connect(self, connection_string):
         """If the connecton string settings are different, try and connect to an attached device"""
         if self._parse_conn_string(connection_string):
-            self._trigger_callback('on_disconnect', self.id, self._connection_id)
+            if self.connected is True:
+                self._trigger_callback('on_disconnect', self.id, self._connection_id)
+                self.connected = False
 
             self.stop_sync()
 
@@ -151,6 +154,7 @@ class JLinkAdapter(DeviceAdapter):
                 self.jlink.set_tif(pylink.enums.JLinkInterfaces.SWD)
                 self.jlink.connect(self._device_info.jlink_name)
                 self.jlink.set_little_endian()
+                self.connected = True
             except pylink.errors.JLinkException as exc:
                 if exc.code == exc.VCC_FAILURE:
                     raise HardwareError("No target power detected", code=exc.code,

--- a/transport_plugins/jlink/version.py
+++ b/transport_plugins/jlink/version.py
@@ -1,1 +1,1 @@
-version = "1.0.4"
+version = "1.0.5"


### PR DESCRIPTION
## Overview

Fixing `_try_connect` to only execute the `on_disconnect` callback if the device had been previously connected.
