### PR TITLE
Add parse_uuid(), parse_uuid2int(), parse_uuid2slug() functions

### DIFF
--- a/iotilecore/RELEASE.md
+++ b/iotilecore/RELEASE.md
@@ -12,6 +12,8 @@ All major changes in each released version of `iotile-core` are listed here.
 - Completely remove `VirtualIOTileInterface` and replace with `AbstractDeviceServer`.
   `virtual_device` script has been updated to use `AbstractDeviceServer` directly instead
   of requiring it to be wrapped inside a `VirtualIOTileInterface` shim.
+- Add parse_uuid(), parse_uuid2int(), parse_uuid2slug() function to aid in UUID
+  conversions
 
 ## 4.1.2
 

--- a/iotilecore/iotile/core/utilities/gid.py
+++ b/iotilecore/iotile/core/utilities/gid.py
@@ -1,3 +1,4 @@
+import re
 from iotile.core.exceptions import *
 
 # Generate a 0000-0000-0000-0001 given an integer
@@ -19,3 +20,89 @@ def uuid_to_slug(uuid):
         raise ArgumentError("Integer should be a positive number and smaller than 0x7fffffff", id=uuid)
 
     return '--'.join(['d', int64gid(uuid)])
+
+
+def parse_uuid(uuidinput, prefix=None):
+    """
+    Parses and decodes an input as a uuid in various forms
+
+        uuidinput:
+            Input that can be a string or integer.
+            Strings can be in hex prefixed as 0x
+            Strings can be an integer not prefixed with 0x
+            Strings can be as a uuid in the form of
+                '0000-0000-0000-0000'
+                'd--0000-0000-0000-0000'
+                'd--0000-0000-0000'
+                'd--0000-0000'
+                'd--0000'
+
+        prefix (str): If present, indicates the prefix to prepend
+            to the slug output.
+
+    Returns:
+        uuid (int): UUID as an integer
+        slug (str): UUID in format of 'XXXX-XXXX-XXXX-XXXX'
+    """
+    uuid = None
+    slug = None
+
+    def i2slug(value, prefix=None):
+        if value is None:
+            raise ArgumentError("Input is required")
+        if uuid < 0 or uuid > 0x7fffffff:
+            raise ArgumentError("Integer should be a positive number and smaller than 0x7fffffff", id=uuid)
+
+        out = int64gid(value)
+
+        if prefix is not None:
+            out = prefix + '--' + out
+
+        return out
+
+    if uuidinput is None:
+        raise ArgumentError("Input is required")
+
+    if type(uuidinput) is int:
+        uuid = uuidinput
+        slug = i2slug(uuid, prefix)
+
+    elif type(uuidinput) is str:
+        hex_str_re = "^(0x[0-9a-fA-F]{1,12})$"
+        int_str_re = "^([0-9]{1,15})$"
+        slug1_re = "^0000-([0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4})$"
+        slug2_re = "^d--0000-([0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4})$"
+        slug3_re = "^d--([0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4})$"
+        slug4_re = "^d--([0-9a-fA-F]{4}-[0-9a-fA-F]{4})$"
+        slug5_re = "^d--([0-9a-fA-F]{4})$"
+        uuidinput = uuidinput.strip()
+        hex_result   = re.match(hex_str_re, uuidinput)
+        int_result   = re.match(int_str_re, uuidinput)
+        slug1_result = re.match(slug1_re,   uuidinput)
+        slug2_result = re.match(slug2_re,   uuidinput)
+        slug3_result = re.match(slug3_re,   uuidinput)
+        slug4_result = re.match(slug4_re,   uuidinput)
+        slug5_result = re.match(slug5_re,   uuidinput)
+        if hex_result or int_result:
+            uuid = int(uuidinput, 0)
+        elif slug1_result:
+            uuid = int(re.sub('-','',slug1_result.group(1)), 16)
+        elif slug2_result:
+            uuid = int(re.sub('-','',slug2_result.group(1)), 16)
+        elif slug3_result:
+            uuid = int(re.sub('-','',slug3_result.group(1)), 16)
+        elif slug4_result:
+            uuid = int(re.sub('-','',slug4_result.group(1)), 16)
+        elif slug5_result:
+            uuid = int(re.sub('-','',slug5_result.group(1)), 16)
+        slug = i2slug(uuid, prefix)
+
+    return uuid, slug
+
+def parse_uuid2int(uuidinput):
+    u, s = parse_uuid(uuidinput)
+    return u
+
+def parse_uuid2slug(uuidinput, prefix=None):
+    u, s = parse_uuid(uuidinput, prefix)
+    return s


### PR DESCRIPTION
Add utility functions to aid in the conversions of UUIDs in integer form to slug form and vice versa.

The functions can be called with inputs of many types and they detect and convert into known output types. This is useful when there may be confusion about UUID input types or formats. 

parse_uuid(uuidinput, prefix=None) always returns both the integer form and the slug form. 
parse_uuid2int(uuidinput) always returns just the integer form
parse_uuid2slug(uuidinput, prefix=None) always returns the slug form. 

Input to all the functions can be integers or strings. 
Acceptable string parsing rules are the following:
```
Strings are interpreted as hex if they are prefixed with '0x' including only characters [0-9a-fA-F]
Strings are interpreted as integer if they are not prefixed with '0x' and include only characters [0-9]
Strings can be as a uuid in the form of
                '0000-0000-0000-0000'
                'd--0000-0000-0000-0000'
                'd--0000-0000-0000'
                'd--0000-0000'
                'd--0000'
```