### PR TITLE
Adding a type option to ModifyJsonStep

### DIFF
--- a/iotileship/RELEASE.md
+++ b/iotileship/RELEASE.md
@@ -2,6 +2,10 @@
 
 All major changes in each released version of IOTileShip are listed here.
 
+## 1.0.7
+
+- Added value_type argument to ModifyJsonStep
+
 ## 1.0.6
 
 - Added the FilesystemManager resource and ModifyJSON step

--- a/iotileship/RELEASE.md
+++ b/iotileship/RELEASE.md
@@ -2,14 +2,9 @@
 
 All major changes in each released version of IOTileShip are listed here.
 
-## 1.0.7
-
-- Added value_type argument to ModifyJsonStep
-
 ## 1.0.6
 
-- Added the FilesystemManager resource and ModifyJSON step
-
+- Added the FilesystemManager resource and ModifyJsonStep
 ## 1.0.5
 
 - Implement proper dependency major version limits.

--- a/iotileship/iotile/ship/actions/ModifyJsonStep.py
+++ b/iotileship/iotile/ship/actions/ModifyJsonStep.py
@@ -48,6 +48,7 @@ class ModifyJsonStep: # pylint: disable=too-few-public-methods
     Args:
         key (list): A list of keys and subkeys specifing the key to change (list can be one)
         value (str): The value to change for the above key
+        value_type (str, optional): The type of value. Typedargs types supported Defaults to 'string'
         path (str): The file path, relative to the Filesystem Manager's root, to the file to change
         create_if_missing (bool, optional): Set to true to create key if the last key in the list is not found
                 Otherwise the function will throw a KeyError. Defaults to False.
@@ -64,9 +65,11 @@ class ModifyJsonStep: # pylint: disable=too-few-public-methods
             raise RecipeActionMissingParameter("ModifyJsonStep Parameter Missing", parameter_name='path')
 
         self._key = args.get('key')
-        self._value = str(args.get('value'))
         self._path = str(args.get('path'))
         self._create = type_system.convert_to_type(args.get('create_if_missing', False), 'bool')
+
+        self._value_type = str(args.get('value_type', 'string'))
+        self._value = type_system.convert_to_type(args.get('value'), self._value_type)
 
     def run(self, resources): # pylint: disable=missing-docstring
         root = resources['filesystem'].root

--- a/iotileship/iotile/ship/actions/ModifyJsonStep.py
+++ b/iotileship/iotile/ship/actions/ModifyJsonStep.py
@@ -48,10 +48,10 @@ class ModifyJsonStep: # pylint: disable=too-few-public-methods
     Args:
         key (list): A list of keys and subkeys specifing the key to change (list can be one)
         value (str): The value to change for the above key
-        value_type (str, optional): The type of value. Typedargs types supported Defaults to 'string'
+        value_type (str): The type of value. Typedargs types supported. Optional, defaults to 'string'
         path (str): The file path, relative to the Filesystem Manager's root, to the file to change
-        create_if_missing (bool, optional): Set to true to create key if the last key in the list is not found
-                Otherwise the function will throw a KeyError. Defaults to False.
+        create_if_missing (bool): Set to true to create key if the last key in the list is not found
+                Otherwise the function will throw a KeyError. Optional, defaults to False.
     """
 
     REQUIRED_RESOURCES = [('filesystem', 'filesystem_manager')]
@@ -65,11 +65,10 @@ class ModifyJsonStep: # pylint: disable=too-few-public-methods
             raise RecipeActionMissingParameter("ModifyJsonStep Parameter Missing", parameter_name='path')
 
         self._key = args.get('key')
-        self._path = str(args.get('path'))
-        self._create = type_system.convert_to_type(args.get('create_if_missing', False), 'bool')
-
         self._value_type = str(args.get('value_type', 'string'))
         self._value = type_system.convert_to_type(args.get('value'), self._value_type)
+        self._path = str(args.get('path'))
+        self._create = type_system.convert_to_type(args.get('create_if_missing', False), 'bool')
 
     def run(self, resources): # pylint: disable=missing-docstring
         root = resources['filesystem'].root

--- a/iotileship/version.py
+++ b/iotileship/version.py
@@ -1,1 +1,1 @@
-version = "1.0.6"
+version = "1.0.7"

--- a/iotileship/version.py
+++ b/iotileship/version.py
@@ -1,1 +1,1 @@
-version = "1.0.7"
+version = "1.0.6"


### PR DESCRIPTION
## Overview

Attempting to run this step to set the iotile id would write it out as a string, in quotations.
To alleviate this, this change will allow the type of the value to be set.

## Major Changes

Add additional optional argument to iotile-ship ModifyJsonStep
