### PR TITLE
Optional objcopy flags during linking

### DIFF
--- a/iotilebuild/RELEASE.md
+++ b/iotilebuild/RELEASE.md
@@ -2,6 +2,11 @@
 
 All major changes in each released version of IOTileBuild are listed here.
 
+## 3.0.8
+
+- Add optional argument in `autobuild_arm_program` to pass `objcopy` flags
+  during linking.
+
 ## 3.0.7
 
 - Add support for `iotile depends python` command to get the python dependencies

--- a/iotilebuild/iotile/build/config/site_scons/arm.py
+++ b/iotilebuild/iotile/build/config/site_scons/arm.py
@@ -17,7 +17,7 @@ import os
 from dependencies import load_dependencies
 
 
-def build_program(tile, elfname, chip, patch=True, objcopy_flags=None):
+def build_program(tile, elfname, chip, patch=True, objcopy_flags=""):
     """
     Build an ARM cortex executable
     """

--- a/iotilebuild/iotile/build/config/site_scons/arm.py
+++ b/iotilebuild/iotile/build/config/site_scons/arm.py
@@ -17,7 +17,7 @@ import os
 from dependencies import load_dependencies
 
 
-def build_program(tile, elfname, chip, patch=True):
+def build_program(tile, elfname, chip, patch=True, objcopy_flags=None):
     """
     Build an ARM cortex executable
     """
@@ -102,7 +102,7 @@ def build_program(tile, elfname, chip, patch=True):
         # Create a patched ELF including a proper checksum
         # First create a binary dump of the program flash
         outbin = prog_env.Command(prog_env['OUTPUTBIN'], os.path.join(dirs['build'], prog_env['OUTPUT']),
-                                  "arm-none-eabi-objcopy -O binary $SOURCES $TARGET")
+                                  "arm-none-eabi-objcopy -O binary {} $SOURCES $TARGET".format(objcopy_flags))
 
         # Now create a command file containing the linker command needed to patch the elf
         outhex = prog_env.Command(prog_env['PATCH_FILE'], outbin, action=prog_env.Action(checksum_creation_action,

--- a/iotilebuild/iotile/build/config/site_scons/autobuild.py
+++ b/iotilebuild/iotile/build/config/site_scons/autobuild.py
@@ -149,7 +149,7 @@ def autobuild_release(family=None):
     copy_extra_files(family.tile)
     build_python_distribution(family.tile)
 
-def autobuild_arm_program(elfname, test_dir=os.path.join('firmware', 'test'), patch=True):
+def autobuild_arm_program(elfname, test_dir=os.path.join('firmware', 'test'), patch=True, objcopy_flags=None):
     """
     Build the an ARM module for all targets and build all unit tests. If pcb files are given, also build those.
     """
@@ -157,7 +157,7 @@ def autobuild_arm_program(elfname, test_dir=os.path.join('firmware', 'test'), pa
     try:
         #Build for all targets
         family = utilities.get_family('module_settings.json')
-        family.for_all_targets(family.tile.short_name, lambda x: arm.build_program(family.tile, elfname, x, patch=patch))
+        family.for_all_targets(family.tile.short_name, lambda x: arm.build_program(family.tile, elfname, x, patch=patch, objcopy_flags=objcopy_flags))
 
         #Build all unit tests
         unit_test.build_units(os.path.join('firmware','test'), family.targets(family.tile.short_name))

--- a/iotilebuild/iotile/build/config/site_scons/autobuild.py
+++ b/iotilebuild/iotile/build/config/site_scons/autobuild.py
@@ -149,7 +149,7 @@ def autobuild_release(family=None):
     copy_extra_files(family.tile)
     build_python_distribution(family.tile)
 
-def autobuild_arm_program(elfname, test_dir=os.path.join('firmware', 'test'), patch=True, objcopy_flags=None):
+def autobuild_arm_program(elfname, test_dir=os.path.join('firmware', 'test'), patch=True, objcopy_flags=""):
     """
     Build the an ARM module for all targets and build all unit tests. If pcb files are given, also build those.
     """

--- a/iotilebuild/version.py
+++ b/iotilebuild/version.py
@@ -1,1 +1,1 @@
-version = "3.0.7"
+version = "3.0.8"


### PR DESCRIPTION
## Overview

Added a parameter that users can pass in their `SConstruct` file to add optional linker options.

Example:
```
import autobuild

elfname = 'execnrf52832'
autobuild.autobuild_arm_program(elfname, patch=True, objcopy_flags="-R .bootloader_info")
```