### PR TITLE
Spot fix byte/str concats

### DIFF
--- a/iotilesensorgraph/RELEASE.md
+++ b/iotilesensorgraph/RELEASE.md
@@ -3,6 +3,10 @@
 All major changes in each released version of iotile-sensorgraph are listed
 here.
 
+## 1.0.6
+
+- Fix py3 byte / str concat errors
+
 ## 1.0.5
 
 - Implement proper dependency major version limits.

--- a/iotilesensorgraph/iotile/sg/output_formats/config.py
+++ b/iotilesensorgraph/iotile/sg/output_formats/config.py
@@ -26,7 +26,7 @@ def format_config(sensor_graph):
             conf_type, conf_val = conf_def
 
             if conf_type == 'binary':
-                conf_val = 'hex:' + hexlify(conf_val)
+                conf_val = 'hex:' + hexlify(conf_val).decode("utf-8")
 
             cmdfile.add("set_variable", slot, conf_var, conf_type, conf_val)
 

--- a/iotilesensorgraph/iotile/sg/output_formats/snippet.py
+++ b/iotilesensorgraph/iotile/sg/output_formats/snippet.py
@@ -63,7 +63,7 @@ def format_snippet(sensor_graph):
             conf_type, conf_val = conf_def
 
             if conf_type == 'binary':
-                conf_val = 'hex:' + hexlify(conf_val)
+                conf_val = 'hex:' + hexlify(conf_val).decode('utf-8')
             elif isinstance(conf_val, str):
                 conf_val = '"%s"' % conf_val
 

--- a/iotilesensorgraph/version.py
+++ b/iotilesensorgraph/version.py
@@ -1,1 +1,1 @@
-version = "1.0.5"
+version = "1.0.6"


### PR DESCRIPTION
Closes #813

Did a search through the rest of coretools to check for this type of conditional, but didn't find anything outside of these two files.

Note that we can cut a release of this immediately since it's dependent on iotile-core<5