### PR TITLE
Update versions and release notes for iotile-core 5.0 release.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,18 +44,17 @@ jobs:
       pip install six cmdln pytest
       pip install pytest pytest-logging pytest-localserver
       pip install requests-mock pycryptodome configparser iotile-support-lib-controller-3
-      pip install "tornado>=4.5.3,<5.0.0"
       pip install -e ./iotilecore/
       pip install -e ./iotilebuild/
       pip install -e ./iotiletest/
-      pip install -e ./iotilegateway/
-      pip install -e ./iotilesensorgraph/
-      pip install -e ./iotileship/
-      pip install -e ./iotileemulate
       pip install -e ./transport_plugins/bled112/
       pip install -e ./transport_plugins/awsiot/
       pip install -e ./transport_plugins/jlink/
       pip install -e ./transport_plugins/websocket/
+      pip install -e ./iotilegateway/
+      pip install -e ./iotilesensorgraph/
+      pip install -e ./iotileship/
+      pip install -e ./iotileemulate
       pip install -e ./iotile_ext_cloud/
       python scripts/test.py test_all test
     displayName: 'pytest'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -94,14 +94,14 @@ jobs:
       pip install -e ./iotilecore/
       pip install -e ./iotilebuild/
       pip install -e ./iotiletest/
-      pip install -e ./iotilegateway/
-      pip install -e ./iotilesensorgraph/
-      pip install -e ./iotileship/
-      pip install -e ./iotileemulate
       pip install -e ./transport_plugins/bled112/
       pip install -e ./transport_plugins/awsiot/
       pip install -e ./transport_plugins/jlink/
       pip install -e ./transport_plugins/websocket/
+      pip install -e ./iotilegateway/
+      pip install -e ./iotilesensorgraph/
+      pip install -e ./iotileship/
+      pip install -e ./iotileemulate
       pip install -e ./iotile_ext_cloud/
       python scripts/test.py test_all test
     displayName: 'pytest'

--- a/iotile_ext_cloud/RELEASE.md
+++ b/iotile_ext_cloud/RELEASE.md
@@ -2,6 +2,10 @@
 
 All major changes in each released version of the iotile-ext-cloud plugin are listed here.
 
+## 1.0.6
+
+- Unpin `iotile-core` to support compatibility with version 5.0.0
+
 ## 1.0.5
 
 - Only request IOTileCloud credentials if we are actually uploading to IOTileCloud.

--- a/iotile_ext_cloud/setup.py
+++ b/iotile_ext_cloud/setup.py
@@ -8,7 +8,7 @@ setup(
     version=version.version,
     license="LGPLv3",
     install_requires=[
-        "iotile-core>=4.0.0,<5",
+        "iotile-core>=5.0.0rc1,<6",
         "iotile_cloud>=0.9.9,<2"
     ],
     python_requires=">=3.5,<4",

--- a/iotile_ext_cloud/version.py
+++ b/iotile_ext_cloud/version.py
@@ -1,1 +1,1 @@
-version = "1.0.5"
+version = "1.0.6"

--- a/iotilebuild/RELEASE.md
+++ b/iotilebuild/RELEASE.md
@@ -2,6 +2,10 @@
 
 All major changes in each released version of IOTileBuild are listed here.
 
+## 3.0.9
+
+- Unpin `iotile-core` to support version 5.0
+
 ## 3.0.8
 
 - Add optional argument in `autobuild_arm_program` to pass `objcopy` flags

--- a/iotilebuild/setup.py
+++ b/iotilebuild/setup.py
@@ -28,7 +28,7 @@ setup(
     license="LGPLv3",
     install_requires=[
         "crcmod>=1.7.0",
-        "iotile-core>=4.0.1,<5",
+        "iotile-core>=5.0.0rc1,<6",
         "sphinx>=2,<3",
         "jinja2>=2.10.0,<3",
         "breathe>=4.11.0,<5",

--- a/iotilebuild/version.py
+++ b/iotilebuild/version.py
@@ -1,1 +1,1 @@
-version = "3.0.8"
+version = "3.0.9"

--- a/iotilecore/RELEASE.md
+++ b/iotilecore/RELEASE.md
@@ -2,7 +2,7 @@
 
 All major changes in each released version of `iotile-core` are listed here.
 
-## HEAD
+## 5.0.0-rc1
 
 - Add support for background event loops using `asyncio` and migrate CMDStream
   DeviceAdapter interface.

--- a/iotilecore/version.py
+++ b/iotilecore/version.py
@@ -1,1 +1,1 @@
-version = "4.1.2"
+version = "5.0.0-rc1"

--- a/iotileemulate/RELEASE.md
+++ b/iotileemulate/RELEASE.md
@@ -2,7 +2,7 @@
 
 All major changes in each released version of iotile-emulate are listed here.
 
-## HEAD
+## 0.5.0-rc1
 
 - Refactor for compatibility with latest coretools release that integrated asyncio
   support directly into CoreTools so it doesn't need to be bolted on anymore inside

--- a/iotileemulate/setup.py
+++ b/iotileemulate/setup.py
@@ -10,8 +10,8 @@ setup(
     license="LGPLv3",
     description="IOTile Device Emulation",
     install_requires=[
-        "iotile-core>=4.0.0,<5",
-        "iotile-sensorgraph>=0.8.1"
+        "iotile-core>=5.0.0rc1,<6",
+        "iotile-sensorgraph>=0.8.1,<1"
     ],
     python_requires=">=3.5,<4",
     entry_points={'iotile.virtual_device': ['reference_1_0 = iotile.emulate.demo:DemoReferenceDevice',

--- a/iotileemulate/setup.py
+++ b/iotileemulate/setup.py
@@ -11,7 +11,7 @@ setup(
     description="IOTile Device Emulation",
     install_requires=[
         "iotile-core>=5.0.0rc1,<6",
-        "iotile-sensorgraph>=0.8.1,<1"
+        "iotile-sensorgraph>=1,<2"
     ],
     python_requires=">=3.5,<4",
     entry_points={'iotile.virtual_device': ['reference_1_0 = iotile.emulate.demo:DemoReferenceDevice',

--- a/iotileemulate/version.py
+++ b/iotileemulate/version.py
@@ -1,1 +1,1 @@
-version = "0.4.4"
+version = "0.5.0-rc1"

--- a/iotilegateway/RELEASE.md
+++ b/iotilegateway/RELEASE.md
@@ -2,7 +2,7 @@
 
 All major changes in each released version of IOTileGateway are listed here.
 
-## HEAD
+## 3.0.0-rc1
 
 - Remove tornado dependency and rely on `asyncio` instead.
 - Significant refactor of all code to port to `asyncio`.  

--- a/iotilegateway/setup.py
+++ b/iotilegateway/setup.py
@@ -21,9 +21,9 @@ setup(
     version=version.version,
     license="LGPLv3",
     install_requires=[
-        "iotile-core>=4.0.0,<5",
+        "iotile-core>=5.0.0rc1,<6",
         "msgpack>=0.6.1,<1",
-        "iotile-transport-websocket>=2.0.2"
+        "iotile-transport-websocket>=3.0.0rc1,<4"
     ],
     python_requires=">=3.5,<4",
     entry_points={

--- a/iotilegateway/version.py
+++ b/iotilegateway/version.py
@@ -1,1 +1,1 @@
-version = "2.1.1"
+version = "3.0.0-rc1"

--- a/iotilesensorgraph/RELEASE.md
+++ b/iotilesensorgraph/RELEASE.md
@@ -3,6 +3,10 @@
 All major changes in each released version of iotile-sensorgraph are listed
 here.
 
+## 1.0.7
+
+- Unpin iotile-core to support compatibility with `iotile-core` 5
+
 ## 1.0.6
 
 - Fix py3 byte / str concat errors

--- a/iotilesensorgraph/setup.py
+++ b/iotilesensorgraph/setup.py
@@ -25,7 +25,7 @@ setup(
     install_requires=[
         "pyparsing~=2.2.0",
         "toposort>=1.5,<2",
-        "iotile-core>=4.0.0,<5"
+        "iotile-core>=5.0.0rc1,<6"
     ],
     python_requires=">=3.5,<4",
     entry_points={'iotile.sg_processor': ['copy_all_a = iotile.sg.processors:copy_all_a',

--- a/iotilesensorgraph/version.py
+++ b/iotilesensorgraph/version.py
@@ -1,1 +1,1 @@
-version = "1.0.6"
+version = "1.0.7"

--- a/iotileship/RELEASE.md
+++ b/iotileship/RELEASE.md
@@ -2,9 +2,14 @@
 
 All major changes in each released version of IOTileShip are listed here.
 
+## 1.0.7
+
+- Unpin `iotile-core` to support iotile-core 5
+
 ## 1.0.6
 
 - Added the FilesystemManager resource and ModifyJsonStep
+
 ## 1.0.5
 
 - Implement proper dependency major version limits.

--- a/iotileship/setup.py
+++ b/iotileship/setup.py
@@ -22,7 +22,7 @@ setup(
     version=version.version,
     license="LGPLv3",
     install_requires=[
-        "iotile-core>=4.0.0,<5",
+        "iotile-core>=5.0.0rc1,<6",
         "pyaml>=18.11.0,<19"
     ],
     python_requires=">=3.5,<4",

--- a/iotileship/version.py
+++ b/iotileship/version.py
@@ -1,1 +1,1 @@
-version = "1.0.6"
+version = "1.0.7"

--- a/iotiletest/RELEASE.md
+++ b/iotiletest/RELEASE.md
@@ -2,6 +2,10 @@
 
 All major changes in each released version of IOTileTest are listed here.
 
+## 2.0.0-rc1
+
+- Remove old test fixtures and update for compatibility with iotile-core 5
+
 ## 1.0.2
 
 - Remove past/future/monotonic, pylint cleanup

--- a/iotiletest/version.py
+++ b/iotiletest/version.py
@@ -1,1 +1,1 @@
-version = "1.0.2"
+version = "2.0.0-rc1"

--- a/transport_plugins/awsiot/RELEASE.md
+++ b/transport_plugins/awsiot/RELEASE.md
@@ -2,6 +2,10 @@
 
 All major changes in each released version of iotile-transport-awsiot are listed here.
 
+## 1.0.4
+
+- Update for iotile-core 5.
+
 ## 1.0.3
 
 - Implement proper dependency major version limits.

--- a/transport_plugins/awsiot/setup.py
+++ b/transport_plugins/awsiot/setup.py
@@ -8,7 +8,7 @@ setup(
     version=version.version,
     license="LGPLv3",
     install_requires=[
-        "iotile-core>=4.0.0,<5",
+        "iotile-core>=5.0.0rc1,<6",
         "AWSIoTPythonSDK>=1.4.3,<2"
     ],
     python_requires=">=3.5,<4",

--- a/transport_plugins/awsiot/version.py
+++ b/transport_plugins/awsiot/version.py
@@ -1,1 +1,1 @@
-version = "1.0.3"
+version = "1.0.4"

--- a/transport_plugins/bled112/RELEASE.md
+++ b/transport_plugins/bled112/RELEASE.md
@@ -2,7 +2,7 @@
 
 All major changes in each released version of the bled112 transport plugin are listed here.
 
-## HEAD
+## 3.0.0-rc1
 
 - Remove VirtualInterface and replace with an initial implementation of `BLED112DeviceServer`.
   There is still more work to do on the device server to make it production quality but all

--- a/transport_plugins/bled112/setup.py
+++ b/transport_plugins/bled112/setup.py
@@ -7,7 +7,7 @@ setup(
     version=version.version,
     license="LGPLv3",
     install_requires=[
-        "iotile-core>=4.0.0,<5",
+        "iotile-core>=5.0.0rc1,<6",
         "pyserial>=3.4.0,<4"
     ],
     python_requires=">=3.5,<4",

--- a/transport_plugins/bled112/version.py
+++ b/transport_plugins/bled112/version.py
@@ -1,1 +1,1 @@
-version = "2.0.4"
+version = "3.0.0-rc1"

--- a/transport_plugins/jlink/RELEASE.md
+++ b/transport_plugins/jlink/RELEASE.md
@@ -3,6 +3,10 @@
 All major changes in each released version of the jlink transport plugin are
 listed here.
 
+## 1.0.8
+
+- Unpin dependency of iotile-core for iotile-core 5 release
+
 ## 1.0.7
 
 - Improved error checking/messaging for `_read_memory_map`

--- a/transport_plugins/jlink/setup.py
+++ b/transport_plugins/jlink/setup.py
@@ -9,7 +9,7 @@ setup(
     version=version.version,
     license="LGPLv3",
     install_requires=[
-        "iotile-core>=4.0.0,<5",
+        "iotile-core>=5.0.0rc1,<6",
         "pylink-square>=0.1.3,<1",
         "pylibftdi>=0.17.0,<1"
     ],

--- a/transport_plugins/jlink/version.py
+++ b/transport_plugins/jlink/version.py
@@ -1,1 +1,1 @@
-version = "1.0.7"
+version = "1.0.8"

--- a/transport_plugins/native_ble/RELEASE.md
+++ b/transport_plugins/native_ble/RELEASE.md
@@ -2,9 +2,10 @@
 
 All major changes in each released version of the native BLE transport plugin are listed here.
 
-## HEAD
+## 3.0.0-rc1
 
 - Temporarily remove `virtual_ble` interface as it is ported to be a DeviceServer.
+- Update for compatibility with `iotile-core` 5.
 
 ## 2.0.3
 

--- a/transport_plugins/native_ble/setup.py
+++ b/transport_plugins/native_ble/setup.py
@@ -8,7 +8,7 @@ setup(
     version=version.version,
     license="LGPLv3",
     install_requires=[
-        "iotile-core>=4.0.0,<5",
+        "iotile-core>=5.0.0rc1,<6",
         "bable-interface>=1.2.0,<2"
     ],
     python_requires=">=3.5,<4",

--- a/transport_plugins/native_ble/version.py
+++ b/transport_plugins/native_ble/version.py
@@ -1,1 +1,1 @@
-version = "2.0.3"
+version = "3.0.0-rc1"

--- a/transport_plugins/websocket/RELEASE.md
+++ b/transport_plugins/websocket/RELEASE.md
@@ -2,7 +2,7 @@
 
 All major changes in each released version of the websocket transport plugin are listed here.
 
-## HEAD
+## 3.0.0-rc1
 
 - Completely refactor to be based on `asyncio` and the `websockets` package
   instead of ws4py and an older package as well as tornado.

--- a/transport_plugins/websocket/setup.py
+++ b/transport_plugins/websocket/setup.py
@@ -8,7 +8,7 @@ setup(
     version=version.version,
     license="LGPLv3",
     install_requires=[
-        "iotile-core>=4.0.0,<5",
+        "iotile-core>=5.0.0rc1,<6",
         "msgpack>=0.6.1,<1"
         "msgpack>=0.6.1",
         "websockets~=7.0"

--- a/transport_plugins/websocket/version.py
+++ b/transport_plugins/websocket/version.py
@@ -1,1 +1,1 @@
-version = "2.0.3"
+version = "3.0.0-rc1"


### PR DESCRIPTION
All other packages have their setup.py files updated to support the latest iotile-core prerelease except iotile-trasnport-awsiot which needs updating.

Packages with are compatible with both iotile-core 4 and 5 have a patch bump with just the new setup.py install_requires whereas packages that required backwards incompatible changes to deal with iotile-core 5 have a major bump with an rc1 prerelease.

### Packages with Major Bump

- `iotile-core 5.0.0-rc1`
- `iotile-emulate 0.5.0-rc1`
- `iotile-gateway 3.0.0-rc1`
- `iotile-test 2.0.0-rc1`
- `iotile-transport-bled112 3.0.0-rc1`
- `iotile-transport-nativeble 3.0.0-rc1`
- `iotile-transport-websocket 3.0.0-rc1`

### Packages with Patch Bump

- `iotile-build 3.0.9`
- `iotile-ext-cloud 1.0.6`
- `iotile-sensograph 1.0.7`
- `iotile-ship 1.0.7`
- `iotile-transport-jlink 1.0.8`
- `iotile-transport-awsiot 1.0.4`