### PR TITLE
Fix releases to not have `-` character.

### DIFF
--- a/iotile_ext_cloud/RELEASE.md
+++ b/iotile_ext_cloud/RELEASE.md
@@ -2,7 +2,7 @@
 
 All major changes in each released version of the iotile-ext-cloud plugin are listed here.
 
-## 1.0.6
+## 1.0.6rc1
 
 - Unpin `iotile-core` to support compatibility with version 5.0.0
 

--- a/iotile_ext_cloud/version.py
+++ b/iotile_ext_cloud/version.py
@@ -1,1 +1,1 @@
-version = "1.0.6"
+version = "1.0.6rc1"

--- a/iotilebuild/RELEASE.md
+++ b/iotilebuild/RELEASE.md
@@ -2,7 +2,7 @@
 
 All major changes in each released version of IOTileBuild are listed here.
 
-## 3.0.9
+## 3.0.9rc1
 
 - Unpin `iotile-core` to support version 5.0
 

--- a/iotilebuild/version.py
+++ b/iotilebuild/version.py
@@ -1,1 +1,1 @@
-version = "3.0.9"
+version = "3.0.9rc1"

--- a/iotilecore/RELEASE.md
+++ b/iotilecore/RELEASE.md
@@ -2,7 +2,7 @@
 
 All major changes in each released version of `iotile-core` are listed here.
 
-## 5.0.0-rc1
+## 5.0.0rc1
 
 - Add support for background event loops using `asyncio` and migrate CMDStream
   DeviceAdapter interface.

--- a/iotileemulate/RELEASE.md
+++ b/iotileemulate/RELEASE.md
@@ -2,7 +2,7 @@
 
 All major changes in each released version of iotile-emulate are listed here.
 
-## 0.5.0-rc1
+## 0.5.0rc1
 
 - Refactor for compatibility with latest coretools release that integrated asyncio
   support directly into CoreTools so it doesn't need to be bolted on anymore inside

--- a/iotilegateway/RELEASE.md
+++ b/iotilegateway/RELEASE.md
@@ -2,7 +2,7 @@
 
 All major changes in each released version of IOTileGateway are listed here.
 
-## 3.0.0-rc1
+## 3.0.0rc1
 
 - Remove tornado dependency and rely on `asyncio` instead.
 - Significant refactor of all code to port to `asyncio`.  

--- a/iotilesensorgraph/RELEASE.md
+++ b/iotilesensorgraph/RELEASE.md
@@ -3,7 +3,7 @@
 All major changes in each released version of iotile-sensorgraph are listed
 here.
 
-## 1.0.7
+## 1.0.7rc1
 
 - Unpin iotile-core to support compatibility with `iotile-core` 5
 

--- a/iotilesensorgraph/version.py
+++ b/iotilesensorgraph/version.py
@@ -1,1 +1,1 @@
-version = "1.0.7"
+version = "1.0.7rc1"

--- a/iotileship/RELEASE.md
+++ b/iotileship/RELEASE.md
@@ -2,7 +2,7 @@
 
 All major changes in each released version of IOTileShip are listed here.
 
-## 1.0.7
+## 1.0.7rc1
 
 - Unpin `iotile-core` to support iotile-core 5
 

--- a/iotileship/version.py
+++ b/iotileship/version.py
@@ -1,1 +1,1 @@
-version = "1.0.7"
+version = "1.0.7rc1"

--- a/iotiletest/RELEASE.md
+++ b/iotiletest/RELEASE.md
@@ -2,7 +2,7 @@
 
 All major changes in each released version of IOTileTest are listed here.
 
-## 2.0.0-rc1
+## 2.0.0rc1
 
 - Remove old test fixtures and update for compatibility with iotile-core 5
 

--- a/transport_plugins/awsiot/RELEASE.md
+++ b/transport_plugins/awsiot/RELEASE.md
@@ -2,7 +2,7 @@
 
 All major changes in each released version of iotile-transport-awsiot are listed here.
 
-## 1.0.4
+## 1.0.4rc1
 
 - Update for iotile-core 5.
 

--- a/transport_plugins/awsiot/version.py
+++ b/transport_plugins/awsiot/version.py
@@ -1,1 +1,1 @@
-version = "1.0.4"
+version = "1.0.4rc1"

--- a/transport_plugins/bled112/RELEASE.md
+++ b/transport_plugins/bled112/RELEASE.md
@@ -2,7 +2,7 @@
 
 All major changes in each released version of the bled112 transport plugin are listed here.
 
-## 3.0.0-rc1
+## 3.0.0rc1
 
 - Remove VirtualInterface and replace with an initial implementation of `BLED112DeviceServer`.
   There is still more work to do on the device server to make it production quality but all

--- a/transport_plugins/bled112/version.py
+++ b/transport_plugins/bled112/version.py
@@ -1,1 +1,1 @@
-version = "3.0.0-rc1"
+version = "3.0.0rc1"

--- a/transport_plugins/jlink/RELEASE.md
+++ b/transport_plugins/jlink/RELEASE.md
@@ -3,7 +3,7 @@
 All major changes in each released version of the jlink transport plugin are
 listed here.
 
-## 1.0.8
+## 1.0.8rc1
 
 - Unpin dependency of iotile-core for iotile-core 5 release
 

--- a/transport_plugins/jlink/version.py
+++ b/transport_plugins/jlink/version.py
@@ -1,1 +1,1 @@
-version = "1.0.8"
+version = "1.0.8rc1"

--- a/transport_plugins/native_ble/RELEASE.md
+++ b/transport_plugins/native_ble/RELEASE.md
@@ -2,7 +2,7 @@
 
 All major changes in each released version of the native BLE transport plugin are listed here.
 
-## 3.0.0-rc1
+## 3.0.0rc1
 
 - Temporarily remove `virtual_ble` interface as it is ported to be a DeviceServer.
 - Update for compatibility with `iotile-core` 5.

--- a/transport_plugins/native_ble/version.py
+++ b/transport_plugins/native_ble/version.py
@@ -1,1 +1,1 @@
-version = "3.0.0-rc1"
+version = "3.0.0rc1"

--- a/transport_plugins/websocket/RELEASE.md
+++ b/transport_plugins/websocket/RELEASE.md
@@ -2,7 +2,7 @@
 
 All major changes in each released version of the websocket transport plugin are listed here.
 
-## 3.0.0-rc1
+## 3.0.0rc1
 
 - Completely refactor to be based on `asyncio` and the `websockets` package
   instead of ws4py and an older package as well as tornado.


### PR DESCRIPTION
The release scripts need the release notes to match the tags exactly so no `-rc1` in the release notes.  Also to avoid situations where upgrading CoreTools without passing `--pre` could pull in prereleases anyway, I am marking all of the new packages as `rc1`, even those that are backwards compatible since their `install_requires` would pull in `iotile-core 5.0.0rc1` when they were upgraded.