### PR TITLE
Fix cloud uploader to support very old controller firmware.

### DIFF
--- a/iotile_ext_cloud/RELEASE.md
+++ b/iotile_ext_cloud/RELEASE.md
@@ -2,6 +2,11 @@
 
 All major changes in each released version of the iotile-ext-cloud plugin are listed here.
 
+## 1.0.7
+
+- Fix issue using cloud uploader on very old controller firmwares that do not support
+  configuring the maximum report size. 
+
 ## 1.0.6
 
 - Unpin `iotile-core` to support compatibility with version 5.0.0

--- a/iotile_ext_cloud/version.py
+++ b/iotile_ext_cloud/version.py
@@ -1,1 +1,1 @@
-version = "1.0.6"
+version = "1.0.7"


### PR DESCRIPTION
Hotfix to support uploading readings from very old pods that don't support configuring the maximum report size.  This is a customer issue currently being hit in Zambia on some very old POD-1 family devices with out-of-date firmware.

The cloud uploader now supports those firmwares by making report size configuration opportunistic and not failing if the RPC is not supported.

@ekkizogloy Note that the default maximum report size on those PODs is 10k readings so if the customer has more than 10k readings they will need to do multiple uploads (making sure the data is acknowledged / processed by the cloud between each upload) in order to get all of the data off the POD.