### PR TITLE
Fix cloud_uploader app and add save_locally method

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,7 +43,7 @@ jobs:
       set PATH=%PATH%;c:\gcc\bin
       pip install six cmdln pytest
       pip install pytest pytest-logging pytest-localserver
-      pip install requests-mock pycryptodome configparser iotile-support-lib-controller-3
+      pip install requests-mock pycryptodome configparser iotile-support-lib-controller-3 iotile-support-con-nrf52832-3
       pip install -e ./iotilecore/
       pip install -e ./iotilebuild/
       pip install -e ./iotiletest/

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -89,7 +89,7 @@ jobs:
 
   - script: |
       python -m pip install six cmdln pytest
-      python -m pip install pytest pytest-logging pytest-localserver requests-mock pycryptodome configparser iotile-support-lib-controller-3
+      python -m pip install pytest pytest-logging pytest-localserver requests-mock pycryptodome configparser iotile-support-lib-controller-3 iotile-support-con-nrf52832-3
       pip install "tornado>=4.5.3,<5.0.0"
       pip install -e ./iotilecore/
       pip install -e ./iotilebuild/

--- a/iotile_ext_cloud/RELEASE.md
+++ b/iotile_ext_cloud/RELEASE.md
@@ -2,6 +2,13 @@
 
 All major changes in each released version of the iotile-ext-cloud plugin are listed here.
 
+## 1.0.9
+
+- Remove `msgpack` dependency that should be in `iotile-core`.
+- Add annotated `save_locally` method to `cloud_uploader` app that is able to save
+  all reports locally without interacting with iotile.cloud.  Also added options
+  to `download` and `upload` methods to also save reports locally.
+
 ## 1.0.8
 
 - Add `msgpack` dependency that was missing

--- a/iotile_ext_cloud/setup.py
+++ b/iotile_ext_cloud/setup.py
@@ -9,8 +9,7 @@ setup(
     license="LGPLv3",
     install_requires=[
         "iotile-core>=5.0.0,<6",
-        "iotile_cloud>=0.9.9,<2",
-        "msgpack>=0.6.1,<1"
+        "iotile_cloud>=0.9.9,<2"
     ],
     python_requires=">=3.5,<4",
     entry_points={'iotile.config_function': ['link_cloud = iotile.cloud.config:link_cloud'],

--- a/iotile_ext_cloud/test/test_cloud_uploader.py
+++ b/iotile_ext_cloud/test/test_cloud_uploader.py
@@ -1,0 +1,42 @@
+"""Test coverage of the cloud_uploader iotile app."""
+
+import os
+import pytest
+from iotile.core.hw import HardwareManager
+
+@pytest.fixture(scope='function')
+def uploader_app():
+    """A reference device with a streamer and loaded with data."""
+
+    with HardwareManager(port="emulated:reference_1_0") as hw:
+        con = hw.get(8, uuid=1, force='NRF52 ')
+        sg = con.sensor_graph()
+
+        sg.add_streamer('output 1', 'controller', False, 'hashedlist', 'telegram')
+        sg.push_many('output 1', 10, 100)
+
+        app = hw.app(name='cloud_uploader')
+
+        yield app
+
+
+def test_basic(uploader_app):
+    """Make sure we can basically download reports."""
+
+    reports = uploader_app.download(0, acknowledge=False)
+    assert len(reports) == 1
+
+
+def test_save(uploader_app, tmpdir):
+    """Make sure we can save report files locally."""
+
+    save_path = str(tmpdir.join('reports'))
+
+    assert not os.path.isdir(save_path)
+
+    uploader_app.save_locally(save_path, trigger=0)
+
+    assert os.path.isdir(save_path)
+    assert len(os.listdir(save_path)) == 1
+
+    print(os.listdir(save_path)[0])

--- a/iotile_ext_cloud/version.py
+++ b/iotile_ext_cloud/version.py
@@ -1,1 +1,1 @@
-version = "1.0.8"
+version = "1.0.9"

--- a/iotilecore/RELEASE.md
+++ b/iotilecore/RELEASE.md
@@ -2,6 +2,15 @@
 
 All major changes in each released version of `iotile-core` are listed here.
 
+## 5.0.2
+
+- Workaround bug in handling of RPCNotFound exception raised when a controller
+  RPC is not found.  It was misraised as an application RPCError instead of
+  RPCNotFound.
+
+- Add required msgpack dependency that was incorrectly in `iotile-ext-cloud` 
+  although `iotile-core` had the dependency.
+
 ## 5.0.1
 
 - Fix bug in utc_assigner.py that resulted in oscillating timestamp calculations

--- a/iotilecore/iotile/core/hw/virtual/common_types.py
+++ b/iotilecore/iotile/core/hw/virtual/common_types.py
@@ -81,9 +81,11 @@ def unpack_rpc_response(status, response=None, rpc_id=0, address=0):
     if address == 8:
         status_code &= ~(1 << 7)
 
+    # There is a firmware bug in lib_controller that misreports rpc not found exceptions
+    # as application level exceptions, not protocol level exceptions.
     if status == 0:
         raise BusyRPCResponse()
-    elif status == 2:
+    elif status == 2 or (address == 8 and status_code == 2):
         raise RPCNotFoundError("rpc %d:%04X not found" % (address, rpc_id))
     elif status == 3:
         raise RPCErrorCode(status_code)

--- a/iotilecore/setup.py
+++ b/iotilecore/setup.py
@@ -28,7 +28,8 @@ setup(
         "python-dateutil>=2.8.0,<3",
         "typedargs>=1.0.0,<2",
         "sortedcontainers~=2.1",
-        "entrypoints>=0.3.0,<1"
+        "entrypoints>=0.3.0,<1",
+        "msgpack>=0.6.1,<1"
     ],
     extras_require={
         'ui': ["asciimatics>=1.10.0,<2"]

--- a/iotilecore/version.py
+++ b/iotilecore/version.py
@@ -1,1 +1,1 @@
-version = "5.0.1"
+version = "5.0.2"

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,7 @@ deps =
     ./transport_plugins/awsiot
     ./transport_plugins/jlink
     iotile-support-lib-controller-3
+    iotile-support-con-nrf52832-3
     linux_only: ./transport_plugins/native_ble
     ./iotile_ext_cloud
     requests-mock


### PR DESCRIPTION
## Overview

This PR works around a firmware issue where the controller does not properly raise `RPCNotFound` when an RPC isn't found and instead raises `RPCError`. This caused a bug in `cloud_uploader` where it checks if a specific RPC is implemented.  The check fails inappropriately because it looks for `RPCNotFound` exception, which is correct, but an incorrect exception is raised.

The fix is to properly raise `RPCNotFound` from the controller tile.
 
@ekkizogloy This PR also adds a `save_locally` method to `cloud_uploader` that **does not interact with iotile cloud in any way** and just saves the same reports that would be uploaded locally to your computer.