### PR TITLE
Fix unstable with large lengths

### DIFF
--- a/transport_plugins/jlink/RELEASE.md
+++ b/transport_plugins/jlink/RELEASE.md
@@ -3,6 +3,10 @@
 All major changes in each released version of the jlink transport plugin are
 listed here.
 
+## 1.0.9
+
+- Fixed bug in memory dump tool to correctly iterate read over large sizes
+
 ## 1.0.8
 
 - Unpin dependency of iotile-core for iotile-core 5 release

--- a/transport_plugins/jlink/iotile_transport_jlink/jlink_background.py
+++ b/transport_plugins/jlink/iotile_transport_jlink/jlink_background.py
@@ -278,13 +278,13 @@ class JLinkControlThread(threading.Thread):
  
                 logger.info("BKPT hit, writing SPI dump command now...")
                 logger.info("At PC: %s", hex(self._jlink.register_read(pc_reg)))
-                self._write_ff_dump_cmd(start_addr, data_length)
+                self._write_ff_dump_cmd(start_addr + bytes_dumped, bytes_to_dump)
 
                 self._continue()
 
                 logger.info("BKPT hit, reading response buffer address...")
                 logger.info("At PC: %s", hex(self._jlink.register_read(pc_reg)))
-                memory += self._read_ff_dump_resp(data_length)
+                memory += self._read_ff_dump_resp(bytes_to_dump)
 
                 bytes_dumped += bytes_to_dump
                 self._continue()

--- a/transport_plugins/jlink/version.py
+++ b/transport_plugins/jlink/version.py
@@ -1,1 +1,1 @@
-version = "1.0.8"
+version = "1.0.9"


### PR DESCRIPTION
## Overview

Bug fix. Dumping memory was unstable or didn't work for large sizes. The injectable code that does the flash forensics allows reading sizes of at most 4096. My tool was violating this rule.

## Major Changes

Had a flaw in the implementation logic. The logic was to read a variable size from a specific memory region, and if it was larger than 4096 bytes, the tool should repeat reads until the desired length has been read. I had the setup for it, but I did not implement it correctly. I had saved the offset variable that determined the next read location/size, but didn't use it for some reason.


