### PR TITLE
Augment TileBasedDevice to have some virtual controller functionality

### DIFF
--- a/iotilecore/RELEASE.md
+++ b/iotilecore/RELEASE.md
@@ -2,6 +2,12 @@
 
 All major changes in each released version of `iotile-core` are listed here.
 
+## 5.0.4
+
+- Augments the TileBasedDevice to respond to certain controller RPCs. It has the basic
+  utilities from the tile_manager.
+- Updates the event loop to have a more robust check for uncancelled tasks on shutdown
+
 ## 5.0.3
 
 - `run_executor` can now be used in finalizer code
@@ -12,7 +18,7 @@ All major changes in each released version of `iotile-core` are listed here.
   RPC is not found.  It was misraised as an application RPCError instead of
   RPCNotFound.
 
-- Add required msgpack dependency that was incorrectly in `iotile-ext-cloud` 
+- Add required msgpack dependency that was incorrectly in `iotile-ext-cloud`
   although `iotile-core` had the dependency.
 
 ## 5.0.1
@@ -45,8 +51,8 @@ All major changes in each released version of `iotile-core` are listed here.
 ## 4.1.0
 
 - Update UTCAssigner with more test coverage and add fix_report() method that
-  will fix all readings inside of a SignedListReport with memoization to 
-  speed up the fixing process. 
+  will fix all readings inside of a SignedListReport with memoization to
+  speed up the fixing process.
 
 - Update UTCAssigner logic to check both directions from a reading to find out
   which part produces a more exact UTC timestamp, choosing the best one
@@ -80,7 +86,7 @@ All major changes in each released version of `iotile-core` are listed here.
 
 ## 3.27.2
 
-- Fix support for `support_package` products in `IOTile` object and 
+- Fix support for `support_package` products in `IOTile` object and
   `ComponentRegistry`.
 
 ## 3.27.1
@@ -127,15 +133,15 @@ All major changes in each released version of `iotile-core` are listed here.
   stored with the virtual environment, speeding up small program invocations
   by removing the necessity to enumerate all installed packages.
 
-- Make log messages from virtual_device script less chatty by removing audit 
+- Make log messages from virtual_device script less chatty by removing audit
   log messages by default.
 
-- Remove nuisance log warning when loading extensions by name (Issue #637) 
+- Remove nuisance log warning when loading extensions by name (Issue #637)
 
 - Fix problem loading `module_settings.json` files for components that had been
   built before on python 3.  (Issue #636)
 
-- Adds support for complex python support wheels in ComponentRegistry.  
+- Adds support for complex python support wheels in ComponentRegistry.
   Submodules inside the support package are now imported correctly so that
   relative imports among the modules work.
 
@@ -169,9 +175,9 @@ All major changes in each released version of `iotile-core` are listed here.
 ## 3.24.2
 
 - Add a better exception when the return value received from an RPC does not
-  match the format that we expect.  
+  match the format that we expect.
 
-- Add a workaround for a controller firmware bug so that CommandNotFound 
+- Add a workaround for a controller firmware bug so that CommandNotFound
   exceptions are properly raised when an RPC does not exist on the controller
   tile.
 
@@ -235,7 +241,7 @@ All major changes in each released version of `iotile-core` are listed here.
 
 ## 3.22.11
 
-- Fix Ctrl-C behavior of watch_broadcasts to not hang on exit sometimes and 
+- Fix Ctrl-C behavior of watch_broadcasts to not hang on exit sometimes and
   properly double buffer the display to remove the flickering.  Also update the
   UI at 50 ms rather than 500 ms to increase responsiveness.
 
@@ -248,7 +254,7 @@ All major changes in each released version of `iotile-core` are listed here.
 ## 3.22.9
 
 - Fix the registry function `list_config` so that the string 'config:' does not
-  prefix each variable name in the list. 
+  prefix each variable name in the list.
 
 ## 3.22.8
 
@@ -272,7 +278,7 @@ All major changes in each released version of `iotile-core` are listed here.
 
 - Make asciimatics an optional feature since it includes a large dependency
   on Pillow which requires compilation on linux.  Now, if you want the fancy
-  command line ui, you need to install it using: 
+  command line ui, you need to install it using:
   `pip install iotilecore[ui]`
 
 ## 3.22.3
@@ -288,7 +294,7 @@ All major changes in each released version of `iotile-core` are listed here.
 
 - Update device_updater app to reboot the device by default
 - Update AdapterStream to better detect unicode strings incorrectly passed to
-  send_highspeed on python 3. 
+  send_highspeed on python 3.
 
 ## 3.22.0
 
@@ -364,14 +370,14 @@ dependencies. (Issue #387)
 - Add support for IOTileApp objects that match the app tag on an iotile device
   and provide a high level API container for accessing functionality that is
   not just implemented by a single tile.  (Issue #303)
-- Add support for waiting for a certain amount of tracing data like 
+- Add support for waiting for a certain amount of tracing data like
   wait_reports.  (Issue #348)
 - Cleanup the enable_streaming and enable_tracing code to allow it to be called
   multiple times per HardwareManager connection without breaking.
 
 ## 3.18.3
 
-- Add support for generating PEP440 compliant version strings in 
+- Add support for generating PEP440 compliant version strings in
   SemanticVersion. (Issue #342)
 
 ## 3.18.2

--- a/iotilecore/iotile/core/hw/virtual/tile_based_device.py
+++ b/iotilecore/iotile/core/hw/virtual/tile_based_device.py
@@ -2,11 +2,10 @@
 
 The device handles RPCs by dispatching them to tiles configured using a config dictionary.
 """
-
-from iotile.core.exceptions import ArgumentError
-from ..exceptions import RPCInvalidIDError, RPCNotFoundError, TileNotFoundError
+from iotile.core.hw.virtual import tile_rpc
 from .virtualdevice_standard import StandardVirtualDevice
 from .virtualtile import VirtualTile
+
 
 class TileBasedVirtualDevice(StandardVirtualDevice):
     """A VirtualDevice composed of one or more tiles.
@@ -14,10 +13,14 @@ class TileBasedVirtualDevice(StandardVirtualDevice):
     Args:
         args (dict): A dictionary that lists the tiles that
             should be loaded to create this virtual device.
+        override_controller (bool): Controls whether the virtual controller
+            gets added or not. Defaults to false.
     """
 
-    def __init__(self, args):
+    def __init__(self, args, override_controller=False):
         iotile_id = args.get('iotile_id')
+
+        con_args = args
 
         if isinstance(iotile_id, str):
             iotile_id = int(iotile_id, 16)
@@ -34,6 +37,13 @@ class TileBasedVirtualDevice(StandardVirtualDevice):
             tile = tile_type(address, args, device=self)
 
             self.add_tile(address, tile)
+
+        # Add a controller tile
+        if not override_controller:
+            tile = VirtualController(8, con_args, device=self)
+            self.add_tile(8, tile)
+            tile.tiles = self._tiles
+            tile.prep_count()
 
     def start(self, channel):
         """Start running this virtual device including any necessary worker threads.
@@ -55,3 +65,76 @@ class TileBasedVirtualDevice(StandardVirtualDevice):
             tile.stop()
 
         super(TileBasedVirtualDevice, self).stop()
+
+
+class VirtualController(VirtualTile):
+    """A tile based virtual controller. Contains a very limited subset of controller RPCs currently.
+
+    When using it, you should force your program to see it as an 'NRF52 ' proxy, because vircon is
+    not an actual proxy object (there are no unique RPCs here outside of the base controller spec).
+    The syntax for doing this is something like:
+
+    get 8 -f 'NRF52 '
+    (assuming you are connected to the device already).
+
+    To use the RPCs, you should use the test_interface calls for get_info and set_version.
+    """
+
+    def __init__(self, address, config, device):
+
+        self.config = config
+        super(VirtualController, self).__init__(address, 'vircon')
+
+        self.tile_list = []
+
+    def prep_count(self):
+        """Put the actual tile indices in to a list that complies with the count_tiles and describe_tile API"""
+        for tile in self.tiles:
+            self.tile_list.append(tile)
+
+    @tile_rpc(0x0004, "", "H6sBBBB")
+    def status(self):
+        """Return a dummy status"""
+        return [0xFFFF, "vircon", 1, 0, 0, 1]
+
+    @tile_rpc(0x0002, "", "10s")
+    def hardware_version(self):
+        """Return the hardware identification string."""
+        return [b'virtualcon']
+
+    @tile_rpc(0x2a01, "", "H")
+    def count_tiles(self):
+        """Count the number of registered tiles including the controller"""
+        return [len(self.tile_list)]
+
+    @tile_rpc(0x2a02, "H", "3B6s6BBL")
+    def describe_tile(self, index):
+        """Describes a tile at the given index
+
+        The information returned is the exact same data as what REGISTER_TILE
+        includes as its argument.
+
+        Args:
+        - uint16_t: The index of the tile you wish to describe.  Must be less than
+            what COUNT_TILES returns.
+
+        Returns:
+        - uint8_t: a numerical hardware type identifer for the processor the tile is
+            running on.
+        - two bytes: (major, minor) API level of the tile fwutive running on this
+            tile.  The api version is encoded with the major version as a byte
+            followed by the minor version.
+        - 6-character string: The tile firmware identifier that is used to match it
+            with the correct proxy module by HardwareManager.
+        - 3 bytes: (major, minor, patch) version identifier of the application
+            firmware running on this tile.
+        - 3 bytes: (major, minor, patch) version identifier of the tile executive
+            running on this tile.
+        - uint8_t: The slot number that refers to the physical location of this tile
+            on the board.  It is used to assign the tile a fixed address on the
+            TileBus.
+        - uint32_t: A unique identifier for this tile, if the tile supports unique
+            identifiers.
+        """
+        tile = self.tiles[self.tile_list[index]]
+        return (0, 0, 0, tile.name, 0, 0, 0, 0, 0, 0, self.tile_list[index], 0)

--- a/iotilecore/test/test_hw/tile_config.json
+++ b/iotilecore/test/test_hw/tile_config.json
@@ -1,5 +1,5 @@
 {
-	"device": 
+	"device":
 	{
 		"iotile_id": 1,
 		"tiles":
@@ -11,7 +11,7 @@
 			},
 
 			{
-				"address": 8,
+				"address": 9,
 				"name": "test/test_hw/virtual_tile.py",
 				"args": {}
 			},

--- a/iotilecore/version.py
+++ b/iotilecore/version.py
@@ -1,1 +1,1 @@
-version = "5.0.3"
+version = "5.0.4"


### PR DESCRIPTION

The goal of this feature is to enable products to use tie tile_manager functionality of a controller
without actually having a controller (virtual devices).

## Overview

These changes cover one areas:
- Responding to tile_manager requests for tile details on each slot

## Major Changes

There is a new VirtualController class in the tile_based_device.py file that is included in all TileBasedDevices. By default you do not need to complete anything and placeholders will be used. The tile_manager will function always, however.

### Reason for version bump

This virtual controller has an intended use case in the next release of one of our products soon and we need a released version of coretools to install it. It introduces new endpoints but doesn't modify existing ones, which warrants a patch bump.