### PR TITLE
Fix jlink multiple frame read

### DIFF
--- a/iotilecore/iotile/core/utilities/async_tools/event_loop.py
+++ b/iotilecore/iotile/core/utilities/async_tools/event_loop.py
@@ -288,10 +288,9 @@ class BackgroundEventLoop:
         running, it will not do anything.
         """
 
-        if self.stopping:
-            raise LoopStoppingError("Cannot perform action while loop is stopping.")
-
         if not self.loop:
+            if self.stopping:
+                raise LoopStoppingError("Cannot perform action while loop is stopping.")
             self._logger.debug("Starting event loop")
             self.loop = asyncio.new_event_loop()
             self.thread = threading.Thread(target=self._loop_thread_main, name=aug, daemon=True)

--- a/iotilecore/iotile/core/utilities/async_tools/event_loop.py
+++ b/iotilecore/iotile/core/utilities/async_tools/event_loop.py
@@ -291,6 +291,7 @@ class BackgroundEventLoop:
         if not self.loop:
             if self.stopping:
                 raise LoopStoppingError("Cannot perform action while loop is stopping.")
+
             self._logger.debug("Starting event loop")
             self.loop = asyncio.new_event_loop()
             self.thread = threading.Thread(target=self._loop_thread_main, name=aug, daemon=True)

--- a/transport_plugins/jlink/iotile_transport_jlink/jlink.py
+++ b/transport_plugins/jlink/iotile_transport_jlink/jlink.py
@@ -344,15 +344,6 @@ class JLinkAdapter(StandardDeviceAdapter):
             await self._jlink_async.change_state_flag(
                 self._control_info, AsyncJLink.TRACE_BIT, True)
         elif interface == "streaming":
-            # status = await self._jlink_async.send_rpc(
-            #     self._device_info, self._control_info,
-            #     8, 0x0004, b'', timeout=0.3)
-            # logger.debug(status['payload'])
-            # status = await self.send_rpc(
-            #     conn_id, 8, 0x0004, b'', timeout=0.3)
-            # logger.debug(status)
-            # logger.debug(self._device_info)
-            # logger.debug(self._control_info)
             await self._jlink_async.change_state_flag(
                 self._control_info, AsyncJLink.STREAM_BIT, True)
             await self._jlink_async.notify_sensor_graph(

--- a/transport_plugins/jlink/iotile_transport_jlink/jlink.py
+++ b/transport_plugins/jlink/iotile_transport_jlink/jlink.py
@@ -337,9 +337,6 @@ class JLinkAdapter(StandardDeviceAdapter):
 
         self.opened_interfaces[interface] = True
 
-        if interface == "tracing" or interface == "streaming":
-            await self.check_interface_compatibility(conn_id)
-
         if interface == "tracing":
             await self._jlink_async.change_state_flag(
                 self._control_info, AsyncJLink.TRACE_BIT, True)
@@ -374,11 +371,6 @@ class JLinkAdapter(StandardDeviceAdapter):
 
         if interface in JLinkAdapter.POLLING_INTERFACES:
             await self._jlink_async.stop_polling()
-
-    async def check_interface_compatibility(self, conn_id):
-        status = await self.send_rpc(
-            conn_id, 8, 0x0004, b'', timeout=0.3)
-        logger.debug(status)
 
     async def send_rpc(self, conn_id, address, rpc_id, payload, timeout):
 

--- a/transport_plugins/jlink/iotile_transport_jlink/jlink.py
+++ b/transport_plugins/jlink/iotile_transport_jlink/jlink.py
@@ -325,10 +325,22 @@ class JLinkAdapter(StandardDeviceAdapter):
 
         self.opened_interfaces[interface] = True
 
+        if interface == "tracing" or interface == "streaming":
+            await self.check_interface_compatibility(conn_id)
+
         if interface == "tracing":
             await self._jlink_async.change_state_flag(
                 self._control_info, AsyncJLink.TRACE_BIT, True)
         elif interface == "streaming":
+            # status = await self._jlink_async.send_rpc(
+            #     self._device_info, self._control_info,
+            #     8, 0x0004, b'', timeout=0.3)
+            # logger.debug(status['payload'])
+            # status = await self.send_rpc(
+            #     conn_id, 8, 0x0004, b'', timeout=0.3)
+            # logger.debug(status)
+            # logger.debug(self._device_info)
+            # logger.debug(self._control_info)
             await self._jlink_async.change_state_flag(
                 self._control_info, AsyncJLink.STREAM_BIT, True)
             await self._jlink_async.notify_sensor_graph(
@@ -359,6 +371,11 @@ class JLinkAdapter(StandardDeviceAdapter):
 
         if interface in JLinkAdapter.POLLING_INTERFACES:
             await self._jlink_async.stop_polling()
+
+    async def check_interface_compatibility(self, conn_id):
+        status = await self.send_rpc(
+            conn_id, 8, 0x0004, b'', timeout=0.3)
+        logger.debug(status)
 
     async def send_rpc(self, conn_id, address, rpc_id, payload, timeout):
 

--- a/transport_plugins/jlink/iotile_transport_jlink/jlink_background.py
+++ b/transport_plugins/jlink/iotile_transport_jlink/jlink_background.py
@@ -324,6 +324,7 @@ class AsyncJLink:
     async def close_jlink(self):
         if self._maintenance_task is not None:
             await self._maintenance_task.stop()
+
         if self._maintenance_counter:
             logger.error("Closing jlink while maintenance still running!")
 


### PR DESCRIPTION
## Main Changes
### event_loop.py
- Allow `run_executor` to be run in coroutine finalizer function
### jlink.py
- Changed `disconnect` logic to close "rpc" interface last
- Added task to handle when iotile is `quit` to cleanup nicely
### jlink_background.py
- Changed frame reading logic from one at a time to all frames available in queue at once to minimize jlink memory read/writes
- Performance enhancement by removing delays
- Fixed coroutine quitting issues because of while loop in `maintenance_coroutine`
