### PR TITLE
Fix tile_based_device controller override

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -191,7 +191,7 @@ indent-after-paren=4
 indent-string='    '
 
 # Maximum number of characters on a single line.
-max-line-length=240
+max-line-length=120
 
 # Maximum number of lines in a module
 max-module-lines=1000

--- a/iotilecore/RELEASE.md
+++ b/iotilecore/RELEASE.md
@@ -2,6 +2,11 @@
 
 All major changes in each released version of `iotile-core` are listed here.
 
+## 5.0.5
+
+- Fix TileBasedDevice controller override
+- Update .pylintrc
+
 ## 5.0.4
 
 - Augments the TileBasedDevice to respond to certain controller RPCs. It has the basic

--- a/iotilecore/iotile/core/hw/virtual/tile_based_device.py
+++ b/iotilecore/iotile/core/hw/virtual/tile_based_device.py
@@ -17,8 +17,10 @@ class TileBasedVirtualDevice(StandardVirtualDevice):
             gets added or not. Defaults to false.
     """
 
-    def __init__(self, args, override_controller=False):
+    def __init__(self, args):
         iotile_id = args.get('iotile_id')
+
+        override_controller = args.get('override_controller', False)
 
         con_args = args
 

--- a/iotilecore/version.py
+++ b/iotilecore/version.py
@@ -1,1 +1,1 @@
-version = "5.0.4"
+version = "5.0.5"


### PR DESCRIPTION
Small fix in the tile_based_device that actually allows the controller override to take place.
Also pushes the pylintrc change.