### PR TITLE
Add support for passing kwargs down to Api() object.

### DIFF
--- a/iotile_ext_cloud/RELEASE.md
+++ b/iotile_ext_cloud/RELEASE.md
@@ -2,6 +2,12 @@
 
 All major changes in each released version of the iotile-ext-cloud plugin are listed here.
 
+## 1.0.10
+
+- Add support for passing kwargs down to Api() from underlying iotile-cloud package.
+  This allows configuring connection retries and timeouts when using the highlevel
+  `IOTileCloud` object.
+
 ## 1.0.9
 
 - Remove `msgpack` dependency that should be in `iotile-core`.

--- a/iotile_ext_cloud/iotile/cloud/cloud.py
+++ b/iotile_ext_cloud/iotile/cloud/cloud.py
@@ -3,10 +3,9 @@
 from io import BytesIO
 import getpass
 import datetime
+from collections import namedtuple
 from dateutil.tz import tzutc
 import dateutil.parser
-from collections import namedtuple
-import requests
 
 from iotile_cloud.api.connection import Api
 from iotile_cloud.api.exceptions import RestHttpBaseException, HttpNotFoundError
@@ -159,7 +158,7 @@ class IOTileCloud:
     def check_time(self, max_slop=300):
         """ Check if current system time is consistent with iotile.cloud time"""
 
-        cloud_time = requests.get('https://iotile.cloud/api/v1/server/').json().get('now', None)
+        cloud_time = self.api.session.get('https://iotile.cloud/api/v1/server/').json().get('now', None)
         if cloud_time is None:
             raise DataError("No date header returned from iotile.cloud")
 
@@ -352,7 +351,8 @@ class IOTileCloud:
         authorization_str = '{0} {1}'.format(self.token_type, self.token)
         headers['Authorization'] = authorization_str
 
-        resp = requests.post(resource.url(), files=payload, headers=headers, params={'timestamp': timestamp})
+        resp = self.api.session.post(resource.url(), files=payload, headers=headers,
+                                     params={'timestamp': timestamp})
 
         count = resource._process_response(resp)['count']
         return count
@@ -429,7 +429,7 @@ class IOTileCloud:
 
         url = '{}/api/v1/auth/api-jwt-refresh/'.format(domain)
 
-        resp = requests.post(url, json={'token': self.token})
+        resp = self.api.session.post(url, json={'token': self.token})
         if resp.status_code != 200:
             raise ExternalError("Could not refresh token", error_code=resp.status_code)
 

--- a/iotile_ext_cloud/iotile/cloud/cloud.py
+++ b/iotile_ext_cloud/iotile/cloud/cloud.py
@@ -42,14 +42,14 @@ class IOTileCloud:
 
     DEVICE_TOKEN_TYPE = 'a-jwt'
 
-    def __init__(self, domain=None, username=None):
+    def __init__(self, domain=None, username=None, **kwargs):
         reg = ComponentRegistry()
         conf = ConfigManager()
 
         if domain is None:
             domain = conf.get('cloud:server')
 
-        self.api = Api(domain=domain)
+        self.api = Api(domain=domain, **kwargs)
 
         try:
             token = reg.get_config('arch:cloud_token')

--- a/iotile_ext_cloud/iotile/cloud/cloud.py
+++ b/iotile_ext_cloud/iotile/cloud/cloud.py
@@ -48,6 +48,8 @@ class IOTileCloud:
         if domain is None:
             domain = conf.get('cloud:server')
 
+        self._domain = domain
+
         self.api = Api(domain=domain, **kwargs)
 
         try:
@@ -158,9 +160,9 @@ class IOTileCloud:
     def check_time(self, max_slop=300):
         """ Check if current system time is consistent with iotile.cloud time"""
 
-        cloud_time = self.api.session.get('https://iotile.cloud/api/v1/server/').json().get('now', None)
+        cloud_time = self.api.session.get('{domain}/api/v1/server/'.format(self._domain)).json().get('now', None)
         if cloud_time is None:
-            raise DataError("No date header returned from iotile.cloud")
+            raise DataError("No date header returned from iotile cloud", domain=self._domain)
 
         curtime = datetime.datetime.now(tzutc())
         delta = dateutil.parser.parse(cloud_time) - curtime

--- a/iotile_ext_cloud/iotile/cloud/cloud.py
+++ b/iotile_ext_cloud/iotile/cloud/cloud.py
@@ -48,9 +48,8 @@ class IOTileCloud:
         if domain is None:
             domain = conf.get('cloud:server')
 
-        self._domain = domain
-
         self.api = Api(domain=domain, **kwargs)
+        self._domain = self.api.domain
 
         try:
             token = reg.get_config('arch:cloud_token')
@@ -160,7 +159,7 @@ class IOTileCloud:
     def check_time(self, max_slop=300):
         """ Check if current system time is consistent with iotile.cloud time"""
 
-        cloud_time = self.api.session.get('{domain}/api/v1/server/'.format(self._domain)).json().get('now', None)
+        cloud_time = self.api.session.get('{}/api/v1/server/'.format(self._domain)).json().get('now', None)
         if cloud_time is None:
             raise DataError("No date header returned from iotile cloud", domain=self._domain)
 

--- a/iotile_ext_cloud/setup.py
+++ b/iotile_ext_cloud/setup.py
@@ -9,7 +9,7 @@ setup(
     license="LGPLv3",
     install_requires=[
         "iotile-core>=5.0.0,<6",
-        "iotile_cloud>=0.9.9,<2"
+        "iotile_cloud>=0.9.11,<2"
     ],
     python_requires=">=3.5,<4",
     entry_points={'iotile.config_function': ['link_cloud = iotile.cloud.config:link_cloud'],

--- a/iotile_ext_cloud/version.py
+++ b/iotile_ext_cloud/version.py
@@ -1,1 +1,1 @@
-version = "1.0.9"
+version = "1.0.10"


### PR DESCRIPTION
This PR adds support to `iotile-ext-cloud` to pass additional arguments to the `iotile-cloud` Api() object that is used to make rest calls to iotile.cloud.  This is needed to be able to configure the `timeout` and `retries` parameters that were added to control what happens in the case of transient network failures.

Previously, `iotile-cloud` didn't support automatic retries on connection errors, now it does so we need this change to be able to use that ability in CoreTools.

See https://github.com/iotile/python_iotile_cloud/pull/62

This is an urgent hotfix to resolve a stability issue with an uploader running inside a network that periodically chooses to drop connections to iotile.cloud.