### PR TITLE
fix: add trailing Z when isoformatting datetime

### DIFF
--- a/iotilecore/iotile/core/hw/reports/flexible_dictionary.py
+++ b/iotilecore/iotile/core/hw/reports/flexible_dictionary.py
@@ -114,6 +114,6 @@ class FlexibleDictionaryReport(IOTileReport):
 def _encode_datetime(obj):
     """Pack a datetime into an isoformat string."""
     if isinstance(obj, datetime.datetime):
-        return obj.isoformat()
+        return obj.isoformat() + 'Z'
 
     return obj


### PR DESCRIPTION
## Overview

Adds a trailing Z to serialized timestamps in `FlexibleDictionaryReport` 

### Additional Notes

- Adds a `tzinfo` marker when using `dateutil.parser.parse`

