### PR TITLE
Full Release JLink streaming from RC

### DIFF
--- a/transport_plugins/jlink/RELEASE.md
+++ b/transport_plugins/jlink/RELEASE.md
@@ -3,7 +3,7 @@
 All major changes in each released version of the jlink transport plugin are
 listed here.
 
-## 1.1.0rc1
+## 1.1.0
 
 - JLink adapter support for streaming and tracing
 

--- a/transport_plugins/jlink/version.py
+++ b/transport_plugins/jlink/version.py
@@ -1,1 +1,1 @@
-version = "1.1.0rc1"
+version = "1.1.0"


### PR DESCRIPTION
Initial RC was approved [here](https://github.com/iotile/coretools/pull/856).