### PR TITLE
Add ability to start a periodic coroutine in the SharedLoop, and test

### DIFF
--- a/iotilecore/RELEASE.md
+++ b/iotilecore/RELEASE.md
@@ -2,6 +2,10 @@
 
 All major changes in each released version of `iotile-core` are listed here.
 
+## HEAD
+
+- Add ability to start periodic coroutines with the SharedLoop
+
 ## 5.0.7
 
 - Add proxy matching with tile version


### PR DESCRIPTION
## Overview

So far, we've been scheduling our periodic coroutines by using while loops, such as:
```python
async def _run_analytics_report(interval=5):
  while 1:
    compute_metrics()
    await asyncio.sleep(interval)
```

This works for many cases where exactness of an interval isn't a critical factor, and when the functional logic time is insignificant compared to the interval. In production, you'd probably want a bit more sugar to handle exceptions (or you'll exit the function) and interact with your logging utilities.

However, you may want to decouple the repeat interval from the computation, and/or not have drift (though we are always subject to jitter). 

## Major Changes

There is a new ability to pass a coroutine in to a function that you want to run on a periodic basis. 

```python
    def launch_periodic_coroutine(self, cor, interval, *args, handle_exceptions=True, **kwargs):
```

You need to send it a coroutine (just the function, not the actual instantiated object -- i.e. send it `_run_analytics_report` not `_run_analytics_report()`)

The complete invokation might be:
```python
from iotile.core.utilities.async_tools.event_loop import SharedLoop

SharedLoop.launch_periodic_coroutine(_run_analytics_report, 300)
```


This repeatable can be cancelled at any time in the future by calling `.cancel()` on the `Future` or `asyncio.Task` that gets returned to you (depending on whether you're inside or outside of the event loop). 

If you want the repeatable to exit if an exception happens, you should send in the `handle_exceptions` as `False`. This is useful during development in particular while ironing out the repeatable function.

This function is drift-corrected, but due to the nature of when tasks get scheduled, might have start time and end time jitter.

## Additional Notes

An example use case might be if we want to track the number of devices we see in our list of visible/scannable PODs, and send an alert any time that number drifts below a set value. For example, in your script you may define a periodic function such as:

(note that you must have this code branch/PR pulled to run this at the time of writing -- it's not in master or any release)
```python
from iotile.core.hw import HardwareManager
from iotile.core.utilities.async_tools.event_loop import SharedLoop

import time

global pod_count  # don't do this - globals are bad, just a demo
pod_count = 0

async def _check_POD_count(alert_level=5):
  if pod_count < alert_level:
    print("We are seeing fewer pods than we expect. Only {} scannable, we expect at least {}.".format(pod_count, alert_level))
    # Send an email or slack message? Post to MQTT?
  else:
    print("we see {} PODs".format(pod_count))

def main():
  global pod_count  # don't do this - globals are bad, just a demo
  with HardwareManager(port='bled112') as hw:
    hw.scan()
    time.sleep(1)  # Let things settle a bit
    pod_count = len(hw.scan())

    SharedLoop.launch_periodic_coroutine(_check_POD_count, 5)
    while 1:
      pod_count = len(hw.scan())
      time.sleep(1) . # For demonstration purposes, scan more often than we alert check for.

main()

```
