### PR TITLE
Fixing text underline for iotile-transport-socket-lib

### DIFF
--- a/transport_plugins/socket_lib/setup.py
+++ b/transport_plugins/socket_lib/setup.py
@@ -40,7 +40,7 @@ setup(
         ],
     long_description="""\
 IOTile Transport Socket Library Plugin
----------------------------------
+--------------------------------------
 
 A python plug for IOTile CoreTools that provides common message formats, packing routines and
 other code that is useful for performing iotile operations via socket or 


### PR DESCRIPTION
## Overview

Fixes the format of the long description of the package so it can be uploaded to Pypi.
