### PR TITLE
Added optional awaitable to return a "pointer" to the device

### DIFF
--- a/iotilecore/iotile/core/scripts/virtualdev_script.py
+++ b/iotilecore/iotile/core/scripts/virtualdev_script.py
@@ -47,7 +47,13 @@ def configure_logging(verbose):
 
 
 def main(argv=None, loop=SharedLoop, device_f=None):
-    """Serve access to a virtual IOTile device using a virtual iotile interface."""
+    """Serve access to a virtual IOTile device using a virtual iotile interface.
+
+    Args:
+        argv(list): Arguments to pass to this script. If none, use args passed in via sys.argv
+        loop(BackgroundLoop): The loop to launch tasks from. Defaults to the SharedLoop
+        device_f(asyncio.future): Optional future that will return a reference to the virt device once initialized
+    """
 
     if argv is None:
         argv = sys.argv[1:]

--- a/iotilecore/iotile/core/scripts/virtualdev_script.py
+++ b/iotilecore/iotile/core/scripts/virtualdev_script.py
@@ -46,7 +46,7 @@ def configure_logging(verbose):
         root.addHandler(logging.NullHandler())
 
 
-def main(argv=None, loop=SharedLoop):
+def main(argv=None, loop=SharedLoop, device_f=None):
     """Serve access to a virtual IOTile device using a virtual iotile interface."""
 
     if argv is None:
@@ -134,8 +134,10 @@ def main(argv=None, loop=SharedLoop):
             raise
 
         started = True
-
         print("Starting to serve virtual IOTile device")
+        if device_f:
+            device_f.set_result(device)
+
 
         if stop_immediately:
             return 0


### PR DESCRIPTION
This script allows arch-node-tasks (and presumably others) to launch a virtual device, but doesn't return any references to the virtual device it creates, preventing the calling task from accessing it's info (such as any config values it's loaded in). This PR adds an optional future that will be set to the virtual device once it's initialized. Since the script launches coroutines then sleeps forever, asyncio futures seemed the best (only?) to get the reference back for something to use.

There is no functionality change to the script if the new argument isn't specified.

