### PR TITLE
Fix asyncio mixup in BaseVirtualDevice (need to await a coroutine)

### DIFF
--- a/doc/source/tutorials/streaming-data.rst
+++ b/doc/source/tutorials/streaming-data.rst
@@ -150,10 +150,10 @@ Just like in the first tutorial, create a class for the virtual device::
     """Virtual IOTile device for CoreTools Walkthrough."""
 
     import random
-    from iotile.core.hw.virtual.virtualdevice import VirtualIOTileDevice
+    from iotile.core.hw.virtual import SimpleVirtualDevice
 
 
-    class DemoVirtualDevice(VirtualIOTileDevice):
+    class DemoVirtualDevice(SimpleVirtualDevice):
         """A simple virtual IOTile device that streams fake temperature.
 
         Args:
@@ -167,10 +167,10 @@ Just like in the first tutorial, create a class for the virtual device::
             # Create a worker that streams our realtime data every second
             self.create_worker(self._stream_temp, 1.0)
 
-        def _stream_temp(self):
+        async def _stream_temp(self):
             """Send a fake temperature reading between 32 and 100."""
 
-            self.stream_realtime(0x1000, random.randint(32, 100))
+            await self.stream_realtime(0x1000, random.randint(32, 100))
 
 Save your device file as `demo_streamer.py`.
 

--- a/iotilecore/RELEASE.md
+++ b/iotilecore/RELEASE.md
@@ -2,6 +2,10 @@
 
 All major changes in each released version of `iotile-core` are listed here.
 
+## 5.0.9
+
+- Fix regression in the realtime streaming device
+
 ## 5.0.8
 
 - Add ability to start periodic coroutines with the SharedLoop

--- a/iotilecore/iotile/core/hw/virtual/virtualdevice_base.py
+++ b/iotilecore/iotile/core/hw/virtual/virtualdevice_base.py
@@ -267,7 +267,7 @@ class BaseVirtualDevice:
         reading = IOTileReading(0, stream, value)
 
         report = IndividualReadingReport.FromReadings(self.iotile_id, [reading])
-        self.stream(report)
+        await self.stream(report)
 
     async def trace(self, data):
         """Trace data asynchronously.

--- a/iotilecore/version.py
+++ b/iotilecore/version.py
@@ -1,1 +1,1 @@
-version = "5.0.8"
+version = "5.0.9"


### PR DESCRIPTION
## Overview & Major Changes

This closes #902 

When going through our docs/coding challenge to make sure everything still worked, I found a couple of things to update.

It's a good thing I checked, because the bonus challenge would have been very challenging to solve otherwise.

I need to cut a release so that we can use our coding challenges (we expect them to install from a released version).

@timburke -- can you sanity check that this was the right thing to await and I'm not messing up another call that needs a non-coroutine? It seemed to work locally on the demo, at least.

I'll wait to push a new version of the docs along with my other change to the tutorial for a virtual device.
