### PR TITLE
Add support for device servers to indicate fatal errors.

### DIFF
--- a/iotilecore/RELEASE.md
+++ b/iotilecore/RELEASE.md
@@ -10,6 +10,10 @@ All major changes in each released version of `iotile-core` are listed here.
 - Add shim to make `iotile-core` compatible with Python 3.8.0 on Windows.  There is a bug in
   that python version that breaks background event loops only on Windows.  It is fixed in
   python 3.8.1.
+- Add `failed` future to `AbstractDeviceServer` that allows servers a way to communicate 
+  fatal errors that cause them to stop working.  This is now used inside `virtual-device`
+  to cleanly stop the process with a nonzero exit code if there is a fatal error serving
+  up the virtual device.
 
 ## 5.0.9
 

--- a/iotilecore/iotile/core/hw/transport/server/abstract.py
+++ b/iotilecore/iotile/core/hw/transport/server/abstract.py
@@ -73,6 +73,31 @@ class AbstractDeviceServer(abc.ABC):
     def __init__(self, adapter, args=None, *, loop=SharedLoop):
         """Required constructor signature."""
 
+    @property
+    @abc.abstractmethod
+    def failed(self):
+        """asyncio.Future that contains the reason why the server stopped working.
+
+        This property is designed to allow for the use case where you want to
+        run the server in the background but also check and see periodically
+        if it has had a fatal error.  Any fatal error that causes the server
+        to shutdown and no longer function should be set as an `exception`
+        on the failed Future so that users can wait for it and know when
+        the server shuts down.
+
+        The property is only guaranteed to return a non-None result once the
+        start() coroutine has been awaited and it is not guaranteed to ever
+        be set.  In particular, during normal operation, calling `stop()` will
+        not cause `failed` to be marked as done().
+
+        This future exists as a way for the server to notify interested parties
+        of **fatal errors** that prevent ongoing operation.
+
+        If ``failed`` is set, ``stop()`` should not be called and will not
+        necessarily work since the server is already broken.
+        """
+
+
     @abc.abstractmethod
     async def start(self):
         """Start serving access to devices.


### PR DESCRIPTION
Currently, the virtual-device script has no way of knowing if the underlying device server that it is hosting has encountered a fatal error and is no longer running.  Since the server runs in a background event loop, exceptions don't naturally cause the main script to exit.

This commit adds a `failed` Future() on all DeviceServers that can be set to indicate that the server has encounted a fatal error condition and stopped operation.

The virtual-device script is updated to wait on this future rather than just sleeping until Ctrl-C is hit.

An example of the new usage is:

```
$ virtual-device bled112 simple
```

If you unplug the BLED112 dongle that is serving the virtual device, it can now cleanly exit the virtual_device program.  FYI, for this new functionality to work, it requires additional changes (not part of this PR) that actually set the `failed` future when there's a fatal serial port error.  This PR is just the baseline infrastructure changes to allow for that work to propagate all the way to the `virtual-device` script.
