### PR TITLE
Comment out "RPC in progress" check

### DIFF
--- a/transport_plugins/bled112/RELEASE.md
+++ b/transport_plugins/bled112/RELEASE.md
@@ -11,6 +11,7 @@ All major changes in each released version of the bled112 transport plugin are l
   generated the same way it is done for user key
 - Add the password-based authentication method
 - Update the authentication flow
+- Disable "RPC in progress" check
 
 ## 3.0.3
 

--- a/transport_plugins/bled112/iotile_transport_bled112/bled112.py
+++ b/transport_plugins/bled112/iotile_transport_bled112/bled112.py
@@ -311,10 +311,6 @@ class BLED112Adapter(DeviceAdapter):
 
         services = self._connections[found_handle]['services']
 
-        if self.check_is_rpc_in_progress(found_handle, services):
-            callback(conn_id, self.id, False, 'RPC still in progress', None, None)
-            return
-
         self._command_task.async_command(['_send_rpc', found_handle, services, address, rpc_id, payload, timeout], self._send_rpc_finished,
                                          {'connection_id': conn_id, 'handle': found_handle,
                                           'callback': callback})


### PR DESCRIPTION
Recently a check was added to send_rpc_async
```Python
        if self.check_is_rpc_in_progress(found_handle, services):
            callback(conn_id, self.id, False, 'RPC still in progress', None, None)
            return
```
This check periodically causes RPCs to fail with exception:
```
E           iotile.core.hw.exceptions.DeviceAdapterError: DeviceAdapterError: Operation send_rpc on conn 0 failed because Error writing to handle
E           Additional Information:
E           reason: Error writing to handle
E           operation: send_rpc
E           conn_id: 0
```

The impelemtation needs to be revised.
