### PR TITLE
Update decription logic for signed reports

### DIFF
--- a/iotilecore/RELEASE.md
+++ b/iotilecore/RELEASE.md
@@ -11,6 +11,7 @@ All major changes in each released version of `iotile-core` are listed here.
   that python version that breaks background event loops only on Windows.  It is fixed in
   python 3.8.1.
 - Add new BLE broadcast encryption method: Encrypted with NullKey
+- Update decryption logic for signed reports
 
 ## 5.0.11
 

--- a/iotilecore/test/test_hw/test_virtualadapter.py
+++ b/iotilecore/test/test_hw/test_virtualadapter.py
@@ -7,7 +7,7 @@
 # are copyright Arch Systems Inc.
 
 from iotile.core.hw.hwmanager import HardwareManager
-from iotile.core.hw.reports.signed_list_format import SignedListReport
+from iotile.core.hw.reports.signed_list_format import SignedListReport, ReportSignatureFlags
 from iotile.core.hw.exceptions import *
 from iotile.core.exceptions import *
 from iotile.core.dev import ComponentRegistry
@@ -155,7 +155,7 @@ def test_config_file2(conf2_report_hw, monkeypatch):
 
     for report in conf2_report_hw.iter_reports():
         assert report.verified
-        assert report.signature_flags == 1
+        assert report.signature_flags == ReportSignatureFlags.SIGNED_WITH_USER_KEY
         assert report.lowest_id >= 1
         assert report.highest_id > report.lowest_id
         assert isinstance(report, SignedListReport)

--- a/iotilecore/test/test_reports/test_signed_list_report.py
+++ b/iotilecore/test/test_reports/test_signed_list_report.py
@@ -2,7 +2,7 @@ import unittest
 import os
 import pytest
 from iotile.core.exceptions import ExternalError
-from iotile.core.hw.reports.signed_list_format import SignedListReport
+from iotile.core.hw.reports.signed_list_format import SignedListReport, ReportSignatureFlags
 from iotile.core.hw.reports.report import IOTileReading
 from iotile.core.hw.auth.env_auth_provider import EnvAuthProvider
 from iotile.core.hw.auth.auth_provider import AuthProvider
@@ -49,7 +49,7 @@ def test_basic_parsing():
 
     assert report2.verified is True
     assert report.verified is True
-    assert report.signature_flags == 0
+    assert report.signature_flags == ReportSignatureFlags.SIGNED_WITH_HASH
 
 def test_footer_calculation():
     """Test if make_sesuentail set properly ids"""
@@ -77,8 +77,8 @@ def test_userkey_signing(monkeypatch):
     encoded = report1.encode()
     report2 = SignedListReport(encoded)
 
-    assert report1.signature_flags == AuthProvider.UserKey
-    assert report2.signature_flags == AuthProvider.UserKey
+    assert report1.signature_flags == ReportSignatureFlags.SIGNED_WITH_USER_KEY
+    assert report2.signature_flags == ReportSignatureFlags.SIGNED_WITH_USER_KEY
     assert report1.verified
     assert report1.encrypted
     assert report2.verified

--- a/iotiletest/iotile/mock/devices/report_test_device.py
+++ b/iotiletest/iotile/mock/devices/report_test_device.py
@@ -133,11 +133,13 @@ class ReportTestDevice(SimpleVirtualDevice):
             reports = [IndividualReadingReport.FromReadings(self.iotile_id, [reading]) for reading in readings]
         elif self.format == 'signed_list':
             if self.report_length == 0:
-                return [SignedListReport.FromReadings(self.iotile_id, [], root_key=self.signing_method)]
+                return [SignedListReport.FromReadings(self.iotile_id, [],
+                    root_key=SignedListReport.StreamTypeToKeyType(self.signing_method))]
 
             for i in range(0, len(readings), self.report_length):
                 chunk = readings[i:i+self.report_length]
-                report = SignedListReport.FromReadings(self.iotile_id, chunk, root_key=self.signing_method)
+                report = SignedListReport.FromReadings(self.iotile_id, chunk,
+                    root_key=SignedListReport.StreamTypeToKeyType(self.signing_method))
                 reports.append(report)
 
         return reports


### PR DESCRIPTION
Recently two new auth methods were introduced: NullKey and PasswordBased. This change has broken the signed list encryption/decryption logic. 

The purpose of the PR is to simplify logic by introducing explicit report type and conversation function and replace hardcoded key type values with defined variables in AuthProvider.


