### PR TITLE
Add config "cloud:verify-server"

### DIFF
--- a/iotile_ext_cloud/RELEASE.md
+++ b/iotile_ext_cloud/RELEASE.md
@@ -2,6 +2,10 @@
 
 All major changes in each released version of the iotile-ext-cloud plugin are listed here.
 
+## 1.1.0
+- Add cloud:verify-server config to iotile-ext-cloud. 
+  This allows to disable verification of cloud server TLS certificate.  
+
 ## 1.0.10
 
 - Add support for passing kwargs down to Api() from underlying iotile-cloud package.

--- a/iotile_ext_cloud/iotile/cloud/apps/ota_updater.py
+++ b/iotile_ext_cloud/iotile/cloud/apps/ota_updater.py
@@ -5,6 +5,7 @@ import operator
 from iotile.core.hw import IOTileApp
 from iotile.core.hw.update import UpdateScript
 from iotile.core.dev.semver import SemanticVersion
+from iotile.core.dev.config import ConfigManager
 from iotile.cloud import IOTileCloud, device_id_to_slug
 from iotile_cloud.utils.basic import datetime_to_str
 from typedargs.annotate import docannotate, context
@@ -24,11 +25,11 @@ op_map = {">=": operator.lt,
           }
 
 
-def _download_ota_script(script_url):
+def _download_ota_script(script_url, verify_server_cert):
     """Download the script from the cloud service and store to temporary file location"""
 
     try:
-        blob = requests.get(script_url, stream=True)
+        blob = requests.get(script_url, stream=True, verify=verify_server_cert)
         return blob.content
     except Exception as e:
         iprint("Failed to download OTA script")
@@ -96,7 +97,7 @@ class OtaUpdater(IOTileApp):
 
         iprint("Downloading script")
         iprint(script[1])
-        blob = _download_ota_script(script[1])
+        blob = _download_ota_script(script[1], self._cloud.server_cert_verifying)
 
         if not blob:
             iprint("Download of script failed for some reason")
@@ -109,7 +110,6 @@ class OtaUpdater(IOTileApp):
         except Exception:
             self._inform_cloud(script[0], self.dev_slug, False)
             raise
-
 
     def _check_criteria(self, criterion):
 

--- a/iotile_ext_cloud/iotile/cloud/apps/ota_updater.py
+++ b/iotile_ext_cloud/iotile/cloud/apps/ota_updater.py
@@ -5,7 +5,6 @@ import operator
 from iotile.core.hw import IOTileApp
 from iotile.core.hw.update import UpdateScript
 from iotile.core.dev.semver import SemanticVersion
-from iotile.core.dev.config import ConfigManager
 from iotile.cloud import IOTileCloud, device_id_to_slug
 from iotile_cloud.utils.basic import datetime_to_str
 from typedargs.annotate import docannotate, context

--- a/iotile_ext_cloud/iotile/cloud/apps/ota_updater.py
+++ b/iotile_ext_cloud/iotile/cloud/apps/ota_updater.py
@@ -96,7 +96,7 @@ class OtaUpdater(IOTileApp):
 
         iprint("Downloading script")
         iprint(script[1])
-        blob = _download_ota_script(script[1], self._cloud.server_cert_verifying)
+        blob = _download_ota_script(script[1], self._cloud.verify_server)
 
         if not blob:
             iprint("Download of script failed for some reason")

--- a/iotile_ext_cloud/iotile/cloud/cloud.py
+++ b/iotile_ext_cloud/iotile/cloud/cloud.py
@@ -48,10 +48,10 @@ class IOTileCloud:
         if domain is None:
             domain = self._conf.get('cloud:server')
 
-        if not self.server_cert_verifying:
+        if not self.verify_server:
             urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
-        self.api = Api(domain=domain, verify=self.server_cert_verifying, **kwargs)
+        self.api = Api(domain=domain, verify=self.verify_server, **kwargs)
         self._domain = self.api.domain
 
         try:
@@ -75,7 +75,7 @@ class IOTileCloud:
         self.token_type = self.api.token_type
 
     @property
-    def server_cert_verifying(self) -> bool:
+    def verify_server(self) -> bool:
         return self._conf.get('cloud:verify-server')
 
     def _prompt_user_pass(self, username, domain):

--- a/iotile_ext_cloud/iotile/cloud/cloud.py
+++ b/iotile_ext_cloud/iotile/cloud/cloud.py
@@ -6,7 +6,7 @@ import datetime
 from collections import namedtuple
 from dateutil.tz import tzutc
 import dateutil.parser
-
+import urllib3
 from iotile_cloud.api.connection import Api
 from iotile_cloud.api.exceptions import RestHttpBaseException, HttpNotFoundError
 from iotile.core.dev.registry import ComponentRegistry
@@ -48,6 +48,9 @@ class IOTileCloud:
         if domain is None:
             domain = self._conf.get('cloud:server')
 
+        if not self.server_cert_verifying:
+            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
         self.api = Api(domain=domain, verify=self.server_cert_verifying, **kwargs)
         self._domain = self.api.domain
 
@@ -72,7 +75,7 @@ class IOTileCloud:
         self.token_type = self.api.token_type
 
     @property
-    def server_cert_verifying(self):
+    def server_cert_verifying(self) -> bool:
         return self._conf.get('cloud:verify-server')
 
     def _prompt_user_pass(self, username, domain):

--- a/iotile_ext_cloud/iotile/cloud/cloud.py
+++ b/iotile_ext_cloud/iotile/cloud/cloud.py
@@ -48,7 +48,9 @@ class IOTileCloud:
         if domain is None:
             domain = conf.get('cloud:server')
 
-        self.api = Api(domain=domain, **kwargs)
+        verify_server_cert = conf.get('cloud:verify-server')
+
+        self.api = Api(domain=domain, verify=verify_server_cert, **kwargs)
         self._domain = self.api.domain
 
         try:

--- a/iotile_ext_cloud/iotile/cloud/cloud.py
+++ b/iotile_ext_cloud/iotile/cloud/cloud.py
@@ -51,7 +51,8 @@ class IOTileCloud:
         if not self.verify_server:
             urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
-        self.api = Api(domain=domain, verify=self.verify_server, **kwargs)
+        _verify = self.verify_server
+        self.api = Api(domain=domain, verify=_verify, **kwargs)
         self._domain = self.api.domain
 
         try:

--- a/iotile_ext_cloud/iotile/cloud/cloud.py
+++ b/iotile_ext_cloud/iotile/cloud/cloud.py
@@ -43,14 +43,12 @@ class IOTileCloud:
 
     def __init__(self, domain=None, username=None, **kwargs):
         reg = ComponentRegistry()
-        conf = ConfigManager()
+        self._conf = ConfigManager()
 
         if domain is None:
-            domain = conf.get('cloud:server')
+            domain = self._conf.get('cloud:server')
 
-        verify_server_cert = conf.get('cloud:verify-server')
-
-        self.api = Api(domain=domain, verify=verify_server_cert, **kwargs)
+        self.api = Api(domain=domain, verify=self.server_cert_verifying, **kwargs)
         self._domain = self.api.domain
 
         try:
@@ -72,6 +70,10 @@ class IOTileCloud:
 
         self.token = self.api.token
         self.token_type = self.api.token_type
+
+    @property
+    def server_cert_verifying(self):
+        return self._conf.get('cloud:verify-server')
 
     def _prompt_user_pass(self, username, domain):
         if username is None:

--- a/iotile_ext_cloud/iotile/cloud/config.py
+++ b/iotile_ext_cloud/iotile/cloud/config.py
@@ -40,6 +40,7 @@ def link_cloud(self, username=None, password=None, device_id=None):
     reg = ComponentRegistry()
 
     domain = self.get('cloud:server')
+    verify_server_cert = self.get('cloud:verify-server')
 
     if username is None:
         prompt_str = "Please enter your IOTile.cloud email: "
@@ -51,7 +52,7 @@ def link_cloud(self, username=None, password=None, device_id=None):
 
         password = getpass.getpass(prompt_str)
 
-    cloud = Api(domain=domain)
+    cloud = Api(domain=domain, verify=verify_server_cert)
     ok_resp = cloud.login(email=username, password=password)
     if not ok_resp:
         raise ArgumentError("Could not login to iotile.cloud as user %s" % username)

--- a/iotile_ext_cloud/iotile/cloud/config.py
+++ b/iotile_ext_cloud/iotile/cloud/config.py
@@ -1,7 +1,7 @@
 """Configuration information for iotile-ext-cloud."""
 
 import getpass
-
+import urllib3
 from iotile.core.dev.registry import ComponentRegistry
 from iotile.cloud.cloud import IOTileCloud
 from iotile.core.utilities.typedargs import param
@@ -51,6 +51,9 @@ def link_cloud(self, username=None, password=None, device_id=None):
         prompt_str = "Please enter your IOTile.cloud password: "
 
         password = getpass.getpass(prompt_str)
+
+    if not verify_server_cert:
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
     cloud = Api(domain=domain, verify=verify_server_cert)
     ok_resp = cloud.login(email=username, password=password)

--- a/iotile_ext_cloud/iotile/cloud/config.py
+++ b/iotile_ext_cloud/iotile/cloud/config.py
@@ -69,9 +69,9 @@ def get_variables():
     """Get a dictionary of configuration variables."""
 
     prefix = "cloud"
-    conf_vars = [["server",
-                  "string",
-                  "The domain name to talk to for iotile.cloud operations (including https:// prefix)",
-                  'https://iotile.cloud']]
+
+    conf_vars = []
+    conf_vars.append(["server", "string", "The domain name to talk to for iotile.cloud operations (including https:// prefix)", 'https://iotile.cloud'])
+    conf_vars.append(["verify-server", "bool", "Verify the TLS certificate of the cloud server", "true"])
 
     return prefix, conf_vars


### PR DESCRIPTION
This PR adds new config option `cloud:verify-server`, value is bool, `True` by default.
This allows to disable verification of cloud server TLS certificate. It is useful when user call cloud API being behind firewall that replaces TLS certificate with self-signed one.

- added config option `cloud:verify-server`
- instantiate Api object with `verify` param
- pass `verify` param when calling cloud server with `requests`
- disable throwing `InsecureRequestWarning` when `cloud:verify-server` is `False`

Closes #952 
Closes #953 