### PR TITLE
Update version number in a version.py module

### DIFF
--- a/iotile_ext_cloud/version.py
+++ b/iotile_ext_cloud/version.py
@@ -1,1 +1,1 @@
-version = "1.0.10"
+version = "1.1.0"


### PR DESCRIPTION
This PR contains one simple fix.
I have missed to updated a version number in a version.py module in PR #960  . 
This prevents from releasing new version of `iotile-ext-cloud`. 