### PR TITLE
Fix for "disconnect" command execution when connection to device is interrupted

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,7 +62,7 @@ jobs:
 
 - job: 'Test_OSX'
   pool:
-    vmImage: 'macOS-10.13'
+    vmImage: 'macOS-10.15'
   strategy:
     matrix:
       Python35:

--- a/iotilecore/RELEASE.md
+++ b/iotilecore/RELEASE.md
@@ -4,6 +4,8 @@ All major changes in each released version of `iotile-core` are listed here.
 
 ## HEAD
 
+## 5.0.14
+
 - Add ability for `debug_manager` to flash `.bin` files
 - Add a fix for "disconnect" command execution when connection to device is interrupted
 

--- a/iotilecore/RELEASE.md
+++ b/iotilecore/RELEASE.md
@@ -5,6 +5,7 @@ All major changes in each released version of `iotile-core` are listed here.
 ## HEAD
 
 - Add ability for `debug_manager` to flash `.bin` files
+- Add a fix for "disconnect" command execution when connection to device is interrupted
 
 ## 5.0.13
 

--- a/iotilecore/iotile/core/hw/transport/adapterstream.py
+++ b/iotilecore/iotile/core/hw/transport/adapterstream.py
@@ -240,7 +240,8 @@ class AdapterStream:
         self._reports = None
         self._traces = None
 
-        self._loop.run_coroutine(self.adapter.disconnect(0))
+        if not self.connection_interrupted:
+            self._loop.run_coroutine(self.adapter.disconnect(0))
         self.connected = False
         self.connection_interrupted = False
         self.connection_string = None


### PR DESCRIPTION
Executing "disconnect" command fails if device connection was interrupted. 
It could be reproduced in a way described in #958 

1) Connect to an AP
2) Turn off AP (remove power)
3) Disconnect from AP (fails)
4) Connect to AP or any other device (fails due to "already connected")

This PR fixes this issue.

The fix is simple:
```
     -   self._loop.run_coroutine(self.adapter.disconnect(0))
     +   if not self.connection_interrupted:
     +       self._loop.run_coroutine(self.adapter.disconnect(0))
```
If `self.connection_interrupted` if set to `True` then it means that all necessary routines triggered by the call `self.adapter.disconnect(0)` are already executed when "disconnect" event (device connection got interrupted) was handled.

Closes #958 