### PR TITLE
Possible early filtering feature to support higher novel-packet bandwidth

### DIFF
--- a/transport_plugins/bled112/iotile_transport_bled112/async_packet.py
+++ b/transport_plugins/bled112/iotile_transport_bled112/async_packet.py
@@ -56,10 +56,13 @@ class AsyncPacketBuffer:
 #23 16 00 00 a0 01 40 10 00 00
 #00 00 00 00 00 00  rssi: -54, type: 0, sender: 0090298125cb
 def packet_is_broadcast_v2(packet):
+    #Broadcast packets consist of 32 bytes for data, 10 for BLE packet header and 4 for bled112 bgapi header
     if len(packet) != 46:
         return False
+    #This identifies the bgapi packet as an event
     if not (packet[0] == 0x80 and packet[2] == 6 and packet[3] == 0):
         return False
+    #This identifies the event as a broadcast v2 packet
     if not (packet[18] == 0x1b and packet[19] == 0x16 and packet[20] == 0xdd and packet[21] == 0xfd):
         return False
     return True
@@ -67,24 +70,21 @@ def packet_is_broadcast_v2(packet):
 def packet_is_dupe(packet, dedupe_dict):
     mac = tuple(packet[6:11])
 
-    #Create the tuple for the packet, ignore the sequence value
-    broadcast = packet[22:]
-    del broadcast[13]
-    broadcast_tup = tuple(broadcast)
+    #Drop the sequence value from the packet, since that changes for each packet
+    data = packet[22:]
 
-    #print(f"Parsing from {mac}: {broadcast_tup}")
-    if dedupe_dict.get(mac, None) == broadcast_tup:
-        #print(f"Dropping from {mac}: {broadcast_tup}")
+    #print(f"Parsing from {mac}: {data}")
+    if dedupe_dict.get(mac, None) == data:
+        #print(f"Dropping from {mac}: {data}")
         return True
-    #print(f"Not a dupe    {mac}: {broadcast_tup}")
-    dedupe_dict[mac] = broadcast_tup
+    #print(f"Not a dupe    {mac}: {data}")
+    dedupe_dict[mac] = data
     return False
 
 
 def ReaderThread(filelike, read_queue, header_length, length_function, stop):
     logger = logging.getLogger(__name__)
     dedupe_dict = {}
-    #count = 0
 
     while not stop.is_set():
         try:
@@ -115,9 +115,8 @@ def ReaderThread(filelike, read_queue, header_length, length_function, stop):
             packet = header + remaining
 
             if packet_is_broadcast_v2(packet):
-                #count += 1
-                #if count % 100 != 0:
                 #if read_queue.qsize() > 25:
+                #if packet_is_dupe(packet, dedupe_dict):
                 if read_queue.qsize() > 25 and packet_is_dupe(packet, dedupe_dict):
                     #print("drop")
                     continue


### PR DESCRIPTION
## Overview & Major Changes

This is a possible change to increase the number of novel broadcasts that coretools can pass through. The idea is to filter out duplicate packets at the earliest possible moment, before any processing time is spent on it. I went through the code and identified everything that should identify a bled packet as a broadcast packet and wrote a hardcoded check for whether the packet that was just read from the bled112 dongle is a broadcast. If so, and if the read queue has 25 packets in it already (chosen somewhat arbitarily) it'll check to see if the packet matches the last broadcast from that mac address. If so then it drops it. 

I'm running some  tests on it now but so far I haven't seen anything that shows it negatively impacting performance and it potentially doubles the number of packets downstream systems see, when the average pod updates it's data no more than once a second (packets include the Pod's timestamp, which increments once a second, so at least one packet a second will get through per Pod.

I haven't cleaned it up yet or added a config variable to enable / disable it yet, but I'd like an early look at it to see if anyone has any problems with this approach.

Edit: The code in this draft PR was added to show an example of what this change would look like, to make it more clear what this change would entail.