### PR TITLE
Fix release notes to include HEAD changes to 5.0.16

### DIFF
--- a/iotilecore/RELEASE.md
+++ b/iotilecore/RELEASE.md
@@ -2,12 +2,10 @@
 
 All major changes in each released version of `iotile-core` are listed here.
 
-## HEAD
-- Fix error handling in auth process
-
 ## 5.0.16
 
 - Add hash algorithms to utilities
+- Fix error handling in auth process
 
 ## 5.0.15
 


### PR DESCRIPTION
The `5.0.16` version also includes the `HEAD` changes.

This was overlooked when updating the previously merged branch from master.