### PR TITLE
Bumping versions for release of iotile-transport-bled112

### DIFF
--- a/transport_plugins/bled112/RELEASE.md
+++ b/transport_plugins/bled112/RELEASE.md
@@ -2,8 +2,9 @@
 
 All major changes in each released version of the bled112 transport plugin are listed here.
 
-## HEAD
+## 3.0.5
 
+- Add optional deduplication of broadcast-V2 formatted Advertising packets 
 - Add `safe_mode` advertisement flag in scan results
 
 ## 3.0.4

--- a/transport_plugins/bled112/version.py
+++ b/transport_plugins/bled112/version.py
@@ -1,1 +1,1 @@
-version = "3.0.4"
+version = "3.0.5"


### PR DESCRIPTION
Bumping version numbers for new release of the iotile-transport-bled112 package, which includes #978.