### PR TITLE
Add ability to force checksum calculation despite sgf

### DIFF
--- a/iotilesensorgraph/RELEASE.md
+++ b/iotilesensorgraph/RELEASE.md
@@ -3,6 +3,11 @@
 All major changes in each released version of iotile-sensorgraph are listed
 here.
 
+## 1.0.9
+
+- Add ability to force checksum calculation regardless of hash settings
+- Fix checksum function's config dump to be sorted properly
+
 ## 1.0.8
 
 - Add feature to set sensorgraph's checksum as config variable

--- a/iotilesensorgraph/iotile/sg/scripts/iotile_sgcompile.py
+++ b/iotilesensorgraph/iotile/sg/scripts/iotile_sgcompile.py
@@ -19,6 +19,7 @@ def build_args():
     parser.add_argument(u'-o', u'--output', type=str, help=u"the output file to save the results (defaults to stdout)")
     parser.add_argument(u'--disable-optimizer', action="store_true", help=u"disable the sensor graph optimizer completely")
     parser.add_argument(u'-v', u'--verbose', help=u"increase output verbosity", action="store_true")
+    parser.add_argument(u'--force_checksum', help=u"forces the compiler to calculate a checksum", action="store_true")
     return parser
 
 
@@ -71,7 +72,7 @@ def main():
         opt = SensorGraphOptimizer()
         opt.optimize(parser.sensor_graph, model=model)
 
-    parser.sensor_graph.add_checksum()
+    parser.sensor_graph.add_checksum(force_checksum=args.force_checksum)
 
     if args.format == u'nodes':
         output = u'\n'.join(parser.sensor_graph.dump_nodes()) + u'\n'

--- a/iotilesensorgraph/version.py
+++ b/iotilesensorgraph/version.py
@@ -1,1 +1,1 @@
-version = "1.0.8"
+version = "1.0.9"


### PR DESCRIPTION
## Overview
We want to be able to use checksum functionality on legacy sensorgraphs that do not have the meta tag headers such as `meta hash_address`, `meta hash_algorithm` etc. We want to be able to just calculate the checksum of the `.sgf` as it is.

### Main Changes
- Fixed a bug when dumping the config variables to build a binary representation. It would dump the config variables unsorted. This fixes sorts it, since the device proxy does its hash calculation on a sorted list of config variables
- Added the `--force-checksum` option in `iotile-sgcompile` to just print the checksum in its DEBUG log. This will not actually save the checksum in any config variable in the `.sgf` file