### PR TITLE
Remove sortedcontainers dependency

### DIFF
--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -4,5 +4,4 @@ websockets
 msgpack>=0.6.1
 python-dateutil>=2.6.0
 typedargs>=1.0.0
-sortedcontainers~=2.1
 entrypoints>=0.3.0

--- a/iotilecore/RELEASE.md
+++ b/iotilecore/RELEASE.md
@@ -2,6 +2,14 @@
 
 All major changes in each released version of `iotile-core` are listed here.
 
+## 5.1.0
+
+- Remove dependency on sortedcontainers.  It was only used in one place and
+  was preventing compiling CoreTools based applications using the ``nuitka``
+  python compiler.  The specific use case in UTCAssigner was replaced with a
+  focused implementation that also happened to be faster for our specific use
+  case.
+
 ## 5.0.16
 
 - Add hash algorithms to utilities

--- a/iotilecore/iotile/core/hw/reports/utc_assigner.py
+++ b/iotilecore/iotile/core/hw/reports/utc_assigner.py
@@ -27,8 +27,6 @@ from typedargs.exceptions import ArgumentError
 from .signed_list_format import SignedListReport
 from .report import IOTileReading
 
-LOG = logging.getLogger(__name__)
-
 class _TimeAnchor:
     """Internal class for storing a utc reference point."""
 
@@ -75,8 +73,6 @@ class SortedAnchorList:
     def _ensure_sorted(self):
         if self._sorted:
             return
-
-        LOG.info("Sorting")
 
         self._data.sort(key=lambda x: x.reading_id)
         self._keys = [x.reading_id for x in self._data]

--- a/iotilecore/iotile/core/hw/reports/utc_assigner.py
+++ b/iotilecore/iotile/core/hw/reports/utc_assigner.py
@@ -22,11 +22,12 @@ returning confidence metrics along with the assigned value.
 
 import datetime
 import logging
+from bisect import bisect_left
 from typedargs.exceptions import ArgumentError
-from sortedcontainers import SortedKeyList
 from .signed_list_format import SignedListReport
 from .report import IOTileReading
 
+LOG = logging.getLogger(__name__)
 
 class _TimeAnchor:
     """Internal class for storing a utc reference point."""
@@ -43,6 +44,86 @@ class _TimeAnchor:
     def copy(self):
         """Return a copy of this _TimeAnchor."""
         return _TimeAnchor(self.reading_id, self.uptime, self.utc, self.is_break, self.exact)
+
+
+class SortedAnchorList:
+    """A simple but time-efficient list that is maintained sorted by a key.
+
+    This is a reimplementation of the API provided by the sortedcontainers
+    package.  It is based on SortedKeyList.
+
+    Internally it maintains 3 structures:
+     - data: the actual added values
+     - keys: a sorted list of the keys computed from the data
+     - key_set: A set for quickly testing key membership.
+
+    ``data`` is only sorted to produce ``keys`` on demand, when a request is
+    made for an operation that requires sorting.  This lazy sorting is
+    designed to work well with the usage pattern of this class in
+    UTCAssignment.
+
+    Unit tests show that runtime for the ``test_utc_assigner.py`` test suite
+    dropped from 7 seconds to 5.5 seconds using this class.
+    """
+
+    def __init__(self):
+        self._key_set = set()
+        self._data = []
+        self._keys = []
+        self._sorted = False
+
+    def _ensure_sorted(self):
+        if self._sorted:
+            return
+
+        LOG.info("Sorting")
+
+        self._data.sort(key=lambda x: x.reading_id)
+        self._keys = [x.reading_id for x in self._data]
+        self._sorted = True
+
+    def add(self, anchor: _TimeAnchor):
+        """Add a new TimeAnchor to this sorted list."""
+
+        self._key_set.add(anchor.reading_id)
+        self._data.append(anchor)
+        self._sorted = False
+
+    def bisect_key_left(self, reading_id: int) -> int:
+        """Find the position for inserting this key."""
+
+        self._ensure_sorted()
+        return bisect_left(self._keys, reading_id)
+
+    def islice(self, start=None, stop=None, reverse=False):
+        """Iterate over a slice of this sorted list."""
+
+        self._ensure_sorted()
+
+        start, stop, _ = slice(start, stop).indices(len(self._data))
+
+        iterator = range(start, stop)
+        if reverse:
+            iterator = reversed(iterator)
+
+        for i in iterator:
+            yield self._data[i]
+
+    def __len__(self):
+        return len(self._data)
+
+    def __iter__(self):
+        self._ensure_sorted()
+
+        return self._data.__iter__()
+
+    def __getitem__(self, i):
+        self._ensure_sorted()
+
+        return self._data[i]
+
+    def __contains__(self, anchor):
+        return anchor.reading_id in self._key_set
 
 
 class UTCAssignment:
@@ -108,7 +189,7 @@ class UTCAssigner:
     _EpochReference = datetime.datetime(1970, 1, 1)
 
     def __init__(self):
-        self._anchor_points = SortedKeyList(key=lambda x: x.reading_id)
+        self._anchor_points = SortedAnchorList()
         self._prepared = False
         self._anchor_streams = {}
         self._break_streams = set()

--- a/iotilecore/setup.py
+++ b/iotilecore/setup.py
@@ -27,7 +27,6 @@ setup(
     install_requires=[
         "python-dateutil>=2.8.0,<3",
         "typedargs>=1.0.0,<2",
-        "sortedcontainers~=2.1",
         "entrypoints>=0.3.0,<1",
         "msgpack>=0.6.1,<1"
     ],

--- a/iotilecore/version.py
+++ b/iotilecore/version.py
@@ -1,1 +1,1 @@
-version = "5.0.16"
+version = "5.1.0"


### PR DESCRIPTION
### Background

This is a small PR to allow us to remove the `sortedcontainers` dependency from `iotile-core`.  The motivation is because `sortedcontainers` breaks the `nuitka` python C compiler and prevents us from statically compiling applications that include `iotile-core` even if they never use the one part of `iotile-core` that uses `sortedcontainers`.  


We only use `sortedcontainers` in one place inside CoreTools.  So, I replaced it with a purpose built small implementation that works for our usecase (without the generality of the `sortedcontainers` implementation.  As a side benefit, it's also faster (again for our use case).  Unit tests went from 7 -> 5.5 seconds after reimplementing.

### Possible Side Effects

1. I checked our entire codebase and there is only one other place where we use sortedcontainers in an internal manufacturing package.  I will separately file an issue in that project to explicitly add sortedcontainers to its `install_requires`.  Currently it implicitly assumes that sortedcontainers will be installed because `iotile-core` depends on it.

@mattrunchey FYI, this is a time-sensitive hotfix because it blocks providing a standalone program to a customer for testing since that program can't be compiled because of this issue.