### PR TITLE
Add tqdm to the utc assigner

### DIFF
--- a/iotilecore/RELEASE.md
+++ b/iotilecore/RELEASE.md
@@ -2,6 +2,12 @@
 
 All major changes in each released version of `iotile-core` are listed here.
 
+## 5.1.1
+
+- Add the tqdm statusbar to the utc_assigner. There are some conditions where the binary 
+  reports take a significant amount of time to process. A status bar helps show estimated time
+  to process and show that code is not stalled.
+
 ## 5.1.0
 
 - Remove dependency on sortedcontainers.  It was only used in one place and

--- a/iotilecore/iotile/core/hw/reports/utc_assigner.py
+++ b/iotilecore/iotile/core/hw/reports/utc_assigner.py
@@ -23,7 +23,7 @@ returning confidence metrics along with the assigned value.
 import datetime
 import logging
 from bisect import bisect_left
-from typedargs.exceptions import ArgumentError, KeyValueException
+from typedargs.exceptions import ArgumentError
 from .signed_list_format import SignedListReport
 from .report import IOTileReading
 

--- a/iotilecore/version.py
+++ b/iotilecore/version.py
@@ -1,1 +1,1 @@
-version = "5.1.0"
+version = "5.1.1"


### PR DESCRIPTION
Add the tqdm statusbar to the utc_assigner. It is imported using a `try {} except {}` block and not included as a dependency in the setup.py. 

This is needed because there are some conditions where the utc assignment takes a significant amount of time. This status bar is needed to know that software is operating correctly and not stalled.