### PR TITLE
Fix bled112 hangs when dongle removed and allow for checking dongle functionality from HardwareManager

### DIFF
--- a/iotilecore/RELEASE.md
+++ b/iotilecore/RELEASE.md
@@ -2,6 +2,12 @@
 
 All major changes in each released version of `iotile-core` are listed here.
 
+## 5.1.2
+
+- Add support for an experimental, unstable `heartbeat` command in `HardwareManager`.  This
+  command allows you to check if a DeviceAdapter is broken due to missing or nonresponsive
+  hardware.  For it to work, the DeviceAdapter must the support the `heartbeat` debug command.
+
 ## 5.1.1
 
 - Add the tqdm statusbar to the utc_assigner. There are some conditions where the binary 

--- a/iotilecore/iotile/core/hw/hwmanager.py
+++ b/iotilecore/iotile/core/hw/hwmanager.py
@@ -308,6 +308,13 @@ class HardwareManager:
         self.stream.enable_debug()
         return DebugManager(self.stream)
 
+    @return_type("bool")
+    def heartbeat(self):
+        """Check if we still have a connection to the DeviceAdapter."""
+
+        result = self.stream.debug_command('heartbeat')
+        return result.get('alive')
+
     @annotated
     def enable_broadcasting(self):
         """Enable the collection of broadcast IOTile reports.
@@ -787,7 +794,7 @@ class HardwareManager:
             return None
 
         proxy_match = self.find_correct_proxy_version(self._name_map[short_name], version)
-        return proxy_match if proxy_match is not None else self._name_map[short_name][0] 
+        return proxy_match if proxy_match is not None else self._name_map[short_name][0]
 
     def find_correct_proxy_version(self, proxies, version):
         """Retrieves the ModuleVersion of each proxy and match it with the tile version

--- a/iotilecore/iotile/core/hw/transport/adapter/async_wrapper.py
+++ b/iotilecore/iotile/core/hw/transport/adapter/async_wrapper.py
@@ -206,7 +206,7 @@ class AsynchronousModernWrapper(StandardDeviceAdapter):
         progress_callback = functools.partial(_on_progress, self, 'debug', conn_id)
 
         resp = await self._execute(self._adapter.debug_sync, conn_id, name, cmd_args, progress_callback)
-        _raise_error(conn_id, 'send_rpc', resp)
+        _raise_error(conn_id, 'debug', resp)
 
         return resp.get('return_value')
 
@@ -219,7 +219,7 @@ class AsynchronousModernWrapper(StandardDeviceAdapter):
         progress_callback = functools.partial(_on_progress, self, 'script', conn_id)
 
         resp = await self._execute(self._adapter.send_script_sync, conn_id, data, progress_callback)
-        _raise_error(conn_id, 'send_rpc', resp)
+        _raise_error(conn_id, 'send_script', resp)
 
 
 def _raise_error(conn_id, operation, resp):

--- a/iotilecore/iotile/core/hw/transport/virtualadapter.py
+++ b/iotilecore/iotile/core/hw/transport/virtualadapter.py
@@ -350,6 +350,9 @@ class VirtualDeviceAdapter(StandardDeviceAdapter):
         See :meth:`AbstractDeviceAdapter.debug`.
         """
 
+        if name == 'heartbeat':
+            return {'alive': True}
+
         self._ensure_connection(conn_id, True)
         dev = self._get_property(conn_id, 'device')
         conn_string = self._get_property(conn_id, 'connection_string')

--- a/iotilecore/version.py
+++ b/iotilecore/version.py
@@ -1,1 +1,1 @@
-version = "5.1.1"
+version = "5.1.2"

--- a/iotileemulate/RELEASE.md
+++ b/iotileemulate/RELEASE.md
@@ -2,6 +2,11 @@
 
 All major changes in each released version of iotile-emulate are listed here.
 
+## 0.5.2
+
+- Add support for `heartbeat` debug command to power HardwareManager `heartbeat`
+  functionality.
+
 ## 0.5.1
 
 - Updating tests to use `ReferenceControllerProxy`

--- a/iotileemulate/iotile/emulate/transport/emulatedadapter.py
+++ b/iotileemulate/iotile/emulate/transport/emulatedadapter.py
@@ -69,6 +69,8 @@ class EmulatedDeviceAdapter(VirtualDeviceAdapter):
             cmd_args (dict): any arguments that we want to send with this command.
         """
 
+        if name == 'heartbeat':
+            return {'alive': True}
 
         device = self._get_property(conn_id, 'device')
 

--- a/iotileemulate/version.py
+++ b/iotileemulate/version.py
@@ -1,1 +1,1 @@
-version = "0.5.1"
+version = "0.5.2"

--- a/transport_plugins/bled112/RELEASE.md
+++ b/transport_plugins/bled112/RELEASE.md
@@ -2,6 +2,14 @@
 
 All major changes in each released version of the bled112 transport plugin are listed here.
 
+## 3.0.6
+
+- Add dongle removal detection logic that sets the `stopped` property.
+- Add a `heartbeat` debug command that checks if the dongle is currently alive.
+- Prevent API calls from hanging if a dongle is removed in the middle of an API call such
+  as connect or send_rpc.  Previously the call would never complete.  Now the call fails
+  with an exception.
+
 ## 3.0.5
 
 - Add optional deduplication of broadcast-V2 formatted Advertising packets 

--- a/transport_plugins/bled112/iotile_transport_bled112/async_packet.py
+++ b/transport_plugins/bled112/iotile_transport_bled112/async_packet.py
@@ -97,5 +97,6 @@ def reader_thread(filelike, read_queue, header_length, length_function, stop, de
 
             read_queue.put(packet)
         except:
-            logger.exception("Error in reader thread")
+            logger.exception("Error in reader thread, putting device failure event")
+            read_queue.put(bytearray([0x80, 0, 255, 255]))
             break

--- a/transport_plugins/bled112/iotile_transport_bled112/bled112.py
+++ b/transport_plugins/bled112/iotile_transport_bled112/bled112.py
@@ -194,6 +194,9 @@ class BLED112Adapter(DeviceAdapter):
     def stop_sync(self):
         """Safely stop this BLED112 instance without leaving it in a weird state"""
 
+        if self.stopped:
+            return
+
         if self.scanning:
             self.stop_scan()
 
@@ -209,6 +212,15 @@ class BLED112Adapter(DeviceAdapter):
 
         self.stopped = True
 
+    def _stop_from_hardware_failure(self):
+        self._connections = {}
+
+        self._command_task.stop()
+        self._stream.stop()
+        self._serial_port.close()
+
+        self.stopped = True
+
     def stop_scan(self):
         """Stop the scanning task"""
         self._command_task.sync_command(['_stop_scan'])
@@ -216,6 +228,7 @@ class BLED112Adapter(DeviceAdapter):
 
     def start_scan(self, active):
         """Start the scanning task"""
+
         self._command_task.sync_command(['_start_scan', active])
         self.scanning = True
 
@@ -349,6 +362,34 @@ class BLED112Adapter(DeviceAdapter):
         self._command_task.async_command(['_send_script', found_handle, services, data, 0, progress_callback],
                                          self._send_script_finished, {'connection_id': conn_id,
                                                                       'callback': callback})
+
+    def debug_async(self, conn_id, cmd_name, cmd_args, progress_callback, callback):
+        """Asynchronously complete a named debug command.
+
+        The command name and arguments are passed to the underlying device adapter
+        and interpreted there.  If the command is long running, progress_callback
+        may be used to provide status updates.  Callback is called when the command
+        has finished.
+
+        Args:
+            conn_id (int): A unique identifier that will refer to this connection
+            cmd_name (string): the name of the debug command we want to invoke
+            cmd_args (dict): any arguments that we want to send with this command.
+            progress_callback (callable): A function to be called with status on our progress, called as:
+                progress_callback(done_count, total_count)
+            callback (callable): A callback for when we have finished the debug command, called as:
+                callback(connection_id, adapter_id, success, retval, failure_reason)
+                'connection_id': the connection id
+                'adapter_id': this adapter's id
+                'success': a bool indicating whether we received a response to our attempted RPC
+                'retval': A command specific dictionary of return value information
+                'failure_reason': a string with the reason for the failure if success == False
+        """
+
+        if cmd_name == 'heartbeat':
+            callback(conn_id, self.id, True, {'alive': not self.stopped}, None)
+        else:
+            callback(conn_id, self.id, False, None, "Debug commands are not supported by this DeviceAdapter")
 
     def _send_script_finished(self, result):
         success, retval, context = self._parse_return(result)
@@ -640,8 +681,6 @@ class BLED112Adapter(DeviceAdapter):
                 io_tile_reading = IOTileReading(reading_time, stream, reading, reading_time=datetime.datetime.utcnow())
                 report = BroadcastReport.FromReadings(info['uuid'], [io_tile_reading], reading_time)
                 self._trigger_callback('on_report', None, report)
-
-
 
     def _parse_v2_advertisement(self, rssi, sender, data):
         """ Parse the IOTile Specific advertisement packet"""
@@ -1132,7 +1171,13 @@ class BLED112Adapter(DeviceAdapter):
         # Check if we should start scanning again
         if not self.scanning and len(self._connections) == 0 and self.connecting_count == 0:
             self._logger.info("Restarting scan for devices")
-            self.start_scan(self._active_scan)
+            try:
+                self.start_scan(self._active_scan)
+            except:
+                self._logger.error("Hardware error restarting scanning, reporting failure", exc_info=True)
+                self._stop_from_hardware_failure()
+                return
+
             self._logger.info("Finished restarting scan for devices")
 
     def _on_authentication_check_response(self, result):

--- a/transport_plugins/bled112/iotile_transport_bled112/bled112_cmd.py
+++ b/transport_plugins/bled112/iotile_transport_bled112/bled112_cmd.py
@@ -46,7 +46,11 @@ class BLED112CommandProcessor(threading.Thread):
                 self._current_callback = callback
 
                 if hasattr(self, cmd):
-                    res = getattr(self, cmd)(*args)
+                    try:
+                        res = getattr(self, cmd)(*args)
+                    except Exception as err:
+                        self._logger.error("Error executing command: %s", cmd, exc_info=True)
+                        res = (False, "Exception during command: %s" % err)
                 else:
                     pass #FIXME: Log an error for an invalid command
 
@@ -71,7 +75,7 @@ class BLED112CommandProcessor(threading.Thread):
             except Empty:
                 pass
             except:
-                self._logger.exception("Error executing command: %s", cmd)
+                self._logger.exception("Fatal error in background processing loop")
                 raise
 
     def _set_scan_parameters(self, interval=2100, window=2100, active=False):

--- a/transport_plugins/bled112/version.py
+++ b/transport_plugins/bled112/version.py
@@ -1,1 +1,1 @@
-version = "3.0.5"
+version = "3.0.6"

--- a/transport_plugins/jlink/RELEASE.md
+++ b/transport_plugins/jlink/RELEASE.md
@@ -3,6 +3,10 @@
 All major changes in each released version of the jlink transport plugin are
 listed here.
 
+## 1.1.1
+
+- Add placeholder support for heartbeat debug command.
+
 ## 1.1.0
 
 - JLink adapter support for streaming and tracing

--- a/transport_plugins/jlink/iotile_transport_jlink/jlink.py
+++ b/transport_plugins/jlink/iotile_transport_jlink/jlink.py
@@ -279,6 +279,9 @@ class JLinkAdapter(StandardDeviceAdapter):
             'program_flash': self._jlink_async.program_flash
         }
 
+        if name == 'heartbeat':
+            return {'alive': True}
+
         self._ensure_connection(conn_id, True)
 
         func = known_commands.get(name)

--- a/transport_plugins/jlink/version.py
+++ b/transport_plugins/jlink/version.py
@@ -1,1 +1,1 @@
-version = "1.1.0"
+version = "1.1.1"


### PR DESCRIPTION
This PR fixes some critical bugs inside the BLED112 device adapter and makes it easier to build applications that need to know when there is a bled112 dongle removed during the application running.

The major changes are:
1. Refactors how serial port exceptions are handled inside the background command loop to ensure that `HardwareManager` commands on a bled112 dongle never hang.  Previously if there was a serial communication error, it would not trigger a failure callback.
2. Adds a new HardwareManager api, `heartbeat`.  This is implemented currently in the `bled112`, `virtual` and `emulated` device adapters and checks if the underlying bled112 dongle is functioning.  It returns True if things are good and False is there's a problem.  The purpose is to allow for polling to see if a dongle has died.
3. Adds a background event propagation mechanism so that the `heartbeat` command will properly read `False` even if you are just `scanning` with the bled112 dongle.  Now serial exceptions in the background reader thread are translated into a sentinal bgapi event `255, 255` that means hardware communication failure.  This triggers the `periodic_callback` to mark the DeviceAdapter as dead within 1 second (on the next `periodic_callback` invocation).

**Testing Performed**
1. I verified that connect and connect_direct no longer hang when the dongle is removed.
2. I verified no exceptions or hangs on exit from `iotile` if a dongle is removed
3. I verified that `iotile hw heartbeat` works and detects dongle removal both when connected to devices and when just scanning.

All tests were performed on Windows 10.

@JKHeadley Can you checkout this branch and see if it provides the APIs you need for your use case?

Closes #988 
Closes #989 