### PR TITLE
Correct indicator flags for Bled112 Broadcast v2 advertisements

### DIFF
--- a/transport_plugins/bled112/RELEASE.md
+++ b/transport_plugins/bled112/RELEASE.md
@@ -2,6 +2,9 @@
 
 All major changes in each released version of the bled112 transport plugin are listed here.
 
+## 3.0.7
+- Correct indicator flags for Broadcast v2 advertisements
+
 ## 3.0.6
 
 - Add dongle removal detection logic that sets the `stopped` property.

--- a/transport_plugins/bled112/iotile_transport_bled112/server_bled112.py
+++ b/transport_plugins/bled112/iotile_transport_bled112/server_bled112.py
@@ -212,7 +212,7 @@ class BLED112Server(StandardDeviceServer):
             reboots_hi = (reboots & 0xFF0000) >> 16
             reboots_lo = (reboots & 0x00FFFF)
 
-            data1 = struct.pack("<BBHL", 27, 0x16, 0x03C0, self.device.iotile_id)
+            data1 = struct.pack("<BBBBL", 27, 0x16, 0xdd, 0xfd, self.device.iotile_id)
             data2 = struct.pack("<HBBLBB", reboots_lo, reboots_hi, flags, timestamp, voltage, OTHER)
             data3 = struct.pack("<HLL", bcast_stream, bcast_value, mac)
 

--- a/transport_plugins/bled112/version.py
+++ b/transport_plugins/bled112/version.py
@@ -1,1 +1,1 @@
-version = "3.0.6"
+version = "3.0.7"


### PR DESCRIPTION
## Overview & Major Changes

This fix allows VirtualDevices that use the Bled112 to transmit Broadcast V2 packets. Two of the indicator flags that marked an advertisement as V2 were incorrect.

### Additional Notes

This has been tested and the resulting packets were received by the ArchFX Setup App.
