### PR TITLE
Add missing crcmod and nrf52 dependencies

### DIFF
--- a/iotilecore/setup.py
+++ b/iotilecore/setup.py
@@ -28,7 +28,8 @@ setup(
         "python-dateutil>=2.8.0,<3",
         "typedargs>=1.0.0,<2",
         "entrypoints>=0.3.0,<1",
-        "msgpack>=0.6.1,<1"
+        "msgpack>=0.6.1,<1",
+        "crcmod>=1.7,<2",
     ],
     extras_require={
         'ui': ["asciimatics>=1.10.0,<2"]

--- a/iotilecore/tox.ini
+++ b/iotilecore/tox.ini
@@ -8,4 +8,5 @@ deps=
     ../iotiletest
     ../iotileemulate
     pycryptodome
+    iotile-support-con-nrf52832-3
 commands=py.test {posargs}


### PR DESCRIPTION
## Overview & Major Changes

Fixes #992 
This adds a missing dependency of iotile-core, crcmod.

While testing, I found that the tox config for iotile-core was missing the NRF52 support dependency, which caused the tests to fail when running tox in iotile-core instead of as part of the entire coretools package.
