### PR TITLE
Feat add inmemory authenticator

### DIFF
--- a/iotilecore/RELEASE.md
+++ b/iotilecore/RELEASE.md
@@ -2,6 +2,12 @@
 
 All major changes in each released version of `iotile-core` are listed here.
 
+## 5.1.3
+
+- Add new auth provider `InMemoryAuthProvider`. This allows users to
+authenticate their device without CLI or environment variables
+- Add registry support to temporarily set passwords for devices by uuid.
+
 ## 5.1.2
 
 - Add support for an experimental, unstable `heartbeat` command in `HardwareManager`.  This

--- a/iotilecore/iotile/core/dev/annotated_registry.py
+++ b/iotilecore/iotile/core/dev/annotated_registry.py
@@ -83,7 +83,7 @@ class AnnotatedRegistry(object):
 
     @param("device_uuid", "int", desc="Device UUID")
     @param("password", "str", desc="Password to the device")
-    def set_temporary_password(self, device_uuid, password: str):
+    def set_temporary_password(self, device_uuid: int, password: str):
         InMemoryAuthProvider.add_password(device_uuid, password)
 
     @param("device_uuid", "int", desc="Device UUID")

--- a/iotilecore/iotile/core/dev/annotated_registry.py
+++ b/iotilecore/iotile/core/dev/annotated_registry.py
@@ -3,6 +3,7 @@
 # tool.  Since the registry is used internally in the type system it cannot
 # itself make use of typedargs annotations
 from iotile.core.utilities.typedargs import annotated, param, return_type, context
+from iotile.core.utilities.typedargs.annotate import docannotate
 from iotile.core.exceptions import ExternalError
 from iotile.core.hw.auth.inmemory_auth_provider import InMemoryAuthProvider
 from .registry import ComponentRegistry
@@ -81,13 +82,23 @@ class AnnotatedRegistry(object):
 
         return self.reg.list_config()
 
-    @param("device_uuid", "int", desc="Device UUID")
-    @param("password", "str", desc="Password to the device")
+    @docannotate
     def set_temporary_password(self, device_uuid: int, password: str):
+        """Sets a temporary password for a device in memory for the current instance.
+
+        Args:
+            device_uuid (int): the device UUID
+            password (str): the password to save in memory
+        """
         InMemoryAuthProvider.add_password(device_uuid, password)
 
-    @param("device_uuid", "int", desc="Device UUID")
+    @docannotate
     def clear_temporary_password(self, device_uuid: int):
+        """Clears the password based on the device UUID
+
+        Args:
+            device_uuid (int): the device UUID
+        """
         InMemoryAuthProvider.clear_password(device_uuid)
 
     @param("key", "string")

--- a/iotilecore/iotile/core/dev/annotated_registry.py
+++ b/iotilecore/iotile/core/dev/annotated_registry.py
@@ -11,14 +11,18 @@ from .registry import ComponentRegistry
 _name_ = "Developer"
 
 
-@annotated
+@docannotate
 def registry():
+    """Returns an Annotated Registry
+
+    Returns:
+        AnnotatedRegistry show-as context: an Annotated Registry
+    """
     return AnnotatedRegistry()
 
 @context()
 class AnnotatedRegistry(object):
-    """
-    AnnotatedRegistry
+    """AnnotatedRegistry
 
     A mapping of all of the installed components on this system that can
     be used as build dependencies and where they are located.  Also used
@@ -28,21 +32,25 @@ class AnnotatedRegistry(object):
     def __init__(self):
         self.reg = ComponentRegistry()
 
-    @param("component", "path", "exists", desc="folder containing component to register")
+    @docannotate
     def add_component(self, component):
-        """
-        Register a component with ComponentRegistry.
+        """Register a component with ComponentRegistry.
 
         Component must be a buildable object with a module_settings.json file that
         describes its name and the domain that it is part of.
+
+        Args:
+            component (path): folder containing component to register
         """
 
         self.reg.add_component(component)
 
-    @return_type("map(string, string)")
+    @docannotate
     def list_plugins(self):
-        """
-        List all of the plugins that have been registerd for the iotile program on this computer
+        """List all of the plugins that have been registerd for the iotile program on this computer
+        
+        Returns:
+            map(string, string): List of plugins registered for this iotile instance
         """
 
         return self.reg.list_plugins()
@@ -50,34 +58,39 @@ class AnnotatedRegistry(object):
     def find_component(self, key, domain=""):
         return self.reg.find_component(key, domain)
 
-    @param("key", "string", desc="iotile component to find")
+    @docannotate
     def remove_component(self, key):
-        """
-        Remove component from registry
+        """Remove component from registry
+
+        Args:
+            key (str): iotile component to remove
         """
 
         return self.reg.remove_component(key)
 
-    @annotated
+    @docannotate
     def clear_components(self):
-        """
-        Clear all of the registered components
+        """Clear all of the registered components
         """
 
         self.reg.clear_components()
 
-    @return_type("list(string)")
+    @docannotate
     def list_components(self):
-        """
-        List all of the registered component names
+        """List all of the registered component names
+
+        Returns:
+            list(string): list of the registered component names
         """
 
         return self.reg.list_components()
 
-    @return_type("list(string)")
+    @docannotate
     def list_config(self):
-        """
-        List all of the registered component names
+        """List all of the registered config names
+
+        Returns:
+            list(string): list of registered config names
         """
 
         return self.reg.list_config()
@@ -101,22 +114,38 @@ class AnnotatedRegistry(object):
         """
         InMemoryAuthProvider.clear_password(device_uuid)
 
-    @param("key", "string")
-    @param("value", "string")
+    @docannotate
     def set(self, key, value):
+        """Sets a config value in the registry to a value
+
+        Args:
+            key (str): the config variable
+            value (str): the value to be set
+        """
         self.reg.set_config(key, value)
 
-    @param("key", "string")
-    @return_type("string")
+    @docannotate
     def get(self, key):
+        """Gets a config value from its key in the registry
+
+        Args:
+            key (str): the config variable
+
+        Returns:
+            string: the value of the config variable
+        """
         return self.reg.get_config(key)
 
-    @param("key", "string")
-    @return_type("string")
+    @docannotate
     def clear(self, key):
+        """Clears a config key from the registry
+
+        Args:
+            key (str): the config variable
+        """
         self.reg.clear_config(key)
 
-    @annotated
+    @docannotate
     def freeze(self):
         """Freeze the current list of extensions to a single file.
 
@@ -130,7 +159,7 @@ class AnnotatedRegistry(object):
 
         self.reg.freeze_extensions()
 
-    @annotated
+    @docannotate
     def unfreeze(self):
         """Remove any frozen extension list."""
 

--- a/iotilecore/iotile/core/dev/annotated_registry.py
+++ b/iotilecore/iotile/core/dev/annotated_registry.py
@@ -4,6 +4,7 @@
 # itself make use of typedargs annotations
 from iotile.core.utilities.typedargs import annotated, param, return_type, context
 from iotile.core.exceptions import ExternalError
+from iotile.core.hw.auth.inmemory_auth_provider import InMemoryAuthProvider
 from .registry import ComponentRegistry
 
 _name_ = "Developer"
@@ -79,6 +80,15 @@ class AnnotatedRegistry(object):
         """
 
         return self.reg.list_config()
+
+    @param("device_uuid", "int", desc="Device UUID")
+    @param("password", "str", desc="Password to the device")
+    def set_temporary_password(self, device_uuid, password: str):
+        InMemoryAuthProvider.add_password(device_uuid, password)
+
+    @param("device_uuid", "int", desc="Device UUID")
+    def clear_temporary_password(self, device_uuid: int):
+        InMemoryAuthProvider.clear_password(device_uuid)
 
     @param("key", "string")
     @param("value", "string")

--- a/iotilecore/iotile/core/hw/auth/auth_chain.py
+++ b/iotilecore/iotile/core/hw/auth/auth_chain.py
@@ -36,6 +36,7 @@ class ChainedAuthProvider(AuthProvider):
 
         sub_providers.sort(key=lambda x: x[0])
         self.providers = sub_providers
+        self.conn_map = None
 
     def _load_installed_providers(self):
         self._auth_factories = {}
@@ -44,12 +45,23 @@ class ChainedAuthProvider(AuthProvider):
         for name, entry in reg.load_extensions('iotile.auth_provider'):
             self._auth_factories[name] = entry
 
+    def _get_device_alias(self, device_id):
+        for conn_string, uuid in self.conn_map:
+            if conn_string == device_id:
+                return uuid
+            elif uuid == device_id:
+                return conn_string
+        return NotFoundError("No alias found for the device", device_id=device_id)
+
     def get_root_key(self, key_type, device_id):
-        """Deligates call to auth providers in the chain
+        """Deligates call to auth providers in the chain.
+        
+        This function will attempt to use a device alias if it exists.
+        This allows support of using both UUID and device MAC.
 
         Args:
             key_type (int): see KnownKeyRoots
-            device_id (int): uuid of the device
+            device_id (int): ID of the device
 
         Returns:
             bytes: the root key
@@ -58,7 +70,11 @@ class ChainedAuthProvider(AuthProvider):
             try:
                 return provider.get_root_key(key_type, device_id)
             except NotFoundError:
-                pass
+                try:
+                    device_alias = self._get_device_alias(device_id)
+                    return provider.get_root_key(key_type, device_alias)
+                except NotFoundError:
+                    pass
 
         raise NotFoundError("get_serialized_key method is not implemented in any sub_providers")
 

--- a/iotilecore/iotile/core/hw/auth/auth_chain.py
+++ b/iotilecore/iotile/core/hw/auth/auth_chain.py
@@ -45,14 +45,6 @@ class ChainedAuthProvider(AuthProvider):
         for name, entry in reg.load_extensions('iotile.auth_provider'):
             self._auth_factories[name] = entry
 
-    def _get_device_alias(self, device_id):
-        for conn_string, uuid in self.conn_map:
-            if conn_string == device_id:
-                return uuid
-            elif uuid == device_id:
-                return conn_string
-        return NotFoundError("No alias found for the device", device_id=device_id)
-
     def get_root_key(self, key_type, device_id):
         """Deligates call to auth providers in the chain.
         
@@ -70,11 +62,7 @@ class ChainedAuthProvider(AuthProvider):
             try:
                 return provider.get_root_key(key_type, device_id)
             except NotFoundError:
-                try:
-                    device_alias = self._get_device_alias(device_id)
-                    return provider.get_root_key(key_type, device_alias)
-                except NotFoundError:
-                    pass
+                pass
 
         raise NotFoundError("get_serialized_key method is not implemented in any sub_providers")
 

--- a/iotilecore/iotile/core/hw/auth/auth_chain.py
+++ b/iotilecore/iotile/core/hw/auth/auth_chain.py
@@ -36,7 +36,6 @@ class ChainedAuthProvider(AuthProvider):
 
         sub_providers.sort(key=lambda x: x[0])
         self.providers = sub_providers
-        self.conn_map = None
 
     def _load_installed_providers(self):
         self._auth_factories = {}

--- a/iotilecore/iotile/core/hw/auth/auth_provider.py
+++ b/iotilecore/iotile/core/hw/auth/auth_provider.py
@@ -26,7 +26,7 @@ class AuthProvider:
         NullKey: 'null_key',
         UserKey: 'user_key',
         DeviceKey: 'device_key',
-        PasswordBasedKey: 'pasword_based_userkey'
+        PasswordBasedKey: 'password_based_userkey'
     }
 
     def __init__(self, args=None):

--- a/iotilecore/iotile/core/hw/auth/default_providers.py
+++ b/iotilecore/iotile/core/hw/auth/default_providers.py
@@ -1,3 +1,4 @@
-DefaultNullAuth = (100, 'NullAuthProvider', {})
-DefaultCliAuth = (50, 'CliAuthProvider', {})
-DefaultEnvAuth = (0, 'EnvAuthProvider', {})
+DefaultNullAuth = (150, 'NullAuthProvider', {})
+DefaultCliAuth = (100, 'CliAuthProvider', {})
+DefaultEnvAuth = (50, 'EnvAuthProvider', {})
+DefaultInMemoryAuth = (0, 'InMemoryAuthProvider', {})

--- a/iotilecore/iotile/core/hw/auth/inmemory_auth_provider.py
+++ b/iotilecore/iotile/core/hw/auth/inmemory_auth_provider.py
@@ -23,16 +23,31 @@ class InMemoryAuthProvider(RootKeyAuthProvider):
         Args:
             device_id (int): uuid or mac of the device
             password (str): password to the device
-
         """
         key = AuthProvider.DeriveRebootKeyFromPassword(password)
         cls._shared_passwords[str(device_id)] = key
 
     @classmethod
+    def clear_password(cls, device_id):
+        """Clears a password from the class
+
+        Args:
+            device_id (int): uuid or mac of the device
+        """
+        cls._shared_passwords.pop(str(device_id), None)
+
+
+    @classmethod
     def get_password(cls, device_id):
         """Returns the password from the class
+
+        Returns:
+            bytes: the root key
         """
-        return cls._shared_passwords[str(device_id)] if str(device_id) in cls._shared_passwords else None
+        if str(device_id) in cls._shared_passwords:
+            return cls._shared_passwords[str(device_id)]
+        else:
+            raise NotFoundError("No key could be found for device", device_id=device_id)
 
     def get_root_key(self, key_type, device_id):
         """Attempt to get a user key from memory

--- a/iotilecore/iotile/core/hw/auth/inmemory_auth_provider.py
+++ b/iotilecore/iotile/core/hw/auth/inmemory_auth_provider.py
@@ -36,7 +36,6 @@ class InMemoryAuthProvider(RootKeyAuthProvider):
         """
         cls._shared_passwords.pop(device_id, None)
 
-
     @classmethod
     def get_password(cls, device_id):
         """Returns the password from the class

--- a/iotilecore/iotile/core/hw/auth/inmemory_auth_provider.py
+++ b/iotilecore/iotile/core/hw/auth/inmemory_auth_provider.py
@@ -1,0 +1,44 @@
+from iotile.core.exceptions import NotFoundError
+from .rootkey_auth_provider import RootKeyAuthProvider
+from .auth_provider import AuthProvider
+
+
+class InMemoryAuthProvider(RootKeyAuthProvider):
+    """Key provider implementation that allows user to set a password in memory"""
+
+    def __init__(self, args=None):
+        if args is None:
+            args = {}
+
+        args['supported_keys'] = [self.PasswordBasedKey]
+        self.keys = {}
+
+        super().__init__(args)
+
+    def add_password(self, device_id, password):
+        """Adds a password to the instance
+
+        Args:
+            device_id (int): uuid or mac of the device
+            password (str): password to the device
+
+        """
+        key = AuthProvider.DeriveRebootKeyFromPassword(password)
+        self.keys[str(device_id)] = key
+
+    def get_root_key(self, key_type, device_id):
+        """Attempt to get a user key from memory
+
+        Args:
+            key_type (int): see KnownKeyRoots
+            device_id (int): uuid or mac of the device
+
+        Returns:
+            bytes: the root key
+        """
+        self.verify_key(key_type)
+
+        if str(device_id) not in self.keys:
+            raise NotFoundError("No key could be found for devices", device_id=device_id)
+
+        return self.keys[str(device_id)]

--- a/iotilecore/iotile/core/hw/auth/inmemory_auth_provider.py
+++ b/iotilecore/iotile/core/hw/auth/inmemory_auth_provider.py
@@ -40,6 +40,9 @@ class InMemoryAuthProvider(RootKeyAuthProvider):
     def get_password(cls, device_id):
         """Returns the password from the class
 
+        Args:
+            device_id (int): uuid or mac of the device
+
         Returns:
             bytes: the root key
         """

--- a/iotilecore/iotile/core/hw/auth/inmemory_auth_provider.py
+++ b/iotilecore/iotile/core/hw/auth/inmemory_auth_provider.py
@@ -25,7 +25,7 @@ class InMemoryAuthProvider(RootKeyAuthProvider):
             password (str): password to the device
         """
         key = AuthProvider.DeriveRebootKeyFromPassword(password)
-        cls._shared_passwords[str(device_id)] = key
+        cls._shared_passwords[device_id] = key
 
     @classmethod
     def clear_password(cls, device_id):
@@ -34,7 +34,7 @@ class InMemoryAuthProvider(RootKeyAuthProvider):
         Args:
             device_id (int): uuid or mac of the device
         """
-        cls._shared_passwords.pop(str(device_id), None)
+        cls._shared_passwords.pop(device_id, None)
 
 
     @classmethod
@@ -44,8 +44,8 @@ class InMemoryAuthProvider(RootKeyAuthProvider):
         Returns:
             bytes: the root key
         """
-        if str(device_id) in cls._shared_passwords:
-            return cls._shared_passwords[str(device_id)]
+        if device_id in cls._shared_passwords:
+            return cls._shared_passwords[device_id]
         else:
             raise NotFoundError("No key could be found for device", device_id=device_id)
 

--- a/iotilecore/setup.py
+++ b/iotilecore/setup.py
@@ -57,7 +57,7 @@ setup(
         ],
         'iotile.default_auth_providers': [
             'EnvAuthProvider = iotile.core.hw.auth.default_providers:DefaultEnvAuth',
-            'InMemoryAuthProvider = iotile.core.hw.auth.inmemory_auth_provider:InMemoryAuthProvider',
+            'InMemoryAuthProvider = iotile.core.hw.auth.default_providers:DefaultInMemoryAuth',
             'CliAuthProvider = iotile.core.hw.auth.default_providers:DefaultCliAuth',
             'NullAuthProvider = iotile.core.hw.auth.default_providers:DefaultNullAuth'
         ],

--- a/iotilecore/setup.py
+++ b/iotilecore/setup.py
@@ -50,12 +50,14 @@ setup(
         ],
         'iotile.auth_provider': [
             'EnvAuthProvider = iotile.core.hw.auth.env_auth_provider:EnvAuthProvider',
+            'InMemoryAuthProvider = iotile.core.hw.auth.inmemory_auth_provider:InMemoryAuthProvider',
             'NullAuthProvider = iotile.core.hw.auth.null_auth_provider:NullAuthProvider',
             'CliAuthProvider = iotile.core.hw.auth.cli_auth_provider:CliAuthProvider',
             'ChainedAuthProvider = iotile.core.hw.auth.auth_chain:ChainedAuthProvider'
         ],
         'iotile.default_auth_providers': [
             'EnvAuthProvider = iotile.core.hw.auth.default_providers:DefaultEnvAuth',
+            'InMemoryAuthProvider = iotile.core.hw.auth.inmemory_auth_provider:InMemoryAuthProvider',
             'CliAuthProvider = iotile.core.hw.auth.default_providers:DefaultCliAuth',
             'NullAuthProvider = iotile.core.hw.auth.default_providers:DefaultNullAuth'
         ],

--- a/iotilecore/version.py
+++ b/iotilecore/version.py
@@ -1,1 +1,1 @@
-version = "5.1.2"
+version = "5.1.3"

--- a/transport_plugins/bled112/RELEASE.md
+++ b/transport_plugins/bled112/RELEASE.md
@@ -5,8 +5,10 @@ All major changes in each released version of the bled112 transport plugin are l
 ## 3.0.8
 
 - Added a connection map consisting of devices' connection string and uuid
-to the command processor
-- Modified `BLED112CommandProcessor` to save `BLED112AuthManager` as a member
+to the `BLED112Adapter`
+- Callback `on_authentication_check_response` uses calls `authenticate` with device UUID instead of MAC
+- Authentication function does basic check if UUID is valid
+ - Fix typos
 
 ## 3.0.7
 

--- a/transport_plugins/bled112/RELEASE.md
+++ b/transport_plugins/bled112/RELEASE.md
@@ -2,7 +2,14 @@
 
 All major changes in each released version of the bled112 transport plugin are listed here.
 
+## 3.0.8
+
+- Added a connection map consisting of devices' connection string and uuid
+to the command processor
+- Modified `BLED112CommandProcessor` to save `BLED112AuthManager` as a member
+
 ## 3.0.7
+
 - Correct indicator flags for Broadcast v2 advertisements
 
 ## 3.0.6

--- a/transport_plugins/bled112/iotile_transport_bled112/bled112.py
+++ b/transport_plugins/bled112/iotile_transport_bled112/bled112.py
@@ -675,6 +675,7 @@ class BLED112Adapter(DeviceAdapter):
                 self._parse_v1_scan_response(string_address, data)
 
         if info:
+            self._command_task.update_conn_map(info['connection_string'], info['uuid'])
             drop_broadcast = self._check_update_seen_broadcast(
                 sender, reading_time, stream, reading,
                 broadcast_toggle, counter=counter, channel=broadcast_multiplex)

--- a/transport_plugins/bled112/iotile_transport_bled112/bled112.py
+++ b/transport_plugins/bled112/iotile_transport_bled112/bled112.py
@@ -207,7 +207,7 @@ class BLED112Adapter(DeviceAdapter):
         else:
             self._conn_map[conn_string] = device_uuid
 
-        while len(self._conn_map) >= self.ConnMapMaxSize:
+        while len(self._conn_map) > self.ConnMapMaxSize:
             self._conn_map.popitem(last=False)
 
     def can_connect(self):

--- a/transport_plugins/bled112/iotile_transport_bled112/bled112_auth.py
+++ b/transport_plugins/bled112/iotile_transport_bled112/bled112_auth.py
@@ -170,7 +170,7 @@ class BLED112AuthManager:
         Returns:
             (bool, bytearray/dict): tuple of success flag, session key or dict with reason of failure
         """
-        if not uuid or not isinstance(uuid, int):
+        if uuid is None or not isinstance(uuid, int):
             return False, {"reason": "Invalid device UUID to authenticate"}
 
         result, response = self._send_client_hello(client_supported_auth, handshake_fn)

--- a/transport_plugins/bled112/iotile_transport_bled112/bled112_auth.py
+++ b/transport_plugins/bled112/iotile_transport_bled112/bled112_auth.py
@@ -164,12 +164,15 @@ class BLED112AuthManager:
         Perform authentication
 
         Args:
-            uuid (int or str): either device mac or id
+            uuid (int): the device UUID
             auth_type (int): See .AuthType
             handshake_fn (SendAuthHandshakeFn): a function pointer
         Returns:
             (bool, bytearray/dict): tuple of success flag, session key or dict with reason of failure
         """
+        if not uuid or not isinstance(uuid, int):
+            return False, {"reason": "Invalid device UUID to authenticate"}
+
         result, response = self._send_client_hello(client_supported_auth, handshake_fn)
         if result:
             (_generation, server_supported_auth, self._device_nonce) = response

--- a/transport_plugins/bled112/iotile_transport_bled112/bled112_cmd.py
+++ b/transport_plugins/bled112/iotile_transport_bled112/bled112_cmd.py
@@ -26,6 +26,7 @@ class BLED112CommandProcessor(threading.Thread):
         self._logger = logging.getLogger(__name__)
         self._logger.addHandler(logging.NullHandler())
         self.event_handler = None
+        self._auth_manager = BLED112AuthManager(0x00, 0x01)
         self._current_context = None
         self._current_callback = None
         self._stop_event_check_interval = stop_check_interval
@@ -299,11 +300,11 @@ class BLED112CommandProcessor(threading.Thread):
 
         supported_auth = AuthType.AUTH_METHOD_0.value | AuthType.AUTH_METHOD_1.value \
                          | AuthType.AUTH_METHOD_2.value | AuthType.AUTH_METHOD_3.value
-        permisions = 0x00
-        token_gen = 0x01
+        # permisions = 0x00
+        # token_gen = 0x01
 
-        manager = BLED112AuthManager(permisions, token_gen)
-        success, data = manager.authenticate(device_uuid, supported_auth, send_auth_client_request)
+        # manager = BLED112AuthManager(permisions, token_gen)
+        success, data = self._auth_manager.authenticate(device_uuid, supported_auth, send_auth_client_request)
 
         return success, data
 

--- a/transport_plugins/bled112/iotile_transport_bled112/bled112_cmd.py
+++ b/transport_plugins/bled112/iotile_transport_bled112/bled112_cmd.py
@@ -1,4 +1,4 @@
-from collections import namedtuple, OrderedDict
+from collections import namedtuple
 import time
 import struct
 import threading
@@ -9,7 +9,7 @@ from iotile.core.utilities.packed import unpack
 from iotile.core.exceptions import HardwareError
 from .tilebus import *
 from .bgapi_structures import process_gatt_service, process_attribute, process_read_handle, process_notification
-from .bgapi_structures import parse_characteristic_declaration, handle_to_uuid
+from .bgapi_structures import parse_characteristic_declaration
 from .async_packet import InternalTimeoutError, DeviceNotConfiguredError
 from .bled112_auth import AuthType, BLED112AuthManager
 
@@ -17,8 +17,7 @@ BGAPIPacket = namedtuple("BGAPIPacket", ["is_event", "command_class", "command",
 
 
 class BLED112CommandProcessor(threading.Thread):
-
-
+    
     def __init__(self, stream, commands, stop_check_interval=0.01):
         super(BLED112CommandProcessor, self).__init__()
 
@@ -302,7 +301,7 @@ class BLED112CommandProcessor(threading.Thread):
         supported_auth = AuthType.AUTH_METHOD_0.value | AuthType.AUTH_METHOD_1.value \
                          | AuthType.AUTH_METHOD_2.value | AuthType.AUTH_METHOD_3.value
         permissions = 0x00
-        token_gen = 0x1
+        token_gen = 0x01
 
         manager = BLED112AuthManager(permissions, token_gen)
         success, data = manager.authenticate(device_uuid, supported_auth, send_auth_client_request)

--- a/transport_plugins/bled112/iotile_transport_bled112/bled112_cmd.py
+++ b/transport_plugins/bled112/iotile_transport_bled112/bled112_cmd.py
@@ -93,17 +93,19 @@ class BLED112CommandProcessor(threading.Thread):
         will be towards the beginning of the list. That way if our list grows
         too large and needs to be overwritten, it will do so by removing the
         beginning elements.
+
+        Args:
+            conn_string (str): The string of the device's MAC address
+            device_uuid (int): The integer representation of the device's UUID
         """
-        if len(self._conn_map) >= BLED112CommandProcessor.CONN_MAP_MAX_SIZE:
-            self._conn_map = self._conn_map[-(BLED112CommandProcessor.CONN_MAP_MAX_SIZE):]
-    
         entry = (conn_string, device_uuid)
 
         if entry in self._conn_map:
             self._conn_map.remove(entry)
+        elif len(self._conn_map) >= BLED112CommandProcessor.CONN_MAP_MAX_SIZE:
+            self._conn_map = self._conn_map[-(BLED112CommandProcessor.CONN_MAP_MAX_SIZE-1):]
 
         self._conn_map.append(entry)
-
 
     def _set_scan_parameters(self, interval=2100, window=2100, active=False):
         """

--- a/transport_plugins/bled112/version.py
+++ b/transport_plugins/bled112/version.py
@@ -1,1 +1,1 @@
-version = "3.0.7"
+version = "3.0.8"


### PR DESCRIPTION
## Overview & Major Changes

We need a way to support applications interfacing `coretools` to be able to authenticate their devices without being hung on a CLI prompt.
Currently, if a user wants to connect to a device, they must either set an environment variable `USER_KEY_<device MAC> = <key>` OR if it doesn't exist, be prompted by CLI to enter a password manually. This implementation is an issue for any application that needs to interface the password protection feature without getting blocked.

The solution was to create a new authentication provider that would allow the user to call the `InMemoryAuthProvider`'s class method to set shared passwords that the authentication logic can retrieve. See my comments in the review for a walkthrough of all the changes.

- Added a mapping of devices' connection strings and UUID to the adapter
- Added a new authentication provider
- Fixed authentication to support authenticating via UUID or MAC
- Added `iotile registry` support to add a temporary password
```
(venv_py38) PS C:\Arch\Repositories> iotile registry
(AnnotatedRegistry) set_temporary_password 0xa51 test
(AnnotatedRegistry) back
(root) hw --port bled112
(HardwareManager) connect 0xa51
```