### PR TITLE
Fix memory leak in the Operation Manager

### DIFF
--- a/iotilecore/iotile/core/utilities/async_tools/operation_manager.py
+++ b/iotilecore/iotile/core/utilities/async_tools/operation_manager.py
@@ -145,7 +145,7 @@ class OperationManager:
         del loc[OperationManager._LEAF]
 
         for parent, key in reversed(parents):
-            if len(parent[key]) is not None:
+            if len(parent[key]) > 0:
                 return
 
             del parent[key]


### PR DESCRIPTION
## Overview & Major Changes

An incorrect comparison to None prevented the list of waiter callbacks from being cleaned up when the callback was ready to call back. The result was a monotonically increasing memory leak, seen in the AP which was using the Operation Manager inside the Supervisor.
