### PR TITLE
Fix JLink SPI Dumping Tool

### DIFF
--- a/transport_plugins/jlink/RELEASE.md
+++ b/transport_plugins/jlink/RELEASE.md
@@ -3,6 +3,10 @@
 All major changes in each released version of the jlink transport plugin are
 listed here.
 
+## 1.1.2
+
+- Halt the device before injecting flash forensics blob
+
 ## 1.1.1
 
 - Add placeholder support for heartbeat debug command.

--- a/transport_plugins/jlink/iotile_transport_jlink/jlink_background.py
+++ b/transport_plugins/jlink/iotile_transport_jlink/jlink_background.py
@@ -259,7 +259,7 @@ class AsyncJLink:
         if memory_region == 'external':
             if pause is False:
                 raise ArgumentError("Pause must be True in order to read external data.")
-            await self.reset()
+            await self.reset(halt=True)
             await self._inject_blob(ff_cfg.ff_absolute_bin_path)
 
             pc_reg = await self._loop.run_in_executor(

--- a/transport_plugins/jlink/version.py
+++ b/transport_plugins/jlink/version.py
@@ -1,1 +1,1 @@
-version = "1.1.1"
+version = "1.1.2"


### PR DESCRIPTION
## Overview & Major Changes

This PR fixes the following issue: https://github.com/iotile/coretools/issues/998

The SPI flash dumping tool was unsuccessful on certain PODs that were in a particular bricked state. The PODs were less so "bricked", but in some sort of loop. This fix addresses that corner case by halting the POD before injecting the "flash forensics" firmware blob.

### Testing
To test, run the command on a POD connected via JLink.
`iotile hw --port 'jlink:device=nrf52' connect_direct 1 debug dump_memory --out_path spi_dump.bin --memory_region external --pause True`
It may take a minute to download the entire flash.
